### PR TITLE
Functionalization pass v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ functorch/_C.so
 t.py
 .vscode/
 ccache.sh
+
+# Editor temporaries
+*.swn
+*.swo
+*.swp
+*.swm
+*~

--- a/functorch/__init__.py
+++ b/functorch/__init__.py
@@ -76,6 +76,11 @@ def _functorch_str(tensor):
             raise Exception("HELP")
         return _old_str(tensor)
 
+    if _C.is_functionaltensor(tensor):
+        # Since we're unwrapping the FunctionalTensorWrapper, we need to make sure
+        # that it's up to date first
+        tensor.sync_()
+
     value = _C.get_unwrapped(tensor)
     value_repr = repr(value)
     value_repr = textwrap.indent(value_repr, '  ')

--- a/functorch/__init__.py
+++ b/functorch/__init__.py
@@ -7,7 +7,6 @@
 import torch
 import functools
 import textwrap
-# from . import _C
 from functorch._C import (
     _func_decrement_nesting,
     _func_increment_nesting,
@@ -72,8 +71,6 @@ _old_str = torch._tensor_str._str
 def _functorch_str(tensor):
     level = _C.maybe_get_level(tensor)
     if level == -1:
-        if _C.is_functionaltensor(tensor):
-            raise Exception("HELP")
         return _old_str(tensor)
 
     if _C.is_functionaltensor(tensor):
@@ -91,9 +88,6 @@ def _functorch_str(tensor):
     if _C.is_gradtrackingtensor(tensor):
         return f'GradTrackingTensor(lvl={level}, value=\\\n{value_repr})'
     if _C.is_functionaltensor(tensor):
-        # NOTE: functional tensor's only have a notion of "level" when
-        #  you use the functionalize() API. Otherwise their level is set to -1.
-        # That shouldn't matter, since this print function is only used by functorch
         return f'FunctionalTensor(lvl={level}, value=\\\n{value_repr})'
 
     raise ValueError("We don't know how to print this, please file us an issue")

--- a/functorch/_src/vmap.py
+++ b/functorch/_src/vmap.py
@@ -283,20 +283,6 @@ def _vmap(func: Callable, in_dims: in_dims_t = 0, out_dims: out_dims_t = 0) -> C
             _vmap_decrement_nesting()
     return wrapped
 
-class functionalizer(object):
-    def __enter__(self):
-        _func_increment_nesting()
-
-    def __exit__(self, *args):
-        _func_decrement_nesting()
-
-    def __call__(self, func):
-        @functools.wraps(func)
-        def decorate_func(*args, **kwargs):
-            with self:
-                return func(*args, **kwargs)
-        return decorate_func
-
 def functionalize(func: Callable) -> Callable:
     @functools.wraps(func)
     def wrapped(*args, **kwargs):

--- a/functorch/csrc/BatchedTensorImpl.cpp
+++ b/functorch/csrc/BatchedTensorImpl.cpp
@@ -142,6 +142,23 @@ bool BatchedTensorImpl::has_storage() const {
 }
 #endif
 
+void BatchedTensorImpl::replace_(const TensorImpl* other_impl) {
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(other_impl->key_set().has(DispatchKey::Batched));
+  auto batched_impl = static_cast<const BatchedTensorImpl*>(other_impl);
+
+  auto unwrapped_impl_self = value().unsafeGetTensorImpl();
+  auto unwrapped_impl_other = batched_impl->value().unsafeGetTensorImpl();
+  if (typeid(*unwrapped_impl_self) == typeid(*unwrapped_impl_other)) {
+      // This allows us to retain the program semantic of mutating inputs
+      unwrapped_impl_self->replace_(unwrapped_impl_other);
+  } else {
+      value_ = batched_impl->value();
+  }
+  bdims_ = batched_impl->bdims();
+  checkInvariants();
+  refreshSizesAndStrides();
+}
+
 const char* BatchedTensorImpl::tensorimpl_type_name() const {
   return "BatchedTensorImpl";
 }

--- a/functorch/csrc/BatchedTensorImpl.h
+++ b/functorch/csrc/BatchedTensorImpl.h
@@ -92,6 +92,7 @@ struct BatchedTensorImpl : public c10::TensorImpl {
 #ifdef DEBUG
   bool has_storage() const override;
 #endif
+  void replace_(const TensorImpl* other_impl) override;
 
   void refreshSizesAndStrides();
 

--- a/functorch/csrc/BatchingRegistrations.cpp
+++ b/functorch/csrc/BatchingRegistrations.cpp
@@ -1418,6 +1418,8 @@ TORCH_LIBRARY_IMPL(aten, FT_BATCHED_KEY, m) {
 // //   m.impl("new_zeros", new_zeros_batching_rule);
 // //
   m.impl("contiguous", contiguous_batching_rule);
+  // We need this for the functionalization pass: replace_ shouldn't enter the boxed fallback
+  m.impl("replace_", torch::CppFunction::makeFallthrough());
 }
 
 }

--- a/functorch/csrc/DynamicLayer.cpp
+++ b/functorch/csrc/DynamicLayer.cpp
@@ -322,9 +322,9 @@ static bool functionalAtCurrentLevel(const Tensor& tensor) {
 void dynamicLayerFrontFallback(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
   auto& dynamicLayerStack = dynamicLayerStackAccessor();
 #ifdef HAS_TORCH_SHOW_DISPATCH_TRACE
-  //if (c10::show_dispatch_trace_enabled()) {
+  if (c10::show_dispatch_trace_enabled()) {
     std::cout << "DLS size: " << dynamicLayerStack.size() << std::endl;
-  //}
+  }
 #endif
   if (dynamicLayerStack.size() == 0) {
     sanityCheckStack(op, stack);

--- a/functorch/csrc/FunctionalTensorWrapper.cpp
+++ b/functorch/csrc/FunctionalTensorWrapper.cpp
@@ -1,0 +1,141 @@
+
+// Copyright (c) Facebook, Inc. and its affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <functorch/csrc/FunctionalTensorWrapper.h>
+
+#include <ATen/WrapDimUtils.h>
+#include <c10/util/Exception.h>
+
+#include <c10/util/irange.h>
+
+namespace at {
+
+FunctionalTensorWrapper::FunctionalTensorWrapper(Tensor value, int64_t level)
+  : FunctionalTensorImplBase(value.dtype(), value.device()),
+    value_(value),
+    level_(level)
+{
+  TORCH_INTERNAL_ASSERT(value_.defined());
+}
+
+void FunctionalTensorWrapper::replace_(const Tensor& other) {
+    auto self_impl = value_.unsafeGetTensorImpl();
+    auto other_functional = dynamic_cast<FunctionalTensorWrapper*>(other.unsafeGetTensorImpl());
+    // new invariant: every time the fucntionalization pass redispatches during functionalize() calls,
+    // we'll hit the DynamicLayerModeBackFallback which should wrap outputs in a FunctionalTensorWrapper
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(other_functional != nullptr);
+    auto other_impl = other_functional->value().unsafeGetTensorImpl();
+    if (typeid(*self_impl) == typeid(*other_impl)) {
+        // It is valid to swap out the metadata on the tensorImpl
+        // but we can only do that if the two tensor's we're swapping have the same type.
+        // This allows us to ensure that programs that mutate their inputs
+        // preserve their semantics under a functionalization pass.
+        self_impl->replace_(other_impl);
+    } else {
+        value_ = other_functional->value();
+    }
+}
+
+void FunctionalTensorWrapper::set_size(int64_t dim, int64_t new_size) {
+    value_.unsafeGetTensorImpl()->set_size(dim, new_size);
+}
+void FunctionalTensorWrapper::set_stride(int64_t dim, int64_t new_stride) {
+    value_.unsafeGetTensorImpl()->set_stride(dim, new_stride);
+}
+void FunctionalTensorWrapper::set_storage_offset(int64_t storage_offset) {
+    value_.unsafeGetTensorImpl()->set_storage_offset(storage_offset);
+}
+bool FunctionalTensorWrapper::has_storage() const {
+    return value_.unsafeGetTensorImpl()->has_storage();
+}
+IntArrayRef FunctionalTensorWrapper::sizes() const {
+    return value_.unsafeGetTensorImpl()->sizes();
+}
+int64_t FunctionalTensorWrapper::dim() const {
+    return value_.unsafeGetTensorImpl()->dim();
+}
+const Storage& FunctionalTensorWrapper::storage() const {
+    return value_.unsafeGetTensorImpl()->storage();
+}
+int64_t FunctionalTensorWrapper::numel() const {
+    return value_.unsafeGetTensorImpl()->numel();
+}
+bool FunctionalTensorWrapper::is_contiguous(at::MemoryFormat memory_format) const {
+    return value_.unsafeGetTensorImpl()->is_contiguous(memory_format);
+}
+int64_t FunctionalTensorWrapper::storage_offset() const {
+    return value_.unsafeGetTensorImpl()->storage_offset();
+}
+int64_t FunctionalTensorWrapper::size(int64_t d) const {
+    return value_.unsafeGetTensorImpl()->size(d);
+}
+int64_t FunctionalTensorWrapper::stride(int64_t d) const {
+    return value_.unsafeGetTensorImpl()->stride(d);
+}
+c10::intrusive_ptr<TensorImpl> FunctionalTensorWrapper::shallow_copy_and_detach(
+    const c10::VariableVersion& version_counter,
+    bool allow_tensor_metadata_change) const {
+    // TODO: maybe just don't allow this
+    return value_.unsafeGetTensorImpl()->shallow_copy_and_detach(version_counter, allow_tensor_metadata_change);
+}
+c10::intrusive_ptr<TensorImpl> FunctionalTensorWrapper::shallow_copy_and_detach(
+    c10::VariableVersion&& version_counter,
+    bool allow_tensor_metadata_change) const {
+    // TODO: maybe just don't allow this
+    return value_.unsafeGetTensorImpl()->shallow_copy_and_detach(version_counter, allow_tensor_metadata_change);
+}
+void FunctionalTensorWrapper::shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) {
+    // TODO: maybe just don't allow this
+    value_.unsafeGetTensorImpl()->shallow_copy_from(impl);
+}
+const char* FunctionalTensorWrapper::tensorimpl_type_name() const {
+    return "FunctionalTensorWrapper";
+}
+
+namespace functionalization {
+namespace impl {
+
+Tensor makeFunctional(const Tensor& tensor, int64_t level) {
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!dynamic_cast<FunctionalTensorWrapper*>(tensor.unsafeGetTensorImpl()));
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!tensor.key_set().has(c10::DispatchKey::Functionalize));
+  return at::detail::make_tensor<FunctionalTensorWrapper>(tensor, level);
+}
+
+c10::optional<Tensor> makeFunctional(const c10::optional<Tensor>& tensor, int64_t level) {
+  if (tensor.has_value()) {
+    return makeFunctional(*tensor, level);
+  }
+  return c10::nullopt;
+}
+
+c10::List<Tensor> makeFunctional(const c10::List<Tensor>& t_list, int64_t level) {
+  std::vector<at::Tensor> functional_tensors;
+  for (auto& t: t_list.vec()) {
+	functional_tensors.push_back(makeFunctional(t, level));
+  }
+  return c10::List<at::Tensor>(functional_tensors);
+}
+
+std::vector<Tensor> makeFunctional(const at::TensorList t_list, int64_t level) {
+  std::vector<at::Tensor> functional_tensors;
+  for (auto& t: t_list) {
+	functional_tensors.push_back(makeFunctional(t, level));
+  }
+  return functional_tensors;
+}
+
+c10::List<c10::optional<Tensor>> makeFunctional(const c10::List<c10::optional<Tensor>>& t_list, int64_t level) {
+  std::vector<c10::optional<at::Tensor>> functional_tensors;
+  for (auto& t: t_list.vec()) {
+	functional_tensors.push_back(makeFunctional(t, level));
+  }
+  return c10::List<c10::optional<at::Tensor>>(functional_tensors);
+}
+
+} // namespace impl
+} // namespace functionalization
+} // namespace at

--- a/functorch/csrc/FunctionalTensorWrapper.h
+++ b/functorch/csrc/FunctionalTensorWrapper.h
@@ -20,7 +20,8 @@ struct TORCH_API FunctionalTensorWrapper : public at::FunctionalTensorImplBase {
   int64_t level() const { return level_; };
 
   // Override the FunctionalTensorImplBase method describing how to re-use a tensor in the functionalization pass.
-  void replace_(const Tensor& other) override;
+  //void replace_(const Tensor& other) override;
+  void replace_(const TensorImpl* other_impl) override;
 
   // Override ALL virtual functions on the TensorImpl to call into the wrapped value's implementation
   IntArrayRef sizes() const override;

--- a/functorch/csrc/FunctionalTensorWrapper.h
+++ b/functorch/csrc/FunctionalTensorWrapper.h
@@ -1,0 +1,73 @@
+
+// Copyright (c) Facebook, Inc. and its affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <ATen/ArrayRef.h>
+#include <ATen/core/List.h>
+#include <ATen/FunctionalTensorImplBase.h>
+
+namespace at {
+
+struct TORCH_API FunctionalTensorWrapper : public at::FunctionalTensorImplBase {
+  explicit FunctionalTensorWrapper(Tensor value, int64_t level);
+
+  const Tensor& value() const { return value_; };
+  int64_t level() const { return level_; };
+
+  // Override the FunctionalTensorImplBase method describing how to re-use a tensor in the functionalization pass.
+  void replace_(const Tensor& other) override;
+
+  // Override ALL virtual functions on the TensorImpl to call into the wrapped value's implementation
+  IntArrayRef sizes() const override;
+  int64_t dim() const override;
+  bool has_storage() const override;
+  const Storage& storage() const override;
+  int64_t numel() const override;
+  bool is_contiguous(at::MemoryFormat memory_format = at::MemoryFormat::Contiguous) const override;
+  //bool is_contiguous_custom(at::MemoryFormat memory_format=at::MemoryFormat::Contiguous) const override;
+  int64_t storage_offset() const override;
+  void set_size(int64_t dim, int64_t new_size) override;
+  void set_stride(int64_t dim, int64_t new_stride) override;
+  void set_storage_offset(int64_t storage_offset) override;
+  int64_t size(int64_t d) const override;
+  int64_t stride(int64_t d) const override;
+  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
+      const c10::VariableVersion& version_counter,
+      bool allow_tensor_metadata_change) const override;
+  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
+      c10::VariableVersion&& version_counter,
+      bool allow_tensor_metadata_change) const override;
+  void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override;
+
+ private:
+  const char* tensorimpl_type_name() const override;
+
+  Tensor value_;
+  int64_t level_;
+};
+
+TORCH_API inline FunctionalTensorWrapper* unsafeGetFunctionalWrapper(const Tensor& tensor) {
+  auto functional_impl = static_cast<FunctionalTensorWrapper*>(tensor.unsafeGetTensorImpl());
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(functional_impl != nullptr);
+  return functional_impl;
+}
+
+namespace functionalization {
+namespace impl {
+
+// Utility functions for the functionalization pass.
+
+TORCH_API Tensor makeFunctional(const Tensor& tensor, int64_t level);
+TORCH_API c10::optional<Tensor> makeFunctional(const c10::optional<Tensor>& tensor);
+TORCH_API c10::List<Tensor> makeFunctional(const c10::List<Tensor>& t_list);
+TORCH_API std::vector<Tensor> makeFunctional(const TensorList t_list);
+TORCH_API c10::List<c10::optional<Tensor>> makeFunctional(const c10::List<c10::optional<Tensor>>& tensor);
+
+} // namespace impl
+} // namespace functionalization
+} // namespace at

--- a/functorch/csrc/TensorWrapper.h
+++ b/functorch/csrc/TensorWrapper.h
@@ -23,6 +23,8 @@ struct TORCH_API TensorWrapper : public c10::TensorImpl {
   void set_size(int64_t dim, int64_t new_size) override;
   void set_stride(int64_t dim, int64_t new_stride) override;
   void set_storage_offset(int64_t storage_offset) override;
+  // Need to override for functionalization to work.
+  void replace_(const TensorImpl* other_impl) override;
 
   void refreshMetadata();
 

--- a/functorch/csrc/VmapModeRegistrations.cpp
+++ b/functorch/csrc/VmapModeRegistrations.cpp
@@ -113,6 +113,8 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchVmapMode, m) {
 
 
   m.impl("randn", randn_mbatching_rule);
+  // We need this for the functionalization pass: replace_ shouldn't enter the boxed fallback
+  m.impl("replace_", torch::CppFunction::makeFallthrough());
 }
 
 

--- a/functorch/csrc/init.cpp
+++ b/functorch/csrc/init.cpp
@@ -200,12 +200,10 @@ int64_t _vmap_decrement_nesting() {
 }
 
 int64_t _func_increment_nesting() {
-    //c10::impl::tls_set_dispatch_key_included(DispatchKey::Functionalize, true);
   return initAndPushDynamicLayer(DispatchKey::Functionalize);
 }
 
 int64_t _func_decrement_nesting() {
-    //c10::impl::tls_set_dispatch_key_included(DispatchKey::Functionalize, false);
   auto layer = popDynamicLayerAndDeleteMetadata();
   TORCH_INTERNAL_ASSERT(layer.key() == DispatchKey::Functionalize);
   return layer.layerId();


### PR DESCRIPTION
First pass of the functionalization pass for functorch. Most of the description can be found in the accompanying core-side PR [here](https://github.com/pytorch/pytorch/pull/63048).

This PR probably needs some cleanup first, but I wanted to put up the functorch-side changes early for completeness.

Stuff that I still need to do:
- I've only done basic testing of `functionalize()` so far
- I need to implement more view ops - only `view()` is currently implemented

The part worth talking about the most is probably the wrapping/unwrapping logic [here](https://github.com/facebookresearch/functorch/pull/89/files#diff-8d75d5141cd5d6feb6d29db3e15bf67070f4f21f34df02e90fcc76a0c3511df1R478), which is kind of similar to the wrapping/unwrapping logic for grad() (and can probably be shared). Main points:
- functorch needs to do the wrapping/unwrapping, and not core, because core doesn't know what "level" the wrapper should have. That means that the wrapping and unwrapping should happen in the boxed fallback, `DynamicLayerBackFallback`.
- It needs to be careful to wrap the outputs of factory functions, but not to wrap any outputs when we're currently printing.

