### PR TITLE
Fix PointwiseCompiler on CUDA

### DIFF
--- a/functorch/_src/operator_authoring.py
+++ b/functorch/_src/operator_authoring.py
@@ -316,7 +316,7 @@ class PointwiseCompiler(object):
         loopnest = _te.LoopNest(_te.Block([out]), output_bufs)
 
         if self.device == "cuda" and loops:
-            flattened = _te.LoopNest.flatten(loops)
+            flattened = loopnest.flatten(loops)
             assert flattened
             inner = _te.LoopNest.split_with_mask(flattened, 512)
             assert inner


### PR DESCRIPTION
The LoopNest.flatten API changed at some point to be an object method instead of a class method, for some reason.