### PR TITLE
Cleanup CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,15 +5,6 @@ commands:
     description: "checkout merge branch"
     steps:
       - checkout
-  #     - run:
-  #         name: Checkout merge branch
-  #         command: |
-  #           set -ex
-  #           BRANCH=$(git rev-parse --abbrev-ref HEAD)
-  #           if [[ "$BRANCH" != "master" ]]; then
-  #             git fetch --force origin ${CIRCLE_BRANCH}/merge:merged/${CIRCLE_BRANCH}
-  #             git checkout "merged/$CIRCLE_BRANCH"
-  #           fi
 
 binary_common: &binary_common
   parameters:
@@ -84,7 +75,7 @@ jobs:
           name: Post process
           command: .circleci/unittest/linux/scripts/post_process.sh
       - store_test_results:
-          path: test-results
+          path: test-reports
 
   unittest_linux_gpu:
     <<: *binary_common
@@ -122,7 +113,7 @@ jobs:
           name: Post process
           command: .circleci/unittest/linux/scripts/post_process.sh
       - store_test_results:
-          path: test-results
+          path: test-reports
 
 workflows:
   unittest:

--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - pip
   - ca-certificates
   - pip:
+      - xmlrunner
       - pillow>=4.1.1
       - scipy
       - av

--- a/.circleci/unittest/linux/scripts/run_test.sh
+++ b/.circleci/unittest/linux/scripts/run_test.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export IN_CI=1
+mkdir test-reports
 eval "$(./conda/bin/conda shell.bash hook)"
 conda activate ./env
 
@@ -9,4 +11,6 @@ python -m torch.utils.collect_env
 
 # test_functorch_lagging_op_db.py: Only run this locally because it checks
 # the functorch lagging op db vs PyTorch's op db.
-find test \( -name test\*.py ! -name test_functorch_lagging_op_db.py \) | xargs -I {} -n 1 bash -c "python {} -v || exit 255"
+EXIT_STATUS=0
+find test \( -name test\*.py ! -name test_functorch_lagging_op_db.py \) | xargs -I {} -n 1 python {} -v || EXIT_STATUS=$?
+exit $EXIT_STATUS

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -7,8 +7,6 @@ set -e
 #
 # Do not install PyTorch and functorch here, otherwise they also get cached.
 
-set -e
-
 this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 root_dir="$(git rev-parse --show-toplevel)"
 conda_dir="${root_dir}/conda"


### PR DESCRIPTION
Closes #148 #139 

Demonstration on a broken branch [here](https://app.circleci.com/pipelines/github/pytorch/functorch/491/workflows/ed2cdc1d-a256-45b3-9cd5-e27f4105034a/jobs/2927)

This runs all of the tests instead of just running up until the first suite fails. This is shown on the broken branch because some failures are from TestOps (in test/test_ops.py) and some are from TestVmapOperatorsOpInfo(in test/test_vmap.py)

Additionally, the link shows the test output. It hooks onto PyTorch's test setup to get the XML files of the output