### PR TITLE
readd movedim

### DIFF
--- a/functorch/csrc/BatchRulesViews.cpp
+++ b/functorch/csrc/BatchRulesViews.cpp
@@ -479,6 +479,7 @@ TORCH_LIBRARY_IMPL(aten, FT_BATCHED_KEY, m) {
   VMAP_SUPPORT("expand", expand_batch_rule);
   VMAP_SUPPORT("unfold", unfold_batch_rule);
   VMAP_SUPPORT("movedim.intlist", movedim_batch_rule);
+  m.impl("movedim.int", static_cast<Tensor(*)(const Tensor&,int64_t,int64_t)>(native::movedim)); // composite wrt autograd
 } 
 
 }}


### PR DESCRIPTION
This PR readds the `movedim.int` implementation registration. The fallback for this operator does not work as it fails this check:

```python
TORCH_CHECK(!schema.is_mutable() && !schema.hasAnyAliasInfo(),
              "Batching rule not implemented for ", schema.operator_name(), "; ",
              "the fallback path doesn't work on out= or view ops.");
```

cc @Chillee 