### PR TITLE
Added backward batch rule for pad replicate/reflect modes

### DIFF
--- a/functorch/csrc/BatchRulesModules.cpp
+++ b/functorch/csrc/BatchRulesModules.cpp
@@ -409,6 +409,14 @@ TORCH_LIBRARY_IMPL(aten, FT_BATCHED_KEY, m) {
   EXISTING_BDIM(replication_pad2d);
   EXISTING_BDIM(replication_pad3d);
 
+  EXISTING_BDIM_ALL_BOXED(replication_pad1d_backward);
+  EXISTING_BDIM_ALL_BOXED(replication_pad2d_backward);
+  EXISTING_BDIM_ALL_BOXED(replication_pad3d_backward);
+
+  EXISTING_BDIM_ALL_BOXED(reflection_pad1d_backward);
+  EXISTING_BDIM_ALL_BOXED(reflection_pad2d_backward);
+  EXISTING_BDIM_ALL_BOXED(reflection_pad3d_backward);
+
   UPSAMPLE_BATCH(upsample_bicubic2d);
   UPSAMPLE_BATCH(upsample_bilinear2d);
   UPSAMPLE_BATCH(upsample_linear1d);

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -467,8 +467,6 @@ class TestOperators(TestCase):
         xfail('nn.functional.grid_sample'),
         xfail('nn.functional.interpolate', 'area'),
         xfail('nn.functional.pad', 'circular'),
-        xfail('nn.functional.pad', 'reflect'),
-        xfail('nn.functional.pad', 'replicate'),
         xfail('nn.functional.unfold'),
         xfail('norm', 'fro'),
         xfail('norm', 'inf'),


### PR DESCRIPTION
Description:
- Added backward batch rule for pad replicate/reflect modes
- Updated tests

Related to #240