### PR TITLE
Single cache

### DIFF
--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -326,14 +326,15 @@ def compiled_function(
             compile_cache.insert(
                 fn_id, num_args, hasher_type, cached_fn, *flattened_args
             )
-        iters = 10000
-        begin = time.perf_counter()
-        # while True:
-        for _ in range(iters):
-            # continue
-            compile_cache.at(fn_id, num_args, hasher_type, *flattened_args)
-        print((time.perf_counter() - begin) / iters * 1e6)
-        pass
+        else:
+            iters = 10000
+            begin = time.perf_counter()
+            # while True:
+            for _ in range(iters):
+                # continue
+                compile_cache.at(fn_id, num_args, hasher_type, *flattened_args)
+            print((time.perf_counter() - begin) / iters * 1e6)
+            pass
 
         return cached_fn(*flattened_args)
 

--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -308,7 +308,7 @@ def compiled_function(
             flattened_args, _ = pytree.tree_flatten((args, kwargs))
 
         # Check if the fn is already compiled
-        cached_fn = compile_cache.at(fn_id, len(flattened_args), *flattened_args)
+        cached_fn = compile_cache.at(fn_id, len(flattened_args), hasher_type, *flattened_args)
 
         # Compile the function and save it in the cache
         if cached_fn is None:
@@ -323,13 +323,8 @@ def compiled_function(
             ).apply
 
             # Save the compiled_fn in the cache
-            name = "fn_" + str(fn_id)
-            st_args = [
-                f"Tensor inp_{idx}" for idx, _ in enumerate(flattened_args)
-            ]
-            signature = f"{name}({', '.join(st_args)}, *)"
             compile_cache.insert(
-                fn_id, [signature], len(flattened_args), hasher_type, cached_fn, *flattened_args
+                fn_id, len(flattened_args), hasher_type, cached_fn, *flattened_args
             )
 
         return cached_fn(*flattened_args)

--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -304,11 +304,11 @@ def compiled_function(
         nonlocal cached_fn
         if HAS_TREE:
             flattened_args = tree.flatten((args, kwargs))
+            num_args = len(flattened_args)
         else:
             flattened_args, _ = pytree.tree_flatten((args, kwargs))
-
         # Check if the fn is already compiled
-        cached_fn = compile_cache.at(fn_id, len(flattened_args), hasher_type, *flattened_args)
+        cached_fn = compile_cache.at(fn_id, num_args, hasher_type, *flattened_args)
 
         # Compile the function and save it in the cache
         if cached_fn is None:
@@ -324,8 +324,16 @@ def compiled_function(
 
             # Save the compiled_fn in the cache
             compile_cache.insert(
-                fn_id, len(flattened_args), hasher_type, cached_fn, *flattened_args
+                fn_id, num_args, hasher_type, cached_fn, *flattened_args
             )
+        iters = 10000
+        begin = time.perf_counter()
+        # while True:
+        for _ in range(iters):
+            # continue
+            compile_cache.at(fn_id, num_args, hasher_type, *flattened_args)
+        print((time.perf_counter() - begin) / iters * 1e6)
+        pass
 
         return cached_fn(*flattened_args)
 

--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -304,9 +304,9 @@ def compiled_function(
         nonlocal cached_fn
         if HAS_TREE:
             flattened_args = tree.flatten((args, kwargs))
-            num_args = len(flattened_args)
         else:
             flattened_args, _ = pytree.tree_flatten((args, kwargs))
+        num_args = len(flattened_args)
         # Check if the fn is already compiled
         cached_fn = compile_cache.at(fn_id, num_args, hasher_type, *flattened_args)
 

--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -326,15 +326,6 @@ def compiled_function(
             compile_cache.insert(
                 fn_id, num_args, hasher_type, cached_fn, *flattened_args
             )
-        else:
-            iters = 10000
-            begin = time.perf_counter()
-            # while True:
-            for _ in range(iters):
-                # continue
-                compile_cache.at(fn_id, num_args, hasher_type, *flattened_args)
-            print((time.perf_counter() - begin) / iters * 1e6)
-            pass
 
         return cached_fn(*flattened_args)
 

--- a/functorch/_src/memory_efficient_op_authoring.py
+++ b/functorch/_src/memory_efficient_op_authoring.py
@@ -6,7 +6,6 @@ from typing import Iterable
 from .aot_autograd import compiled_function, partition_with_recompute_fwd_in_bwd
 
 
-
 def tensorexpr_compile(fx_module, flat_args):
     """Compiles the given fx_module using TensorExpr Kernel"""
     inp_devices = set([i.device for i in flat_args if isinstance(i, torch.Tensor)])

--- a/functorch/_src/memory_efficient_op_authoring.py
+++ b/functorch/_src/memory_efficient_op_authoring.py
@@ -6,6 +6,7 @@ from typing import Iterable
 from .aot_autograd import compiled_function, partition_with_recompute_fwd_in_bwd
 
 
+
 def tensorexpr_compile(fx_module, flat_args):
     """Compiles the given fx_module using TensorExpr Kernel"""
     inp_devices = set([i.device for i in flat_args if isinstance(i, torch.Tensor)])

--- a/functorch/csrc/CompileCache.cpp
+++ b/functorch/csrc/CompileCache.cpp
@@ -63,40 +63,6 @@ struct DynamicArgSpecializationKey {
     initDimflags(v.sizes(), v.strides());
   }
 
-  // TODO (anijain) - Code seems expensive for each comparison. Revisit if cache
-  // latency is bad.
-  bool operator<(const DynamicArgSpecializationKey &other) const {
-    auto this_tie = std::tie(flags_, aliasGroup_, dispatchKey_, nDims_);
-    auto other_tie = std::tie(other.flags_, other.aliasGroup_,
-                              other.dispatchKey_, other.nDims_);
-    if (this_tie != other_tie) {
-      return this_tie < other_tie;
-    }
-
-    for (int dim = 0; dim < nDims_; dim++) {
-      if (dimflags_[dim] != other.dimflags_[dim]) {
-        return dimflags_[dim] < other.dimflags_[dim];
-      }
-    }
-    return false;
-  }
-
-  bool operator==(const DynamicArgSpecializationKey &other) const {
-    auto this_tie = std::tie(flags_, aliasGroup_, dispatchKey_, nDims_);
-    auto other_tie = std::tie(other.flags_, other.aliasGroup_,
-                              other.dispatchKey_, other.nDims_);
-    if (this_tie != other_tie) {
-      return false;
-    }
-
-    for (int dim = 0; dim < nDims_; dim++) {
-      if (dimflags_[dim] != other.dimflags_[dim]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   /// Get the dispatch key for this specialization.
   at::DispatchKeySet dispatchKey() const {
     return at::DispatchKeySet(at::DispatchKeySet::RAW, dispatchKey_);
@@ -207,44 +173,6 @@ struct StaticArgSpecializationKey {
       shapes_.push_back(v.sizes()[dim]);
       strides_.push_back(v.strides()[dim]);
     }
-  }
-
-  // TODO (anijain) - Code seems expensive for each comparison. Revisit if cache
-  // latency is bad.
-  bool operator<(const StaticArgSpecializationKey &other) const {
-    auto this_tie = std::tie(flags_, aliasGroup_, dispatchKey_, nDims_);
-    auto other_tie = std::tie(other.flags_, other.aliasGroup_,
-                              other.dispatchKey_, other.nDims_);
-    if (this_tie != other_tie) {
-      return this_tie < other_tie;
-    }
-
-    for (int dim = 0; dim < nDims_; dim++) {
-      auto this_tie = std::tie(shapes_[dim], strides_[dim]);
-      auto other_tie = std::tie(other.shapes_[dim], other.strides_[dim]);
-      if (this_tie != other_tie) {
-        return this_tie < other_tie;
-      }
-    }
-    return false;
-  }
-
-  bool operator==(const StaticArgSpecializationKey &other) const {
-    auto this_tie = std::tie(flags_, aliasGroup_, dispatchKey_, nDims_);
-    auto other_tie = std::tie(other.flags_, other.aliasGroup_,
-                              other.dispatchKey_, other.nDims_);
-    if (this_tie != other_tie) {
-      return false;
-    }
-
-    for (int dim = 0; dim < nDims_; dim++) {
-      auto this_tie = std::tie(shapes_[dim], strides_[dim]);
-      auto other_tie = std::tie(other.shapes_[dim], other.strides_[dim]);
-      if (this_tie != other_tie) {
-        return false;
-      }
-    }
-    return true;
   }
 
   std::string to_string() {


### PR DESCRIPTION
Replacing with single cache. This one removes the use of templates to have a single cache, which is much easier to control. 

The key of the cache is of type string, which is built by naively concatenating all the private members of the SpecializationKey class (either Dynamic or Static for now).

Some of the missing items before merging
* Testing the latency. String building might make look up slow.

