### PR TITLE
jvp x vjp testing

### DIFF
--- a/test/xfail_suggester.py
+++ b/test/xfail_suggester.py
@@ -32,6 +32,7 @@ base_names = {
     'test_jvp_',
     'test_vmapjvp_',
     'test_vmapjvpall_',
+    'test_jvpvjp_',
     'test_decomposition_',
     'test_make_fx_',
 }


### PR DESCRIPTION
Failures are either:
- lack of PyTorch forward-mode AD support (mostly)
- efficient zero tensors errors
- CUDA asserts (really need to be investigated).

All of the problems should be reproducible on the pytorch/pytorch side.