### PR TITLE
Fix getitem

### DIFF
--- a/functorch/csrc/BatchedFallback.cpp
+++ b/functorch/csrc/BatchedFallback.cpp
@@ -67,7 +67,10 @@ static bool areAnyArgumentsTensorList(const at::FunctionSchema& schema) {
   return std::any_of(
       schema.arguments().begin(),
       schema.arguments().end(),
-      [] (const Argument& arg) { return arg.type()->isSubtypeOf(ListType::ofTensors()); });
+      [] (const Argument& arg) {
+        return arg.type()->isSubtypeOf(ListType::ofTensors()) ||
+          arg.type()->isSubtypeOf(ListType::ofOptionalTensors());
+      });
 }
 
 static void warnFallback(const c10::FunctionSchema& schema, bool is_inplace) {

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -549,7 +549,7 @@ class TestOperators(TestCase):
         xfail('nn.functional.fractional_max_pool3d'),
         xfail('as_strided'),
         xfail('nn.functional.fractional_max_pool2d'),
-        xfail('__getitem__'),
+        xfail('__getitem__', ''),
         xfail('index_put'),
         xfail('lu_solve'),
     })
@@ -744,7 +744,7 @@ class TestOperators(TestCase):
     @ops(functorch_lagging_op_db + additional_op_db, allowed_dtypes=(torch.float,))
     @skipOps('TestOperators', 'test_vmapvjp_has_batch_rule', vmapvjp_fail.union({
         xfail('view_as_complex'),
-        xfail('__getitem__'),
+        xfail('__getitem__', ''),
         xfail('cholesky'),
         xfail('complex'),
         xfail('copysign'),
@@ -865,7 +865,7 @@ class TestOperators(TestCase):
         # fallback path doesn't work
         xfail('H'),
         # All of the following are bugs and need to be fixed
-        xfail('__getitem__'),
+        xfail('__getitem__', ''),
         xfail('clamp', ''),
         xfail('dsplit'),
         xfail('fill_'),

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -3219,7 +3219,7 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('to_sparse'),
         xfail('vdot'),
         xfail('vsplit'),
-        xfail('__getitem__'),
+        xfail('__getitem__', ''),
         xfail('all'),
         xfail('any'),
         xfail('count_nonzero'),


### PR DESCRIPTION
Fixes https://github.com/pytorch/functorch/issues/363

This PR:
- adds a batch rule for _index_put_impl_
- fixes the index_put_ batch rule
- adds a new OpInfo so we can actually test this
- fixes the fallback paths to error out on Tensor?[], otherwise they are
very wrong.