### PR TITLE
[Compile Cache] Handle non tensor args

### DIFF
--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -235,7 +235,7 @@ def partition_with_recompute_fwd_in_bwd(joint_module: fx.GraphModule, _joint_inp
 def create_joint_forward_backward(fn):
     def joint_forward_backward(primals, tangents):
         out = fn(*primals)
-        primals = [p for p in pytree.tree_flatten(primals)[0] if p.requires_grad]
+        primals = [p for p in pytree.tree_flatten(primals)[0] if isinstance(p, torch.Tensor) and p.requires_grad]
         backward_out = []
         if primals:  # todo(chilli): Make it support it if not all outputs have gradients
             backward_out = torch.autograd.grad(out, primals, grad_outputs=tangents, allow_unused=True)
@@ -357,6 +357,29 @@ class PytreeThunk:
         return pytree.tree_unflatten(x, self.spec)
 
 
+def num_of_tensor_args(args):
+    count = 0
+    for arg in args:
+        if isinstance(arg, torch.Tensor):
+            count += 1
+    return count
+
+
+def handle_non_tensor_args(flattened_args):
+    """
+    Store the hash of non tensor args. Also, reorder the args such that the
+    tensor args are at the beginning of the list.
+    """
+    tensor_args = list()
+    non_tensor_args = list()
+    for flat_arg in flattened_args:
+        if isinstance(flat_arg, torch.Tensor):
+            tensor_args.append(flat_arg)
+        else:
+            non_tensor_args.append(flat_arg.__hash__())
+    return tensor_args + non_tensor_args
+
+
 def compiled_function(
     fn,
     fw_compiler,
@@ -381,9 +404,11 @@ def compiled_function(
             flattened_args = tree.flatten((args, kwargs))
         else:
             flattened_args, _ = pytree.tree_flatten((args, kwargs))
-        num_args = len(flattened_args)
+        num_tensor_args = num_of_tensor_args(flattened_args)
+
         # Check if the fn is already compiled
-        cached_res = compile_cache.at(fn_id, num_args, hasher_type, *flattened_args)
+        flattened_args_for_cache = handle_non_tensor_args(flattened_args)
+        cached_res = compile_cache.at(fn_id, num_tensor_args, hasher_type, *flattened_args_for_cache)
 
         # Compile the function and save it in the cache
         if cached_res is None:
@@ -403,8 +428,9 @@ def compiled_function(
             ).apply
             cached_res = (compiled_fn, out_spec)
             # Save the compiled_fn in the cache
+            flattened_args_for_cache = handle_non_tensor_args(flattened_args)
             compile_cache.insert(
-                fn_id, num_args, hasher_type, cached_res, *flattened_args
+                fn_id, num_tensor_args, hasher_type, cached_res, *flattened_args_for_cache
             )
 
         cached_fn, out_spec = cached_res

--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -22,13 +22,17 @@ pytree._register_pytree_node(immutable_collections.immutable_dict, lambda x: (li
 # TODO - move this to PyTorch core. This overrides the pytree implementation for
 # dict to maintain parity with Deepmind pytree.
 Context = Any
+
+
 def _dict_flatten(d: Dict[Any, Any]) -> Tuple[List[Any], Context]:
     keys = list(sorted(d.keys()))
     values = [d[key] for key in keys]
     return values, keys
 
+
 def _dict_unflatten(values: List[Any], context: Context) -> Dict[Any, Any]:
     return {key: value for key, value in zip(context, values)}
+
 
 pytree._register_pytree_node(dict, _dict_flatten, _dict_unflatten)
 
@@ -409,7 +413,6 @@ def rearrange(tensor_args, static_args, static_argnums):
     while tensor_index < len(tensor_args):
         args.append(tensor_args[tensor_index])
         tensor_index += 1
-
 
     while static_index < len(static_args):
         args.append(static_args[static_index])

--- a/functorch/csrc/CompileCache.cpp
+++ b/functorch/csrc/CompileCache.cpp
@@ -177,7 +177,12 @@ public:
     // Convert to Tensor Args
     std::vector<at::Tensor> tensorArgs(numTensorArgs);
     for (int i = 0; i < numTensorArgs; ++i) {
-      tensorArgs[i] = THPVariable_Unpack(PyTuple_GET_ITEM(args, i));
+      PyObject *arg = PyTuple_GET_ITEM(args, i);
+      if (!THPVariable_Check(arg)) {
+        throw std::runtime_error("Encountered a non-tensor argument. Set up "
+                                 "static_argnums correctly.");
+      }
+      tensorArgs[i] = THPVariable_Unpack(arg);
     }
     return tensorArgs;
   }

--- a/functorch/csrc/CompileCache.cpp
+++ b/functorch/csrc/CompileCache.cpp
@@ -48,7 +48,6 @@ using hash_key_t = std::vector<int64_t>;
 /// dtype, dispatch options, aliasing, and per-dim contiguity/broadcasting
 /// information.
 
-
 enum DimFlags {
   /// A leading dimension implicitly added by broadcasting.
   SIZE_MISSING = 1 << 0,
@@ -84,16 +83,16 @@ std::vector<int> genDimFlags(c10::IntArrayRef sizes, c10::IntArrayRef strides) {
   for (int64_t dim = 0; dim < nDims; ++dim) {
     uint8_t flag =
         (sizes[dim] == 0 ? SIZE_MISSING
-                          : (sizes[dim] == 1 ? SIZE_ONE : SIZE_OTHER));
+                         : (sizes[dim] == 1 ? SIZE_ONE : SIZE_OTHER));
     if (strides[dim] == 0) {
       flag |= STRIDE_ZERO;
     } else if (strides[dim] == 1) {
       flag |= STRIDE_ONE;
     } else if (dim + 1 < (int64_t)sizes.size() &&
-                strides[dim] == strides[dim + 1] * sizes[dim + 1]) {
+               strides[dim] == strides[dim + 1] * sizes[dim + 1]) {
       flag |= STRIDE_CONTIGUOUS;
     } else if (dim > 0 && strides[dim] == strides[dim - 1] * sizes[dim - 1] &&
-                (dimflags[dim - 1] & STRIDE_CONTIGUOUS) == 0) {
+               (dimflags[dim - 1] & STRIDE_CONTIGUOUS) == 0) {
       flag |= STRIDE_TRANSPOSED_CONTIGUOUS;
     } else {
       flag |= STRIDE_AS_ARG;
@@ -104,27 +103,23 @@ std::vector<int> genDimFlags(c10::IntArrayRef sizes, c10::IntArrayRef strides) {
 }
 
 hash_key_t dynamic_hasher(const LocalState &state, const at::Tensor &v) {
-    hash_key_t hash = {
-      0,
-      static_cast<int>(packFlags(state, v)),
-      static_cast<int>(state.apply(v.key_set()).raw_repr()),
-      static_cast<int>(v.ndimension())};
-    auto dimFlags = genDimFlags(v.sizes(), v.strides());
-    hash.insert(hash.end(), dimFlags.begin(), dimFlags.end());
-    return hash;
+  hash_key_t hash = {0, static_cast<int>(packFlags(state, v)),
+                     static_cast<int>(state.apply(v.key_set()).raw_repr()),
+                     static_cast<int>(v.ndimension())};
+  auto dimFlags = genDimFlags(v.sizes(), v.strides());
+  hash.insert(hash.end(), dimFlags.begin(), dimFlags.end());
+  return hash;
 }
 
 /// Per-tensor cache specialization key targetting static shapes. Recordsdtype,
 /// dispatch options, aliasing, and full shapes and strides.
 hash_key_t static_hasher(const LocalState &state, const at::Tensor &v) {
-    hash_key_t hash = {
-      1,
-      static_cast<int>(packFlags(state, v)),
-      static_cast<int>(state.apply(v.key_set()).raw_repr()),
-      static_cast<int>(v.ndimension())};
-    hash.insert(hash.end(), v.sizes().begin(), v.sizes().end());
-    hash.insert(hash.end(), v.strides().begin(), v.strides().end());
-    return hash;
+  hash_key_t hash = {1, static_cast<int>(packFlags(state, v)),
+                     static_cast<int>(state.apply(v.key_set()).raw_repr()),
+                     static_cast<int>(v.ndimension())};
+  hash.insert(hash.end(), v.sizes().begin(), v.sizes().end());
+  hash.insert(hash.end(), v.strides().begin(), v.strides().end());
+  return hash;
 }
 
 /// ArgCompileCache is a templated class allowing plugging of different types of
@@ -139,9 +134,9 @@ public:
   /// Cache type mapping specialization keys to compiled kernels.
   class vector_hasher {
   public:
-    std::size_t operator()(hash_key_t const& vec) const {
+    std::size_t operator()(hash_key_t const &vec) const {
       std::size_t seed = vec.size();
-      for(auto& i : vec) {
+      for (auto &i : vec) {
         seed ^= i + 0x9e3779b9 + (seed << 6) + (seed >> 2);
       }
       return seed;
@@ -151,39 +146,50 @@ public:
 
   /// Compute the set of specialization keys based on the inputs to
   /// the kernel.
-  hash_key_t computeCacheKey(const std::vector<at::Tensor>& args, int numArgs,
-                              const std::string& hasherType, int64_t id) {
+  hash_key_t computeCacheKey(PyObject *args,
+                             const std::vector<at::Tensor> &tensorArgs,
+                             int numTensorArgs, const std::string &hasherType,
+                             int64_t id) {
     LocalState state;
     hash_key_t cacheKey;
-    for (int i = 0; i < numArgs; ++i) {
+    for (int i = 0; i < numTensorArgs; ++i) {
       if (hasherType == "StaticShapeHasher") {
-        auto res = static_hasher(state, args[i]);
+        auto res = static_hasher(state, tensorArgs[i]);
         cacheKey.insert(cacheKey.end(), res.begin(), res.end());
       } else if (hasherType == "DynamicShapeHasher") {
-        auto res = dynamic_hasher(state, args[i]);
+        auto res = dynamic_hasher(state, tensorArgs[i]);
         cacheKey.insert(cacheKey.end(), res.begin(), res.end());
       }
     }
     cacheKey.push_back(id);
-    cacheKey.push_back(numArgs);
+    cacheKey.push_back(numTensorArgs);
+
+    // Cache the non-tensor args. Currently, all the non-tensor args are cached.
+    for (int i = numTensorArgs; i < PyTuple_Size(args); i++) {
+      PyObject *arg = PyTuple_GET_ITEM(args, i);
+      assert(PyLong_Check(arg));
+      cacheKey.push_back(PyLong_AsLong(arg));
+    }
     return cacheKey;
   }
 
-  std::vector<at::Tensor> parsePythonArgs(int numArgs, PyObject *args) {
+  std::vector<at::Tensor> parsePythonArgs(int numTensorArgs, PyObject *args) {
     // Convert to Tensor Args
-    std::vector<at::Tensor> tensorArgs(numArgs);
-    for (int i = 0; i < numArgs; ++i) {
+    std::vector<at::Tensor> tensorArgs(numTensorArgs);
+    for (int i = 0; i < numTensorArgs; ++i) {
       tensorArgs[i] = THPVariable_Unpack(PyTuple_GET_ITEM(args, i));
     }
     return tensorArgs;
   }
 
   /// Check if the function has already been compiled.
-  // py::object at(int64_t id, int numArgs, PyObject *args, PyObject *kwargs) {
-  py::object at(int64_t id, int numArgs, const std::string &hasherType,
+  // py::object at(int64_t id, int numTensorArgs, PyObject *args, PyObject
+  // *kwargs) {
+  py::object at(int64_t id, int numTensorArgs, const std::string &hasherType,
                 PyObject *args) {
-    std::vector<at::Tensor> tensorArgs = parsePythonArgs(numArgs, args);
-    hash_key_t cacheKey = computeCacheKey(tensorArgs, numArgs, hasherType, id);
+    std::vector<at::Tensor> tensorArgs = parsePythonArgs(numTensorArgs, args);
+    hash_key_t cacheKey =
+        computeCacheKey(args, tensorArgs, numTensorArgs, hasherType, id);
 
     auto item = cache_.find(cacheKey); // protected by GIL
 
@@ -194,11 +200,12 @@ public:
   }
 
   /// Insert a new compiled functions for new tensor properties.
-  void insert(int64_t id, int numArgs, const std::string &hasherType,
+  void insert(int64_t id, int numTensorArgs, const std::string &hasherType,
               const py::object &compileFn, PyObject *args) {
-    std::vector<at::Tensor> tensorArgs = parsePythonArgs(numArgs, args);
+    std::vector<at::Tensor> tensorArgs = parsePythonArgs(numTensorArgs, args);
     LocalState state;
-    hash_key_t cacheKey= computeCacheKey(tensorArgs, numArgs, hasherType, id);
+    hash_key_t cacheKey =
+        computeCacheKey(args, tensorArgs, numTensorArgs, hasherType, id);
     cache_.emplace(cacheKey, compileFn);
   }
 
@@ -225,15 +232,15 @@ void initCompileCacheBindings(PyObject *module) {
   py::class_<CompileCache>(te, "CompileCache")
       .def(py::init(&createCompileCache))
       .def("at",
-           [](CompileCache &self, int64_t id, int numArgs,
+           [](CompileCache &self, int64_t id, int numTensorArgs,
               const std::string hasherType, py::args args) {
-             return self.at(id, numArgs, hasherType, args.ptr());
+             return self.at(id, numTensorArgs, hasherType, args.ptr());
            })
       .def("insert",
-           [](CompileCache &self, int64_t id, int numArgs,
+           [](CompileCache &self, int64_t id, int numTensorArgs,
               const std::string hasherType, const py::object &compileFn,
               py::args args, py::kwargs kwargs) {
-             self.insert(id, numArgs, hasherType, compileFn, args.ptr());
+             self.insert(id, numTensorArgs, hasherType, compileFn, args.ptr());
            })
       .def("clear", [](CompileCache &self) { self.clear(); })
       .def("size", [](CompileCache &self) { return self.size(); });

--- a/test/test_compile_cache.py
+++ b/test/test_compile_cache.py
@@ -228,7 +228,7 @@ class TestCompileCacheNonTensorArgs(TestCase):
 
     def test_simple_different_ordering(self):
         def fn(p, x):
-            return p * x
+            return p - x
 
         def check(a, b, aot_autograd_fn, fn):
             b_clone = b.clone().detach().requires_grad_(True)

--- a/test/test_compile_cache.py
+++ b/test/test_compile_cache.py
@@ -3,7 +3,7 @@ import torch
 import functorch
 from torch.testing._internal.common_utils import run_tests, TestCase
 
-from functorch.compile import compiled_function
+from functorch.compile import aot_function
 from functorch.compile import memory_efficient_pointwise_fusion
 
 
@@ -108,7 +108,7 @@ class TestCompileCache(TestCase):
             return x
 
         def g(x, bias):
-            return compiled_function(
+            return aot_function(
                 f, _nop_compile, _nop_compile, hasher_type="DynamicShapeHasher"
             )(x, bias)
 
@@ -208,7 +208,7 @@ class TestCompileCache(TestCase):
             def _nop_compile(x, _):
                 return x
 
-            aot_autograd_f = compiled_function(
+            aot_autograd_f = aot_function(
                 f, _nop_compile, _nop_compile, hasher_type=hasher_type
             )
 
@@ -240,7 +240,7 @@ class TestCompileCache(TestCase):
 
             start_num_recomps = functorch.compile.num_of_recompilations()
 
-            aot_autograd_f = compiled_function(
+            aot_autograd_f = aot_function(
                 fn, _nop_compile, _nop_compile, hasher_type=hasher_type
             )
 
@@ -279,13 +279,13 @@ class TestCompileCache(TestCase):
 
             start_num_recomps = functorch.compile.num_of_recompilations()
 
-            aot_autograd_f = compiled_function(
+            aot_autograd_f = aot_function(
                 fn, _nop_compile, _nop_compile, hasher_type=hasher_type
             )
 
             a = torch.randn(2, 2, requires_grad=True)
             b = 0.3
-            res = aot_autograd_f(a, b)
+            aot_autograd_f(a, b)
 
             # Setting the prob to 0. This should cause recompilation.
             a = torch.randn(2, 2, requires_grad=True)


### PR DESCRIPTION
The non tensor args are hashed in python and sent to the cache. Currently, all the non tensor args are cached.

@Chillee 