### PR TITLE
Add instance norm (+ backward)

### DIFF
--- a/functorch/csrc/BatchRulesDecompositions.cpp
+++ b/functorch/csrc/BatchRulesDecompositions.cpp
@@ -195,6 +195,7 @@ TORCH_LIBRARY_IMPL(aten, FT_BATCHED_KEY, m) {
   OP_DECOMPOSE(hstack);
   OP_DECOMPOSE(index_select_backward);
   OP_DECOMPOSE(inner);
+  OP_DECOMPOSE(instance_norm);
   OP_DECOMPOSE(kron);
   OP_DECOMPOSE(layer_norm);
   OP_DECOMPOSE2(ldexp, Tensor);

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -568,7 +568,6 @@ class TestOperators(TestCase):
         xfail('__getitem__', ''),
         xfail('index_put', ''),
         xfail('lu_solve'),
-        xfail('nn.functional.instance_norm'),
         xfail('index_copy'),
     })
 
@@ -704,7 +703,6 @@ class TestOperators(TestCase):
         xfail('nn.functional.batch_norm', device_type='cuda'),
         xfail('nn.functional.batch_norm', 'without_cudnn', device_type='cuda'),
         xfail('nn.functional.hinge_embedding_loss', device_type='cuda'),
-        xfail('nn.functional.instance_norm', device_type='cuda'),
 
         # Causing a CUDA assert, needs investigation
         skip('div', 'floor_rounding', device_type='cuda'),
@@ -717,7 +715,6 @@ class TestOperators(TestCase):
         xfail('_masked.prod', device_type='cpu'),
         xfail('nn.functional.batch_norm', device_type='cpu'),
         xfail('nn.functional.hinge_embedding_loss', device_type='cpu'),
-        xfail('nn.functional.instance_norm', device_type='cpu'),
 
         # xfail list
         xfail('norm', 'nuc'),
@@ -847,7 +844,6 @@ class TestOperators(TestCase):
         xfail('linalg.cross'),
         xfail('nn.functional.gaussian_nll_loss'),
         xfail('nn.functional.huber_loss'),
-        xfail('nn.functional.instance_norm'),
         xfail('nn.functional.poisson_nll_loss'),
         xfail('nn.functional.bilinear'),
         xfail('nn.functional.prelu'),
@@ -932,7 +928,8 @@ class TestOperators(TestCase):
             return
 
         samples = op.sample_inputs(device, dtype, requires_grad=True)
-        is_batch_norm = op.name == "nn.functional.batch_norm"
+        batch_norm_fns = ("nn.functional.batch_norm", "nn.functional.instance_norm")  # instance norm calls batch norm
+        is_batch_norm = op.name in batch_norm_fns
 
         for sample in samples:
             args = [sample.input] + list(sample.args)

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -3210,7 +3210,6 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('nn.functional.gaussian_nll_loss'),
         xfail('nn.functional.poisson_nll_loss'),
         xfail('nn.functional.huber_loss'),
-        xfail('nn.functional.instance_norm'),
         # We can get this to work on CUDA through decomposition,
         # but fails on CPU due to max_pool1d_cpu not having a derivative
         xfail('nn.functional.max_pool1d'),


### PR DESCRIPTION
Instance norm just decomposes to batch norm so the batch rule itself is simple. However, because it also takes running_mean and running_var as inputs, the sample inputs needed to have the same restrictions as the batch norm ones (if the input is batched, running mean and running var must be batched).

This got a little weird because when running_mean and running_var are both None, it should be fine for the input to be batched or not (we aren't updating anything). However, the implementation of instance norm created a new tensor in that case. This leaves a TODO explaining what's happening but it will need to be fixed in pytorch/pytorch