### PR TITLE
[requirements] missing networkx

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ To do devel install:
 pip install -e .
 ```
     
-To install with optional dependencies, e.g. for AOT:
+To install with optional dependencies, e.g. for AOTAutograd:
     
 ```
 pip install -e .[aot]

--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ pytest test/test_vmap.py -v
 pytest test/test_eager_transforms.py -v
 ```
 
+To do devel install:
+    
+```
+pip install -e .
+```
+    
+To install with optional dependencies, e.g. for AOT:
+    
+```
+pip install -e .[aot]
+```
+    
+    
 </p>
 </details>
 

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,10 @@ requirements = [
     # This represents a nightly version of PyTorch.
     # It can be installed as a binary or from source.
     "torch>=1.10.0.dev",
-    "networkx",
 ]
 
+extras = {}
+extras["aot"] = ["networkx", ]
 
 class clean(distutils.command.clean.clean):
     def run(self):
@@ -129,6 +130,7 @@ if __name__ == '__main__':
         # Package info
         packages=find_packages(),
         install_requires=requirements,
+        extras_require=extras,
         ext_modules=get_extensions(),
         cmdclass={
             "build_ext": BuildExtension.with_options(no_python_abi_suffix=True),

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ requirements = [
     # This represents a nightly version of PyTorch.
     # It can be installed as a binary or from source.
     "torch>=1.10.0.dev",
+    "networkx",
 ]
 
 


### PR DESCRIPTION
trying the examples it requires `networkx`.

If it's an optional requirement, could we then perhaps have some sort of `extras` group like:

```
pip install -e .[all]
```
which will then get all the requirements, including the optional ones?
```
extras = {}
extras["all"] = ["networkx", ...]
setup(
    ...
    extras_require=extras,
```

e.g. you can see how it's being used [here](https://github.com/huggingface/transformers/blob/master/setup.py#L367)