### PR TITLE
Enabled pytree of tensors output for jvp, jacfwd

### DIFF
--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -41,7 +41,7 @@ def _undo_create_differentiable(inps, level=None):
         if isinstance(x, tuple):
             return tree_map(unwrap_tensors, tuple(x))
 
-        return x
+        raise RuntimeError(f"Expected tensors, got unsupported type {type(x)}")
 
     return tree_map(unwrap_tensors, inps)
 
@@ -641,10 +641,7 @@ jvp_str = 'jvp(f, primals, tangents)'
 
 def safe_unpack_dual(dual, strict):
     if not isinstance(dual, torch.Tensor):
-        # return dual itself and an empty tensor
-        # JAX returns array((b'',), dtype=[('float0', 'V')])
-        # for tangents in a similar case
-        return dual, torch.tensor([])
+        raise RuntimeError(f"Expected tensors, got unsupported type {type(dual)}")
 
     primal, tangent = fwAD.unpack_dual(dual)
     if tangent is None:

--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -41,7 +41,7 @@ def _undo_create_differentiable(inps, level=None):
         if isinstance(x, tuple):
             return tree_map(unwrap_tensors, tuple(x))
 
-        raise RuntimeError(f"Expected tensors, got unsupported type {type(x)}")
+        return x
 
     return tree_map(unwrap_tensors, inps)
 
@@ -396,16 +396,8 @@ def jacrev(func: Callable, argnums: Union[int, Tuple[int]] = 0, *, has_aux=False
 
         # See NOTE: [Computing jacobian with vmap and vjp for multiple outputs]
         flat_output, output_spec = tree_flatten(output)
-        if len(flat_output) == 0:
-            raise RuntimeError(
-                'jacrev(f, ...)(*args): expected f to return at least one Tensor, '
-                'got no Tensors.')
-        for out in flat_output:
-            if isinstance(out, torch.Tensor):
-                continue
-            raise RuntimeError(
-                'jacrev(f, ...)(*args): expected f to only return Tensors as '
-                f'outputs, got {type(out)}')
+        assert_non_empty_output(flat_output, 'jacrev(f, ...)(*args)')
+
         # NB: vjp already checks that all outputs are tensors
         # Step 1: Construct grad_outputs by splitting the standard basis
         flat_output_numels = tuple(out.numel() for out in flat_output)
@@ -609,6 +601,11 @@ def assert_flat_tuple_of_tensors(elts, api, argname):
             f'{api}: Expected {argname} to be a non-empty tuple of Tensors.')
 
 
+def assert_non_empty_output(output, api):
+    if output == [None] or len(output) < 1:
+        raise RuntimeError(f'{api}: Expected non-empty output of f')
+
+
 def assert_output_is_tensor_or_tensors(output, api):
     if isinstance(output, torch.Tensor):
         return
@@ -643,6 +640,12 @@ jvp_str = 'jvp(f, primals, tangents)'
 
 
 def safe_unpack_dual(dual, strict):
+    if not isinstance(dual, torch.Tensor):
+        # return dual itself and an empty tensor
+        # JAX returns array((b'',), dtype=[('float0', 'V')])
+        # for tangents in a similar case
+        return dual, torch.tensor([])
+
     primal, tangent = fwAD.unpack_dual(dual)
     if tangent is None:
         if strict:
@@ -729,8 +732,8 @@ def jvp(func, primals, tangents, *, strict=False):
                                for p, t in zip(flat_primals, flat_tangents))
             duals = tree_unflatten(flat_duals, primals_spec)
             result_duals = func(*duals)
-            assert_output_is_tensor_or_tensors(result_duals, jvp_str)
             result_duals, spec = tree_flatten(result_duals)
+            assert_non_empty_output(result_duals, jvp_str)
 
             primals_out, tangents_out = \
                 zip(*[safe_unpack_dual(dual, strict) for dual in result_duals])
@@ -842,9 +845,9 @@ def jacfwd(func, argnums=0):
             return jvp_out
 
         results = vmap(push_jvp)(basis)
-        assert_output_is_tensor_or_tensors(results, 'jacfwd(f, ...)(*args)')
-
         jac_outs, spec = tree_flatten(results)
+        assert_non_empty_output(jac_outs, 'jacfwd(f, ...)(*args)')
+
         jac_outs_ins = tuple(
             tuple(
                 safe_unflatten(jac_out_in, -1, primal.shape)

--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -244,7 +244,10 @@ def vjp(func: Callable, *primals, has_aux=False):
 
             if has_aux:
                 if not (isinstance(primals_out, tuple) and len(primals_out) == 2):
-                    raise TypeError("Function output should be a tuple: (output, aux) if has_aux is True")
+                    raise RuntimeError(
+                        "vjp(f, *primals): output of function f should be a tuple: (output, aux) "
+                        "if has_aux is True"
+                    )
                 primals_out, aux = primals_out
                 aux = _undo_create_differentiable(aux, level)
 
@@ -588,7 +591,7 @@ def noop():
     yield
 
 
-def assert_flat_tuple_of_tensors(elts: Tuple[torch.Tensor, ...], api: str, argname: str) -> None:
+def assert_flat_tuple_of_tensors(elts: Any, api: str, argname: str) -> None:
     if not isinstance(elts, tuple):
         raise RuntimeError(
             f'{api}: Expected {argname} to be a tuple of Tensors, got {type(elts)}')
@@ -616,9 +619,7 @@ def assert_non_empty_tensor_output(output: List[Any], api: str) -> None:
             )
 
 
-def assert_output_is_tensor_or_tensors(
-    output: Union[torch.Tensor, Tuple[torch.Tensor, ...]], api: str
-) -> None:
+def assert_output_is_tensor_or_tensors(output: Any, api: str) -> None:
     if isinstance(output, torch.Tensor):
         return
     if not isinstance(output, tuple):
@@ -636,7 +637,7 @@ def assert_output_is_tensor_or_tensors(
             f'{type(out)} as an output')
 
 
-def assert_non_empty_list_of_tensors(output, api, argname):
+def assert_non_empty_list_of_tensors(output: List[torch.Tensor], api: str, argname: str) -> None:
     if len(output) == 0:
         raise RuntimeError(
             f'{api}: Expected {argname} to contain at least one Tensor.')

--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -243,12 +243,16 @@ def vjp(func: Callable, *primals, has_aux=False):
             primals_out = func(*diff_primals)
 
             if has_aux:
+                # TODO: Add a test for that once vjp/jvp both have has_aux option
+                if not isinstance(primals_out, tuple):
+                    raise TypeError("Function output should be a tuple if has_aux is True")
                 primals_out, aux = primals_out
                 aux = _undo_create_differentiable(aux, level)
 
-            results = _undo_create_differentiable(primals_out, level)
-            flat_diff_primals, primals_spec = tree_flatten(diff_primals)
             flat_primals_out, primals_out_spec = tree_flatten(primals_out)
+            assert_non_empty_output(flat_primals_out, 'vjp(f)')
+            flat_diff_primals, primals_spec = tree_flatten(diff_primals)
+            results = _undo_create_differentiable(primals_out, level)
 
             for primal_out in flat_primals_out:
                 assert isinstance(primal_out, torch.Tensor)

--- a/test/test_eager_transforms.py
+++ b/test/test_eager_transforms.py
@@ -1273,11 +1273,15 @@ class TestJac(TestCase):
         x = torch.randn(2, 3, device=device)
 
         for output in [None, ()]:
-            with self.assertRaisesRegex(RuntimeError, r"Expected f to be a function that has non-empty output"):
+            with self.assertRaisesRegex(
+                RuntimeError, r"(vjp|jvp).+\: Expected f to be a function that has non-empty output"
+            ):
                 jacapi(lambda _: output)(x)
 
         for output in [1, True, 12.2, "abc"]:
-            with self.assertRaisesRegex(RuntimeError, r"expected f\(\*primals\) to return only tensors"):
+            with self.assertRaisesRegex(
+                RuntimeError, r"(vjp|jvp).+\: expected f\(\*primals\) to return only tensors"
+            ):
                 jacapi(lambda _: output)(x)
 
         # Check list output

--- a/test/test_eager_transforms.py
+++ b/test/test_eager_transforms.py
@@ -1653,7 +1653,7 @@ class TestJvp(TestCase):
         with self.assertRaisesRegex(RuntimeError, 'only contain Tensors'):
             jvp(torch.sin, (x,), (1.,))
 
-    def test_outputs_should_be_tensor_or_tensors(self, device):
+    def test_outputs_can_any_pytree(self, device):
         x = torch.randn(2, 3, device=device)
         t = torch.randn(2, 3, device=device)
 
@@ -1663,15 +1663,41 @@ class TestJvp(TestCase):
         def g(x):
             return ()
 
-        def h(x):
-            return x, [x]
-
-        with self.assertRaisesRegex(RuntimeError, "a Tensor or Tensors"):
+        with self.assertRaisesRegex(RuntimeError, "Expected non-empty output"):
             jvp(f, (x,), (t,))
-        with self.assertRaisesRegex(RuntimeError, "non-empty"):
+
+        with self.assertRaisesRegex(RuntimeError, "Expected non-empty output"):
             jvp(g, (x,), (t,))
-        with self.assertRaisesRegex(RuntimeError, "a Tensor or Tensors"):
-            jvp(h, (x,), (t,))
+
+        # Check list output
+        out = jvp(lambda x: [x, x.sum()], (x,), (t,))
+        for i in range(2):
+            assert isinstance(out[i], list) and len(out[i]) == 2
+
+        # Check dict output
+        out = jvp(lambda x: {"x": x, "xsum": x.sum()}, (x,), (t,))
+        for i in range(2):
+            assert isinstance(out[i], dict) and len(out[i]) == 2 and "xsum" in out[i]
+
+        def composite_output(x):
+            out = x.sum()
+            return [
+                (out, {"a": x, "out": [x, out]}),
+                int(out),
+                out > 0,
+            ]
+
+        out = jvp(composite_output, (x,), (t,))
+        for i in range(2):
+            assert isinstance(out[i], list)
+            assert isinstance(out[i][0], tuple) and \
+                isinstance(out[i][0][1], dict)
+
+        # Checks primals and tangents for int(out)
+        assert isinstance(out[0][1], int) and isinstance(out[1][1], torch.Tensor)
+        # Checks primals and tangents for out > 0
+        assert isinstance(out[0][2], torch.Tensor) and out[0][2].dtype == torch.bool \
+            and isinstance(out[1][2], torch.Tensor)
 
 
 class TestCustomFunction(TestCase):

--- a/test/test_eager_transforms.py
+++ b/test/test_eager_transforms.py
@@ -1198,20 +1198,58 @@ class TestJac(TestCase):
         self.assertEqual(result, torch.eye(3, 3, device=device))
         self.assertEqual(aux, x.cos())
 
-    @FIXME_jacrev_only
+    @jacrev_and_jacfwd
     def test_aux_pytree(self, device, jacapi):
         def f(x):
             y = x.clone()
             return y, {'a': y.cos(), 'b': [y.tan()]}
 
         x = torch.randn(3, device=device)
-        result, aux = jacapi(f, has_aux=True)(x)
 
-        self.assertEqual(result, torch.eye(3, 3, device=device))
-        expected_aux = {'a': x.cos(), 'b': [x.tan()]}
-        self.assertEqual(aux, expected_aux)
+        # TODO: Remove when https://github.com/pytorch/functorch/issues/392
+        # is fixed
+        if jacapi == jacrev:
+            result, aux = jacapi(f, has_aux=True)(x)
+            self.assertEqual(result, torch.eye(3, 3, device=device))
+            expected_aux = {'a': x.cos(), 'b': [x.tan()]}
+            self.assertEqual(aux, expected_aux)
+        else:
+            result, aux = jacapi(f)(x)
+            self.assertEqual(result, torch.eye(3, 3, device=device))
+            expected_aux = {'a': -torch.diag(x.sin()), 'b': [torch.diag(1.0 + x.tan() ** 2)]}
+            self.assertEqual(aux, expected_aux)
 
-    @FIXME_jacrev_only
+    @jacrev_and_jacfwd
+    def test_outputs_can_any_pytree(self, device, jacapi):
+        x = torch.randn(2, 3, device=device)
+
+        for output in [None, ()]:
+            with self.assertRaisesRegex(RuntimeError, "Expected non-empty output"):
+                jacapi(lambda _: output)(x)
+
+        for output in [1, True, 12.2, "abc"]:
+            with self.assertRaisesRegex(RuntimeError, "Expected tensors, got unsupported type"):
+                jacapi(lambda _: output)(x)
+
+        # Check list output
+        out = jacapi(lambda x: [x, x.sum()])(x)
+        assert isinstance(out, list) and len(out) == 2
+
+        # Check dict output
+        out = jacapi(lambda x: {"x": x, "xsum": x.sum()})(x)
+        assert isinstance(out, dict) and len(out) == 2 and "xsum" in out
+
+        def composite_output(x):
+            out = x.sum()
+            return [
+                (out, {"a": x, "out": [x, out]}),
+            ]
+
+        out = jacapi(composite_output)(x)
+        assert isinstance(out, list)
+        assert isinstance(out[0], tuple) and isinstance(out[0][1], dict)
+
+    @jacrev_and_jacfwd
     def test_multiple_inputs_outputs_pytree(self, device, jacapi):
         def f(a, b, c):
             a0, a1 = a
@@ -1686,35 +1724,6 @@ class TestJvp(TestCase):
             assert isinstance(out[i], list)
             assert isinstance(out[i][0], tuple) and \
                 isinstance(out[i][0][1], dict)
-
-    def test_jacfwd_outputs_can_any_pytree(self, device):
-        x = torch.randn(2, 3, device=device)
-
-        for output in [None, ()]:
-            with self.assertRaisesRegex(RuntimeError, "Expected non-empty output"):
-                jacfwd(lambda _: output)(x)
-
-        for output in [1, True, 12.2, "abc"]:
-            with self.assertRaisesRegex(RuntimeError, "Expected tensors, got unsupported type"):
-                jacfwd(lambda _: output)(x)
-
-        # Check list output
-        out = jacfwd(lambda x: [x, x.sum()])(x)
-        assert isinstance(out, list) and len(out) == 2
-
-        # Check dict output
-        out = jacfwd(lambda x: {"x": x, "xsum": x.sum()})(x)
-        assert isinstance(out, dict) and len(out) == 2 and "xsum" in out
-
-        def composite_output(x):
-            out = x.sum()
-            return [
-                (out, {"a": x, "out": [x, out]}),
-            ]
-
-        out = jacfwd(composite_output)(x)
-        assert isinstance(out, list)
-        assert isinstance(out[0], tuple) and isinstance(out[0][1], dict)
 
 
 class TestCustomFunction(TestCase):

--- a/test/test_eager_transforms.py
+++ b/test/test_eager_transforms.py
@@ -610,14 +610,14 @@ class TestGradTransform(TestCase):
 
         for output in [None, ()]:
             with self.assertRaisesRegex(
-                RuntimeError, r"vjp\(f, \*primals\)\: Expected f to be a function that has non-empty output"
+                RuntimeError, r"vjp\(f, \*primals\): Expected f to be a function that has non-empty output"
             ):
                 _, vjp_fn = vjp(lambda _: output, x)
                 vjp_fn(t)
 
         for output in [1, True, 12.2, "abc"]:
             with self.assertRaisesRegex(
-                RuntimeError, r"vjp\(f, \*primals\)\: expected f\(\*primals\) to return only tensors"
+                RuntimeError, r"vjp\(f, \*primals\): expected f\(\*primals\) to return only tensors"
             ):
                 _, vjp_fn = vjp(lambda _: output, x)
                 vjp_fn(t)
@@ -662,10 +662,10 @@ class TestGradTransform(TestCase):
 
         x = torch.randn(3, device=device)
 
-        with self.assertRaisesRegex(TypeError, 'Function output should be a tuple'):
+        with self.assertRaisesRegex(RuntimeError, r'vjp\(f, \*primals\): output of function f should be a tuple'):
             vjp(lambda t: [t, t], x, has_aux=True)
 
-        with self.assertRaisesRegex(TypeError, 'Function output should be a tuple'):
+        with self.assertRaisesRegex(RuntimeError, r'vjp\(f, \*primals\): output of function f should be a tuple'):
             vjp(lambda t: (t, t + 2, t + 3), x, has_aux=True)
 
         def f(t):
@@ -1274,13 +1274,13 @@ class TestJac(TestCase):
 
         for output in [None, ()]:
             with self.assertRaisesRegex(
-                RuntimeError, r"(vjp|jvp).+\: Expected f to be a function that has non-empty output"
+                RuntimeError, r"(vjp|jvp).+: Expected f to be a function that has non-empty output"
             ):
                 jacapi(lambda _: output)(x)
 
         for output in [1, True, 12.2, "abc"]:
             with self.assertRaisesRegex(
-                RuntimeError, r"(vjp|jvp).+\: expected f\(\*primals\) to return only tensors"
+                RuntimeError, r"(vjp|jvp).+: expected f\(\*primals\) to return only tensors"
             ):
                 jacapi(lambda _: output)(x)
 
@@ -1750,13 +1750,13 @@ class TestJvp(TestCase):
 
         for output in [None, ()]:
             with self.assertRaisesRegex(
-                RuntimeError, r"jvp\(f, primals, tangents\)\: Expected f to be a function that has non-empty output"
+                RuntimeError, r"jvp\(f, primals, tangents\): Expected f to be a function that has non-empty output"
             ):
                 jvp(lambda _: output, (x,), (t,))
 
         for output in [1, True, 12.2, "abc"]:
             with self.assertRaisesRegex(
-                RuntimeError, r"jvp\(f, primals, tangents\)\: expected f\(\*primals\) to return only tensors"
+                RuntimeError, r"jvp\(f, primals, tangents\): expected f\(\*primals\) to return only tensors"
             ):
                 jvp(lambda _: output, (x,), (t,))
 


### PR DESCRIPTION
Description:
- Enabled pytree of tensors output for jvp, jacfwd
- Added tests

Now we can do
```python
import torch
import functorch as ft

def sum_parabola(x):
    res = (2 * x**2 + 3 * x + 4).sum()
    return res, {"res": res}

x = torch.tensor([1., 1.5])
t = torch.tensor([2., 2.5])
out = ft.jvp(sum_parabola, (x,), (t,))
print("-- out ft vjp sum_parabola: ", out)

x = jnp.array([1., 1.5])
t = jnp.array([2., 2.5])
out = jax.jvp(sum_parabola, (x,), (t,))
print("-- out jax jvp sum_parabola: ", out)


x = torch.tensor([1., 1.5])
out = ft.jacfwd(sum_parabola)(x)
print("-- out ft jacfwd sum_parabola: ", out)

x = jnp.array([1., 1.5])
out = jax.jacfwd(sum_parabola)(x)
print("-- out jax jvp sum_parabola: ", out)

> 
-- out ft vjp sum_parabola:  ((tensor(22.), {'res': tensor(22.)}), (tensor(36.5000), {'res': tensor(36.5000)}))
-- out jax jvp sum_parabola:  ((DeviceArray(22., dtype=float32), {'res': DeviceArray(22., dtype=float32)}), (DeviceArray(36.5, dtype=float32), {'res': DeviceArray(36.5, dtype=float32)}))
-- out ft jacfwd sum_parabola:  (tensor([7., 9.]), {'res': tensor([7., 9.])})
-- out jax jvp sum_parabola:  (DeviceArray([7., 9.], dtype=float32), {'res': DeviceArray([7., 9.], dtype=float32)})
```

Fixes #268