### PR TITLE
Make min-cut rematerialization optional.

### DIFF
--- a/benchmarks/transformer_fusion_patterns/benchmark.py
+++ b/benchmarks/transformer_fusion_patterns/benchmark.py
@@ -1,6 +1,6 @@
 import torch
 import time
-from functorch.compile import memory_efficient_fusion, clear_compile_cache
+from functorch.compile import fusion, clear_compile_cache
 import benchmark_helper
 
 
@@ -174,7 +174,7 @@ for cl in [DropoutResBias, BiasReluDropout, DropoutResBiasScalar, BiasDropoutRes
             static_argnums.append(idx)
 
     # Get the optimized function
-    opt_fn = memory_efficient_fusion(fn, static_argnums)
+    opt_fn = fusion(fn, memory_efficient_fusion=True, static_argnums)
 
     # Profile cuda kernels
     benchmark_helper.profile_cuda_kernels(fn, args, "Eager")

--- a/benchmarks/transformer_fusion_patterns/benchmark.py
+++ b/benchmarks/transformer_fusion_patterns/benchmark.py
@@ -174,7 +174,7 @@ for cl in [DropoutResBias, BiasReluDropout, DropoutResBiasScalar, BiasDropoutRes
             static_argnums.append(idx)
 
     # Get the optimized function
-    opt_fn = fusion(fn, memory_efficient_fusion=True, static_argnums)
+    opt_fn = fusion(fn, memory_efficient_fusion=True, static_argnums=static_argnums)
 
     # Profile cuda kernels
     benchmark_helper.profile_cuda_kernels(fn, args, "Eager")

--- a/functorch/_src/compilers.py
+++ b/functorch/_src/compilers.py
@@ -230,7 +230,7 @@ default_decompositions = set([
 default_decompositions = {k: v for k, v in decomposition_table.items() if k in default_decompositions}
 
 
-def memory_efficient_fusion(fn, static_argnums=None):
+def fusion(fn, memory_efficient_fusion=True, static_argnums=None):
     """
     Recomputes the fwd pass in the bwd pass to perform memory efficient fusion.
     Uses NVFuser as the backend compiler.
@@ -238,11 +238,14 @@ def memory_efficient_fusion(fn, static_argnums=None):
     config = {
         'fw_compiler': ts_compile,
         'bw_compiler': ts_compile,
-        'partition_fn': partition_with_recompute_fwd_in_bwd,
         'hasher_type': "StaticShapheHasher",
         'decompositions': default_decompositions,
         'static_argnums': static_argnums
     }
+    
+    if memory_efficient_fusion is True:
+       config['partition_fn'] = partition_with_recompute_fwd_in_bwd
+
     if isinstance(fn, torch.nn.Module):
         return aot_module(fn, **config)
     else:

--- a/functorch/compile/__init__.py
+++ b/functorch/compile/__init__.py
@@ -16,7 +16,7 @@ from .._src.compilers import (
     draw_graph_compile,
     nop,
     nnc_jit,
-    memory_efficient_fusion,
+    fusion,
     debug_compile,
 )
 from .._src.partitioners import (

--- a/test/test_memory_efficient_fusion.py
+++ b/test/test_memory_efficient_fusion.py
@@ -1,6 +1,6 @@
 import torch
 from torch.nn import functional as F
-from functorch.compile import memory_efficient_fusion
+from functorch.compile import fusion
 from torch.testing._internal.common_utils import TestCase, run_tests
 import inspect
 from typing import Callable
@@ -57,7 +57,7 @@ def run_and_compare_activation(fn, shape):
     ref = fn(*ref_args)
     ref.sum().backward()
 
-    mem_optimized_fn = memory_efficient_fusion(fn)
+    mem_optimized_fn = fusion(fn, memory_efficient_fusion=True)
     res = mem_optimized_fn(*res_args)
     res.sum().backward()
 


### PR DESCRIPTION
Some users may not want to use min-cut rematerialization for something like activation checkpointing. 
So I changed this to optional. Does this make sense?

cc @Chillee 