### PR TITLE
Fix typo of `memory_efficient_fusion` parameter

### DIFF
--- a/functorch/_src/compilers.py
+++ b/functorch/_src/compilers.py
@@ -244,7 +244,7 @@ def memory_efficient_fusion(fn, static_argnums=None):
         'fw_compiler': ts_compile,
         'bw_compiler': ts_compile,
         'partition_fn': min_cut_rematerialization_partition,
-        'hasher_type': "StaticShapheHasher",
+        'hasher_type': "StaticShapeHasher",
         'decompositions': default_decompositions,
         'static_argnums': static_argnums
     }


### PR DESCRIPTION
This causes some problems about input shape.