### PR TITLE
Fix unexpected success not getting highlighted in CI

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip
   - ca-certificates
   - pip:
-      - xmlrunner
+      - unittest-xml-reporting
       - pillow>=4.1.1
       - scipy
       - av


### PR DESCRIPTION
A surprisingly simple fix, sad that I didn't catch it earlier. Basically the newer versions are released under this name instead of `xmlrunner`. Newer versions support highlighting "unexpected success" as a failure. An example of what this looks like is [here](https://app.circleci.com/pipelines/github/pytorch/functorch/1456/workflows/cf17b90e-3505-46d6-80b3-197239dd65f4/jobs/8732).

Should make debugging main CI take on the order of one commit instead of 2