### PR TITLE
Add Batch Norm module utilities to not track running stats

### DIFF
--- a/examples/maml_omniglot/maml-omniglot-transforms.py
+++ b/examples/maml_omniglot/maml-omniglot-transforms.py
@@ -85,22 +85,21 @@ def main():
     )
 
     # Create a vanilla PyTorch neural network.
-    # TODO (samdow): fix batch norm support
     inplace_relu = True
     net = nn.Sequential(
         nn.Conv2d(1, 64, 3),
-        nn.BatchNorm2d(64, momentum=1, affine=True, track_running_stats=False),
+        nn.BatchNorm2d(64, affine=True, track_running_stats=False),
         nn.ReLU(inplace=inplace_relu),
         nn.MaxPool2d(2, 2),
         nn.Conv2d(64, 64, 3),
-        nn.BatchNorm2d(64, momentum=1, affine=True, track_running_stats=False),
+        nn.BatchNorm2d(64, affine=True, track_running_stats=False),
         nn.ReLU(inplace=inplace_relu),
         nn.MaxPool2d(2, 2),
         nn.Conv2d(64, 64, 3),
-        nn.BatchNorm2d(64, momentum=1, affine=True, track_running_stats=False),
+        nn.BatchNorm2d(64, affine=True, track_running_stats=False),
         nn.ReLU(inplace=inplace_relu),
         nn.MaxPool2d(2, 2),
-        Flatten(),
+        nn.Flatten(),
         nn.Linear(64, args.n_way)).to(device)
 
     net.train()
@@ -258,13 +257,6 @@ def plot(log):
     print(f'--- Plotting accuracy to {fname}')
     fig.savefig(fname)
     plt.close(fig)
-
-
-# Won't need this after this PR is merged in:
-# https://github.com/pytorch/pytorch/pull/22245
-class Flatten(nn.Module):
-    def forward(self, input):
-        return input.view(input.size(0), -1)
 
 
 if __name__ == '__main__':

--- a/functorch/experimental/__init__.py
+++ b/functorch/experimental/__init__.py
@@ -1,1 +1,1 @@
-from .batch_norm_replacement import replace_all_batch_norm_modules, copy_and_replace_all_batch_norm_modules
+from .batch_norm_replacement import replace_all_batch_norm_modules_

--- a/functorch/experimental/batch_norm_replacement.py
+++ b/functorch/experimental/batch_norm_replacement.py
@@ -1,4 +1,3 @@
-import copy
 import torch.nn as nn
 
 
@@ -10,15 +9,14 @@ def batch_norm_without_running_stats(module: nn.Module):
         module.track_running_stats = False
 
 
-def replace_all_batch_norm_modules(root: nn.Module) -> nn.Module:
+def replace_all_batch_norm_modules_(root: nn.Module) -> nn.Module:
+    """
+    In place updates :attr:`root` by setting the ``running_mean`` and ``running_var`` to be None and
+    setting track_running_stats to be False for any nn.BatchNorm module in :attr:`root`
+    """
     # base case
     batch_norm_without_running_stats(root)
 
     for obj in root.modules():
         batch_norm_without_running_stats(obj)
     return root
-
-
-def copy_and_replace_all_batch_norm_modules(root: nn.Module) -> nn.Module:
-    replaced = copy.deepcopy(root)
-    return replace_all_batch_norm_modules(replaced)

--- a/test/test_eager_transforms.py
+++ b/test/test_eager_transforms.py
@@ -15,15 +15,14 @@ import unittest
 import warnings
 import math
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, onlyCPU
-from functorch.experimental.batch_norm_replacement import replace_all_batch_norm_modules
 from torch.testing._internal.common_dtype import get_all_fp_dtypes
 from functools import partial
-from functorch.experimental import copy_and_replace_all_batch_norm_modules, replace_all_batch_norm_modules
+from functorch.experimental import replace_all_batch_norm_modules_
 
 import functorch
 from functorch import (
-    grad, vjp, vmap, jacrev, jacfwd, grad_and_value,
-    make_functional, make_functional_with_buffers,
+    grad, vjp, vmap, jacrev, jacfwd, grad_and_value, hessian,
+    jvp, make_functional, make_functional_with_buffers,
 )
 from functorch._src.make_functional import (
     functional_init, functional_init_with_buffers,
@@ -2108,17 +2107,19 @@ class TestExamplesCorrectness(TestCase):
         n_inner_iter = 2
         num_tasks = 2
 
+        # real example uses batch norm but it's numerically unstable in the first
+        # iteration, when near 0, and won't produce same gradients. Uses group norm instead
         net = nn.Sequential(
             nn.Conv2d(1, 64, 3),
-            nn.BatchNorm2d(64, momentum=1, affine=True, track_running_stats=False),
+            nn.GroupNorm(64, 64, affine=True),
             nn.ReLU(inplace=inplace_relu),
             nn.MaxPool2d(2, 2),
             nn.Conv2d(64, 64, 3),
-            nn.BatchNorm2d(64, momentum=1, affine=True, track_running_stats=False),
+            nn.GroupNorm(64, 64, affine=True),
             nn.ReLU(inplace=inplace_relu),
             nn.MaxPool2d(2, 2),
             nn.Conv2d(64, 64, 3),
-            nn.BatchNorm2d(64, momentum=1, affine=True, track_running_stats=False),
+            nn.GroupNorm(64, 64, affine=True),
             nn.ReLU(inplace=inplace_relu),
             nn.MaxPool2d(2, 2),
             nn.Flatten(),
@@ -2171,71 +2172,8 @@ class TestExamplesCorrectness(TestCase):
 
         self.assertEqual(result_grads, expected_grads)
 
-    def test_maml_omniglot_minimal_repro(self, device):
-        # TODO: there appears to be precision issues for float32
-        dtype = torch.double
-
-        n_way = 5
-        n_inner_iter = 2
-        num_tasks = 2
-
-        net = nn.Sequential(
-            nn.Conv2d(1, 64, 3),
-            nn.BatchNorm2d(64, momentum=1, affine=True, track_running_stats=False),
-            nn.Flatten(),
-            nn.Linear(43264, n_way)).to(device).to(dtype)
-
-        fnet, params, buffers = make_functional_with_buffers(net)
-        net = (params, buffers, fnet)
-
-        def loss_for_task(net, n_inner_iter, use_transform, x_spt, y_spt, x_qry, y_qry):
-            params, buffers, fnet = net
-            querysz = x_qry.size(0)
-
-            def compute_loss(new_params, buffers, x, y):
-                logits = fnet(new_params, buffers, x)
-                loss = F.cross_entropy(logits, y)
-                return loss
-
-            new_params = params
-            for _ in range(n_inner_iter):
-                if use_transform:
-                    grads = grad(compute_loss)(new_params, buffers, x_spt, y_spt)
-                else:
-                    res = compute_loss(new_params, buffers, x_spt, y_spt)
-                    grads = torch.autograd.grad(res, new_params, create_graph=True)
-                new_params = [p - g * 1e-1 for p, g, in zip(new_params, grads)]
-
-            qry_logits = fnet(new_params, buffers, x_qry)
-            qry_loss = F.cross_entropy(qry_logits, y_qry)
-            qry_acc = (qry_logits.argmax(
-                dim=1) == y_qry).sum() / querysz
-
-            return qry_loss, qry_acc
-
-        # Get some sample inputs...
-        x_spt = torch.randn(num_tasks, 25, 1, 28, 28, dtype=dtype, device=device)
-        y_spt = torch.randint(0, 5, (num_tasks, 25), device=device)
-        x_qry = torch.randn(num_tasks, 75, 1, 28, 28, dtype=dtype, device=device)
-        y_qry = torch.randint(0, 5, (num_tasks, 75), device=device)
-
-        # compute with vmap + grad
-        compute_loss = partial(loss_for_task, net, n_inner_iter, True)
-        qry_losses, _ = vmap(compute_loss)(x_spt, y_spt, x_qry, y_qry)
-        result_grads = torch.autograd.grad(qry_losses.sum(), params)
-
-        # compute without vmap + grad
-        compute_loss = partial(loss_for_task, net, n_inner_iter, False)
-        losses = [compute_loss(x_spt[i], y_spt[i], x_qry[i], y_qry[i])[0]
-                  for i in range(num_tasks)]
-        expected_grads = torch.autograd.grad(sum(losses), params)
-
-        self.assertEqual(result_grads[2:], expected_grads[2:])  # should pass
-        self.assertEqual(result_grads[:2], expected_grads[:2])  # should fail
-
-    @parametrize('copy', [True, False])
     @parametrize('originally_track_running_stats', [True, False])
-    def test_update_batch_norm(self, device, copy, originally_track_running_stats):
+    def test_update_batch_norm(self, device, originally_track_running_stats):
         dtype = torch.double
         inplace_relu = False
         classes = 5
@@ -2247,12 +2185,8 @@ class TestExamplesCorrectness(TestCase):
             nn.Flatten(),
             nn.Linear(43264, classes)).to(device).to(dtype)
 
-        if copy:
-            transformed_net = copy_and_replace_all_batch_norm_modules(net)
-            assert transformed_net is not net
-        else:
-            replace_all_batch_norm_modules(net)
-            transformed_net = net
+        replace_all_batch_norm_modules_(net)
+        transformed_net = net
         fnet, params, buffers = make_functional_with_buffers(transformed_net)
         net = (params, buffers, fnet)
         criterion = nn.CrossEntropyLoss()


### PR DESCRIPTION
We want to let users run the maml_omniglot example as it was originally written, using batch norm. Given how vmap works though, this can't be done with batch norm that tracks running statistics because those are updated in place. That's fine, the example shouldn't be using the running statistics anyway.

The issues with batch norm were determined to be numerical precision issues around 0. The example in the examples folder uses batch norm and still trains, suggesting it's an error around the value being near 0:
![maml-accs](https://user-images.githubusercontent.com/17888388/156790152-31b827e6-deb0-467f-a7a5-a7dee83cbbd5.png)

So this:
 - switches the maml_omniglot example in the examples folder to use Batch Norm
 - adds utilities for switching batch norm on prebuilt models. This isn't needed for maml_omniglot because the net in that example is built inline. However it would be useful for examples like torchvision models
 - tests the newly added utilities to run without tracking stats

In a separate PR I will:
- update the batch norm error message to be more descriptive
- setup a page describing the ways to make batch norm work with vmap