### PR TITLE
Added docs deployment step in GHA

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Build Docs
+name: Build and Deploy Docs
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -35,5 +35,40 @@ jobs:
       - name: Upload docs as GHA artifact
         uses: actions/upload-artifact@v2
         with:
-          name: docs.whl
+          name: built-docs
           path: docs/build/html
+
+  deploy-docs:
+    needs: [build-docs]
+    runs-on: ubuntu-latest
+    if: (github.ref == 'refs/heads/main' && github.event_name == 'push')
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          fetch-depth: 3
+
+      - name: Download docs artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: built-docs
+          path: /tmp/docs
+
+      - name: Copy built docs to nightly
+        run: |
+          cp -R /tmp/docs/* nightly/
+          # Manipulations to squash the history:
+          # 1) reset to a fixed commit
+          # 2) use github-actions-x/commit to commit everything as a single commit
+          git reset --soft 218f32faf8b8cc5236bc49ea77ef7d222e21e5d6
+
+      # Can not use commit --amend to squash history
+      - name: Commit and push to gh-pages
+        uses: github-actions-x/commit@v2.8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          push-branch: 'gh-pages'
+          commit-message: 'New docs'
+          force-push: 'true'
+          name: gha
+          email: gha@email.org

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,20 +55,28 @@ jobs:
           path: /tmp/docs
 
       - name: Copy built docs to nightly
+        id: copy-docs
         run: |
           cp -R /tmp/docs/* nightly/
-          # Manipulations to squash the history:
-          # 1) reset to a fixed commit
-          # 2) use github-actions-x/commit to commit everything as a single commit
-          git reset --soft 218f32faf8b8cc5236bc49ea77ef7d222e21e5d6
+          git log -3
+          # Set commit name and hash as variables: commit_name, commit_hash
+          echo "::set-output name=commit_name::$(git log -1 --format='%s')"
+          echo "::set-output name=commit_hash::$(git log -1 --format='%h')"
 
-      # Can not use commit --amend to squash history
+      - name: Git reset to commit/amend
+        if: ${{ steps.copy-docs.outputs.commit_name == 'auto-generated commit' }}
+        run: |
+          # if commit_name is "auto-generated commit"
+          # then go back in commit history to commit to the same commit
+          git reset --soft ${{ steps.copy-docs.outputs.commit_hash }}~1
+          git log -3
+
       - name: Commit and push to gh-pages
         uses: github-actions-x/commit@v2.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           push-branch: 'gh-pages'
-          commit-message: 'New docs'
+          commit-message: 'auto-generated commit'
           force-push: 'true'
           name: gha
           email: gha@email.org


### PR DESCRIPTION
Description:
- Added GHA "docs deploy" job based on "build-docs" job
- Using an "action" to commit and push to the branch.
  - use `git reset --soft <fixed-commit>` to squash history
  - History on gh-pages: https://github.com/vfdev-5/functorch/commits/gh-pages
- Runned GHA that pushed to gh-pages on my fork:
  - https://github.com/vfdev-5/functorch/actions/runs/1888876266


Fixes #500 