### PR TITLE
[AOT Autograd] FX graph modifications to avoid Torchscript bugs

### DIFF
--- a/functorch/_src/compilers.py
+++ b/functorch/_src/compilers.py
@@ -18,10 +18,16 @@ def _canonicalize(fx_g):
 def ts_compile(fx_g, _):
     fx_g = _canonicalize(fx_g)
     for node in fx_g.graph.nodes:
-        if node.target == torch.ops.aten.new_zeros:
+        if node.target in (torch.ops.aten.new_zeros, torch.ops.aten.new_empty):
             if node.args[1] == []:
                 args = list(node.args)
                 args[1] = [1]
+                node.args = tuple(args)
+        elif node.target == torch.ops.aten.avg_pool2d_backward:
+            # Handle empty strides
+            if node.args[3] == []:
+                args = list(node.args)
+                args[3] = [1, 1]
                 node.args = tuple(args)
 
     for node in fx_g.graph.nodes:


### PR DESCRIPTION
Handling empty list Torchscript bugs for 2 operators
* `new_empty`
* `avg_pool2d_backward` - handle empty strides