### PR TITLE
Added temporary odict pytree registration

### DIFF
--- a/functorch/_src/vmap.py
+++ b/functorch/_src/vmap.py
@@ -6,9 +6,10 @@
 
 import torch
 import functools
+from collections import OrderedDict
 from torch import Tensor
 from typing import Any, Callable, Optional, Tuple, Union, List
-from torch.utils._pytree import tree_flatten, tree_unflatten, _broadcast_to_and_flatten, TreeSpec
+from torch.utils._pytree import tree_flatten, tree_unflatten, _broadcast_to_and_flatten, TreeSpec, _register_pytree_node
 from .pytree_hacks import tree_map_
 from functools import partial
 import inspect
@@ -40,8 +41,20 @@ def register_torch_return_types():
 
 register_torch_return_types()
 
-# Checks that all args-to-be-batched have the same batch dim size
 
+# Temporary OrderedDict registration as pytree
+def _odict_flatten(d):
+    return list(d.values()), list(d.keys())
+
+
+def _odict_unflatten(values, context):
+    return OrderedDict((key, value) for key, value in zip(context, values))
+
+
+_register_pytree_node(OrderedDict, _odict_flatten, _odict_unflatten)
+
+
+# Checks that all args-to-be-batched have the same batch dim size
 
 def _validate_and_get_batch_size(
         flat_in_dims: List[Optional[int]],

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import OrderedDict
 from unittest.case import skipIf, skip
 from torch.testing._internal.common_utils import TestCase, run_tests
 import torch
@@ -302,6 +303,34 @@ class TestVmapAPI(TestCase):
         self.assertEqual(y2, y3)
         self.assertEqual(y4, y3)
         self.assertEqual(y5, y4)
+
+    def test_pytree_odict_returns(self):
+        x = torch.randn(2, 3)
+
+        def f(t):
+            y = t.sin()
+            return OrderedDict([("sin", y), ("cos", t.cos())])
+
+        out = vmap(f)(x)
+        assert isinstance(out, OrderedDict)
+        expected = f(x)
+        self.assertEqual(out["sin"], expected["sin"])
+        self.assertEqual(out["cos"], expected["cos"])
+
+    # temporary test for _odict_flatten and _odict_unflatten
+    def test_pytest_odict_flatten_unflatten(self):
+
+        from functorch._src.vmap import _odict_flatten, _odict_unflatten
+
+        x = torch.randn(2, 3)
+        inpt = OrderedDict([("sin", x.sin()), ("cos", x.cos())])
+
+        out = _odict_flatten(inpt)
+        self.assertEqual(out[0], list(inpt.values()))
+        self.assertEqual(out[1], list(inpt.keys()))
+
+        recon_inpt = _odict_unflatten(*out)
+        self.assertEqual(recon_inpt, inpt)
 
     def test_pytree_returns_outdims(self):
         x = torch.randn(2, 3)


### PR DESCRIPTION
Description:

- Added temporary odict pytree registration
  - combine_state_for_ensemble can work on torchvision segmentation models

Related to https://github.com/pytorch/functorch/issues/445#issuecomment-1050946177

Logs : 
```
python -u check_combine_state_for_ensemble_on_tv_segm_models.py 

Torch: 1.12.0.dev20220223+cu111
torchvision: 0.13.0.dev20220223+cu111
Functorch: 0.2.0a0+c8b640c

-- Check fcn_resnet50 model
/usr/local/lib/python3.8/dist-packages/torch/nn/functional.py:1279: UserWarning: There is a performance drop because we have not yet implemented the batching rule for aten::dropout. Please file us an issue on GitHub so that we can prioritize its implementation. (Triggered internally at  /ft/functorch/csrc/BatchedFallback.cpp:83.)
  return _VF.dropout_(input, p, training) if inplace else _VF.dropout(input, p, training)
-- Check fcn_resnet101 model
Output does not match reference: -237.7958221435547 vs -237.7958984375
-- Check deeplabv3_resnet50 model
-- Check deeplabv3_resnet101 model
Output does not match reference: -285.8777770996094 vs -285.8778076171875
-- Check deeplabv3_mobilenet_v3_large model
-- Check lraspp_mobilenet_v3_large model
```

