### PR TITLE
vmap codegen, for review

### DIFF
--- a/functorch/csrc/VmapGeneratedPlumbing.h
+++ b/functorch/csrc/VmapGeneratedPlumbing.h
@@ -13,7 +13,7 @@ at::Tensor _cast_Byte_generated_plumbing(const at::Tensor & self, bool non_block
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_cast_Byte)(self, non_blocking);
+    return at::_ops::_cast_Byte::call(self, non_blocking);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -28,7 +28,7 @@ at::Tensor _cast_Char_generated_plumbing(const at::Tensor & self, bool non_block
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_cast_Char)(self, non_blocking);
+    return at::_ops::_cast_Char::call(self, non_blocking);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -43,7 +43,7 @@ at::Tensor _cast_Double_generated_plumbing(const at::Tensor & self, bool non_blo
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_cast_Double)(self, non_blocking);
+    return at::_ops::_cast_Double::call(self, non_blocking);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -58,7 +58,7 @@ at::Tensor _cast_Float_generated_plumbing(const at::Tensor & self, bool non_bloc
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_cast_Float)(self, non_blocking);
+    return at::_ops::_cast_Float::call(self, non_blocking);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -73,7 +73,7 @@ at::Tensor _cast_Int_generated_plumbing(const at::Tensor & self, bool non_blocki
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_cast_Int)(self, non_blocking);
+    return at::_ops::_cast_Int::call(self, non_blocking);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -88,7 +88,7 @@ at::Tensor _cast_Long_generated_plumbing(const at::Tensor & self, bool non_block
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_cast_Long)(self, non_blocking);
+    return at::_ops::_cast_Long::call(self, non_blocking);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -103,7 +103,7 @@ at::Tensor _cast_Short_generated_plumbing(const at::Tensor & self, bool non_bloc
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_cast_Short)(self, non_blocking);
+    return at::_ops::_cast_Short::call(self, non_blocking);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -118,7 +118,7 @@ at::Tensor _cast_Half_generated_plumbing(const at::Tensor & self, bool non_block
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_cast_Half)(self, non_blocking);
+    return at::_ops::_cast_Half::call(self, non_blocking);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -133,7 +133,7 @@ at::Tensor data_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(data)(self);
+    return at::_ops::data::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -148,7 +148,7 @@ at::Tensor & requires_grad__generated_plumbing(at::Tensor & self, bool requires_
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(requires_grad_)(self, requires_grad);
+    return at::_ops::requires_grad_::call(self, requires_grad);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -163,7 +163,7 @@ at::Tensor _fw_primal_generated_plumbing(const at::Tensor & self, int64_t level)
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_fw_primal)(self, level);
+    return at::_ops::_fw_primal::call(self, level);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -178,7 +178,7 @@ at::Tensor _make_dual_generated_plumbing(const at::Tensor & primal, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(primal, cur_level) && !isBatchedAtLevel(tangent, cur_level)) {
-    return ATEN_FN(_make_dual)(primal, tangent, level);
+    return at::_ops::_make_dual::call(primal, tangent, level);
   }
   Tensor primal_value;
   optional<int64_t> primal_bdim;
@@ -196,7 +196,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(dual, cur_level)) {
-    return ATEN_FN(_unpack_dual)(dual, level);
+    return at::_ops::_unpack_dual::call(dual, level);
   }
   Tensor dual_value;
   optional<int64_t> dual_bdim;
@@ -211,7 +211,7 @@ at::Tensor _new_zeros_with_same_feature_meta_generated_plumbing(const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(_new_zeros_with_same_feature_meta)(self, other, self_num_batch_dims);
+    return at::_ops::_new_zeros_with_same_feature_meta::call(self, other, self_num_batch_dims);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -229,7 +229,7 @@ at::Tensor & rename__generated_plumbing(at::Tensor & self, c10::optional<at::Dim
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(rename_)(self, names);
+    return at::_ops::rename_::call(self, names);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -244,7 +244,7 @@ at::Tensor rename_generated_plumbing(const at::Tensor & self, c10::optional<at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(rename)(self, names);
+    return at::_ops::rename::call(self, names);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -259,7 +259,7 @@ at::Tensor align_to_generated_plumbing(const at::Tensor & self, at::DimnameList 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(align_to)(self, names);
+    return at::_ops::align_to::call(self, names);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -274,7 +274,7 @@ at::Tensor align_to_ellipsis_idx_generated_plumbing(const at::Tensor & self, at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(align_to, ellipsis_idx)(self, order, ellipsis_idx);
+    return at::_ops::align_to_ellipsis_idx::call(self, order, ellipsis_idx);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -289,7 +289,7 @@ at::Tensor align_as_generated_plumbing(const at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(align_as)(self, other);
+    return at::_ops::align_as::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -307,7 +307,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(align_tensors)(tensors);
+    return at::_ops::align_tensors::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -320,7 +320,7 @@ at::Tensor refine_names_generated_plumbing(const at::Tensor & self, at::DimnameL
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(refine_names)(self, names);
+    return at::_ops::refine_names::call(self, names);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -335,7 +335,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(log_probs, cur_level) && !isBatchedAtLevel(targets, cur_level)) {
-    return ATEN_FN(_cudnn_ctc_loss)(log_probs, targets, input_lengths, target_lengths, blank, deterministic, zero_infinity);
+    return at::_ops::_cudnn_ctc_loss::call(log_probs, targets, input_lengths, target_lengths, blank, deterministic, zero_infinity);
   }
   Tensor log_probs_value;
   optional<int64_t> log_probs_bdim;
@@ -353,7 +353,7 @@ at::Tensor _cudnn_rnn_flatten_weight_generated_plumbing(at::TensorList weight_ar
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(weight_arr, cur_level)) {
-    return ATEN_FN(_cudnn_rnn_flatten_weight)(weight_arr, weight_stride0, input_size, mode, hidden_size, proj_size, num_layers, batch_first, bidirectional);
+    return at::_ops::_cudnn_rnn_flatten_weight::call(weight_arr, weight_stride0, input_size, mode, hidden_size, proj_size, num_layers, batch_first, bidirectional);
   }
 
   auto results = batch_rule(weight_arr, weight_stride0, input_size, mode, hidden_size, proj_size, num_layers, batch_first, bidirectional);
@@ -366,7 +366,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(weight_buf, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(cx, cur_level) && !isBatchedAtLevel(dropout_state, cur_level)) {
-    return ATEN_FN(_cudnn_rnn)(input, weight, weight_stride0, weight_buf, hx, cx, mode, hidden_size, proj_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state);
+    return at::_ops::_cudnn_rnn::call(input, weight, weight_stride0, weight_buf, hx, cx, mode, hidden_size, proj_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -399,7 +399,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(weight_buf, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(cx, cur_level) && !isBatchedAtLevel(output, cur_level) && !isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(grad_hy, cur_level) && !isBatchedAtLevel(grad_cy, cur_level) && !isBatchedAtLevel(dropout_state, cur_level) && !isBatchedAtLevel(reserve, cur_level)) {
-    return ATEN_FN(_cudnn_rnn_backward)(input, weight, weight_stride0, weight_buf, hx, cx, output, grad_output, grad_hy, grad_cy, mode, hidden_size, proj_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state, reserve, output_mask);
+    return at::_ops::_cudnn_rnn_backward::call(input, weight, weight_stride0, weight_buf, hx, cx, output, grad_output, grad_hy, grad_cy, mode, hidden_size, proj_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state, reserve, output_mask);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -451,7 +451,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_fused_dropout)(self, p, generator);
+    return at::_ops::_fused_dropout::call(self, p, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -466,7 +466,7 @@ at::Tensor _masked_scale_generated_plumbing(const at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mask, cur_level)) {
-    return ATEN_FN(_masked_scale)(self, mask, scale);
+    return at::_ops::_masked_scale::call(self, mask, scale);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -484,7 +484,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN(native_dropout)(input, p, train);
+    return at::_ops::native_dropout::call(input, p, train);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -499,7 +499,7 @@ at::Tensor native_dropout_backward_generated_plumbing(const at::Tensor & grad_ou
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(mask, cur_level)) {
-    return ATEN_FN(native_dropout_backward)(grad_output, mask, scale);
+    return at::_ops::native_dropout_backward::call(grad_output, mask, scale);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -517,7 +517,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(quasi, cur_level) && !isBatchedAtLevel(sobolstate, cur_level)) {
-    return ATEN_FN(_sobol_engine_draw)(quasi, n, sobolstate, dimension, num_generated, dtype);
+    return at::_ops::_sobol_engine_draw::call(quasi, n, sobolstate, dimension, num_generated, dtype);
   }
   Tensor quasi_value;
   optional<int64_t> quasi_bdim;
@@ -535,7 +535,7 @@ at::Tensor & _sobol_engine_ff__generated_plumbing(at::Tensor & self, int64_t n, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(sobolstate, cur_level)) {
-    return ATEN_FN(_sobol_engine_ff_)(self, n, sobolstate, dimension, num_generated);
+    return at::_ops::_sobol_engine_ff_::call(self, n, sobolstate, dimension, num_generated);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -553,7 +553,7 @@ at::Tensor & _sobol_engine_scramble__generated_plumbing(at::Tensor & self, const
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(ltm, cur_level)) {
-    return ATEN_FN(_sobol_engine_scramble_)(self, ltm, dimension);
+    return at::_ops::_sobol_engine_scramble_::call(self, ltm, dimension);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -571,7 +571,7 @@ at::Tensor & _sobol_engine_initialize_state__generated_plumbing(at::Tensor & sel
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_sobol_engine_initialize_state_)(self, dimension);
+    return at::_ops::_sobol_engine_initialize_state_::call(self, dimension);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -586,7 +586,7 @@ at::Tensor _reshape_from_tensor_generated_plumbing(const at::Tensor & self, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(shape, cur_level)) {
-    return ATEN_FN(_reshape_from_tensor)(self, shape);
+    return at::_ops::_reshape_from_tensor::call(self, shape);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -604,7 +604,7 @@ at::Tensor _shape_as_tensor_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_shape_as_tensor)(self);
+    return at::_ops::_shape_as_tensor::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -619,7 +619,7 @@ at::Tensor dropout_generated_plumbing(const at::Tensor & input, double p, bool t
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN(dropout)(input, p, train);
+    return at::_ops::dropout::call(input, p, train);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -634,7 +634,7 @@ at::Tensor & dropout__generated_plumbing(at::Tensor & self, double p, bool train
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(dropout_)(self, p, train);
+    return at::_ops::dropout_::call(self, p, train);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -649,7 +649,7 @@ at::Tensor feature_dropout_generated_plumbing(const at::Tensor & input, double p
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN(feature_dropout)(input, p, train);
+    return at::_ops::feature_dropout::call(input, p, train);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -664,7 +664,7 @@ at::Tensor & feature_dropout__generated_plumbing(at::Tensor & self, double p, bo
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(feature_dropout_)(self, p, train);
+    return at::_ops::feature_dropout_::call(self, p, train);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -679,7 +679,7 @@ at::Tensor alpha_dropout_generated_plumbing(const at::Tensor & input, double p, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN(alpha_dropout)(input, p, train);
+    return at::_ops::alpha_dropout::call(input, p, train);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -694,7 +694,7 @@ at::Tensor & alpha_dropout__generated_plumbing(at::Tensor & self, double p, bool
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(alpha_dropout_)(self, p, train);
+    return at::_ops::alpha_dropout_::call(self, p, train);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -709,7 +709,7 @@ at::Tensor feature_alpha_dropout_generated_plumbing(const at::Tensor & input, do
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN(feature_alpha_dropout)(input, p, train);
+    return at::_ops::feature_alpha_dropout::call(input, p, train);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -724,7 +724,7 @@ at::Tensor & feature_alpha_dropout__generated_plumbing(at::Tensor & self, double
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(feature_alpha_dropout_)(self, p, train);
+    return at::_ops::feature_alpha_dropout_::call(self, p, train);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -739,7 +739,7 @@ at::Tensor abs_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(abs)(self);
+    return at::_ops::abs::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -754,7 +754,7 @@ at::Tensor & abs__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(abs_)(self);
+    return at::_ops::abs_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -769,7 +769,7 @@ at::Tensor absolute_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(absolute)(self);
+    return at::_ops::absolute::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -784,7 +784,7 @@ at::Tensor & absolute__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(absolute_)(self);
+    return at::_ops::absolute_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -799,7 +799,7 @@ at::Tensor angle_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(angle)(self);
+    return at::_ops::angle::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -814,7 +814,7 @@ at::Tensor view_as_real_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(view_as_real)(self);
+    return at::_ops::view_as_real::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -829,7 +829,7 @@ at::Tensor view_as_complex_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(view_as_complex)(self);
+    return at::_ops::view_as_complex::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -844,7 +844,7 @@ at::Tensor sgn_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sgn)(self);
+    return at::_ops::sgn::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -859,7 +859,7 @@ at::Tensor & sgn__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sgn_)(self);
+    return at::_ops::sgn_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -874,7 +874,7 @@ at::Tensor real_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(real)(self);
+    return at::_ops::real::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -889,7 +889,7 @@ at::Tensor imag_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(imag)(self);
+    return at::_ops::imag::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -904,7 +904,7 @@ at::Tensor _conj_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_conj)(self);
+    return at::_ops::_conj::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -919,7 +919,7 @@ at::Tensor conj_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(conj)(self);
+    return at::_ops::conj::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -934,7 +934,7 @@ at::Tensor _conj_physical_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_conj_physical)(self);
+    return at::_ops::_conj_physical::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -949,7 +949,7 @@ at::Tensor conj_physical_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(conj_physical)(self);
+    return at::_ops::conj_physical::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -964,7 +964,7 @@ at::Tensor & conj_physical__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(conj_physical_)(self);
+    return at::_ops::conj_physical_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -979,7 +979,7 @@ at::Tensor resolve_conj_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(resolve_conj)(self);
+    return at::_ops::resolve_conj::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -994,7 +994,7 @@ at::Tensor resolve_neg_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(resolve_neg)(self);
+    return at::_ops::resolve_neg::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1009,7 +1009,7 @@ at::Tensor _neg_view_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_neg_view)(self);
+    return at::_ops::_neg_view::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1024,7 +1024,7 @@ at::Tensor acos_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(acos)(self);
+    return at::_ops::acos::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1039,7 +1039,7 @@ at::Tensor & acos__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(acos_)(self);
+    return at::_ops::acos_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1054,7 +1054,7 @@ at::Tensor arccos_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(arccos)(self);
+    return at::_ops::arccos::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1069,7 +1069,7 @@ at::Tensor & arccos__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(arccos_)(self);
+    return at::_ops::arccos_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1084,7 +1084,7 @@ at::Tensor avg_pool1d_generated_plumbing(const at::Tensor & self, at::IntArrayRe
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(avg_pool1d)(self, kernel_size, stride, padding, ceil_mode, count_include_pad);
+    return at::_ops::avg_pool1d::call(self, kernel_size, stride, padding, ceil_mode, count_include_pad);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1099,7 +1099,7 @@ at::Tensor adaptive_avg_pool1d_generated_plumbing(const at::Tensor & self, at::I
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(adaptive_avg_pool1d)(self, output_size);
+    return at::_ops::adaptive_avg_pool1d::call(self, output_size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1114,7 +1114,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(adaptive_max_pool1d)(self, output_size);
+    return at::_ops::adaptive_max_pool1d::call(self, output_size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1129,7 +1129,7 @@ at::Tensor add_Tensor_generated_plumbing(const at::Tensor & self, const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(add, Tensor)(self, other, alpha);
+    return at::_ops::add_Tensor::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1147,7 +1147,7 @@ at::Tensor & add__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(add_, Tensor)(self, other, alpha);
+    return at::_ops::add__Tensor::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1165,7 +1165,7 @@ at::Tensor _add_relu_Tensor_generated_plumbing(const at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(_add_relu, Tensor)(self, other, alpha);
+    return at::_ops::_add_relu_Tensor::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1183,7 +1183,7 @@ at::Tensor & _add_relu__Tensor_generated_plumbing(at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(_add_relu_, Tensor)(self, other, alpha);
+    return at::_ops::_add_relu__Tensor::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1201,7 +1201,7 @@ at::Tensor _add_relu_Scalar_generated_plumbing(const at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(_add_relu, Scalar)(self, other, alpha);
+    return at::_ops::_add_relu_Scalar::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1216,7 +1216,7 @@ at::Tensor & _add_relu__Scalar_generated_plumbing(at::Tensor & self, const at::S
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(_add_relu_, Scalar)(self, other, alpha);
+    return at::_ops::_add_relu__Scalar::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1231,7 +1231,7 @@ at::Tensor add_Scalar_generated_plumbing(const at::Tensor & self, const at::Scal
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(add, Scalar)(self, other, alpha);
+    return at::_ops::add_Scalar::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1246,7 +1246,7 @@ at::Tensor & add__Scalar_generated_plumbing(at::Tensor & self, const at::Scalar 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(add_, Scalar)(self, other, alpha);
+    return at::_ops::add__Scalar::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1261,7 +1261,7 @@ at::Tensor addmv_generated_plumbing(const at::Tensor & self, const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mat, cur_level) && !isBatchedAtLevel(vec, cur_level)) {
-    return ATEN_FN(addmv)(self, mat, vec, beta, alpha);
+    return at::_ops::addmv::call(self, mat, vec, beta, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1282,7 +1282,7 @@ at::Tensor & addmv__generated_plumbing(at::Tensor & self, const at::Tensor & mat
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mat, cur_level) && !isBatchedAtLevel(vec, cur_level)) {
-    return ATEN_FN(addmv_)(self, mat, vec, beta, alpha);
+    return at::_ops::addmv_::call(self, mat, vec, beta, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1303,7 +1303,7 @@ at::Tensor addr_generated_plumbing(const at::Tensor & self, const at::Tensor & v
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(vec1, cur_level) && !isBatchedAtLevel(vec2, cur_level)) {
-    return ATEN_FN(addr)(self, vec1, vec2, beta, alpha);
+    return at::_ops::addr::call(self, vec1, vec2, beta, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1324,7 +1324,7 @@ at::Tensor & addr__generated_plumbing(at::Tensor & self, const at::Tensor & vec1
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(vec1, cur_level) && !isBatchedAtLevel(vec2, cur_level)) {
-    return ATEN_FN(addr_)(self, vec1, vec2, beta, alpha);
+    return at::_ops::addr_::call(self, vec1, vec2, beta, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1345,7 +1345,7 @@ at::Tensor affine_grid_generator_generated_plumbing(const at::Tensor & theta, at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(theta, cur_level)) {
-    return ATEN_FN(affine_grid_generator)(theta, size, align_corners);
+    return at::_ops::affine_grid_generator::call(theta, size, align_corners);
   }
   Tensor theta_value;
   optional<int64_t> theta_bdim;
@@ -1360,7 +1360,7 @@ at::Tensor affine_grid_generator_backward_generated_plumbing(const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level)) {
-    return ATEN_FN(affine_grid_generator_backward)(grad, size, align_corners);
+    return at::_ops::affine_grid_generator_backward::call(grad, size, align_corners);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -1375,7 +1375,7 @@ at::Tensor all_dim_generated_plumbing(const at::Tensor & self, int64_t dim, bool
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(all, dim)(self, dim, keepdim);
+    return at::_ops::all_dim::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1390,7 +1390,7 @@ at::Tensor all_dimname_generated_plumbing(const at::Tensor & self, at::Dimname d
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(all, dimname)(self, dim, keepdim);
+    return at::_ops::all_dimname::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1405,7 +1405,7 @@ at::Tensor any_dim_generated_plumbing(const at::Tensor & self, int64_t dim, bool
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(any, dim)(self, dim, keepdim);
+    return at::_ops::any_dim::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1420,7 +1420,7 @@ at::Tensor any_dimname_generated_plumbing(const at::Tensor & self, at::Dimname d
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(any, dimname)(self, dim, keepdim);
+    return at::_ops::any_dimname::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1435,7 +1435,7 @@ at::Tensor _dim_arange_generated_plumbing(const at::Tensor & like, int64_t dim) 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(like, cur_level)) {
-    return ATEN_FN(_dim_arange)(like, dim);
+    return at::_ops::_dim_arange::call(like, dim);
   }
   Tensor like_value;
   optional<int64_t> like_bdim;
@@ -1450,7 +1450,7 @@ at::Tensor argmax_generated_plumbing(const at::Tensor & self, c10::optional<int6
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(argmax)(self, dim, keepdim);
+    return at::_ops::argmax::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1465,7 +1465,7 @@ at::Tensor argmin_generated_plumbing(const at::Tensor & self, c10::optional<int6
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(argmin)(self, dim, keepdim);
+    return at::_ops::argmin::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1480,7 +1480,7 @@ at::Tensor acosh_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(acosh)(self);
+    return at::_ops::acosh::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1495,7 +1495,7 @@ at::Tensor & acosh__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(acosh_)(self);
+    return at::_ops::acosh_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1510,7 +1510,7 @@ at::Tensor arccosh_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(arccosh)(self);
+    return at::_ops::arccosh::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1525,7 +1525,7 @@ at::Tensor & arccosh__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(arccosh_)(self);
+    return at::_ops::arccosh_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1540,7 +1540,7 @@ at::Tensor asinh_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(asinh)(self);
+    return at::_ops::asinh::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1555,7 +1555,7 @@ at::Tensor & asinh__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(asinh_)(self);
+    return at::_ops::asinh_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1570,7 +1570,7 @@ at::Tensor arcsinh_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(arcsinh)(self);
+    return at::_ops::arcsinh::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1585,7 +1585,7 @@ at::Tensor & arcsinh__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(arcsinh_)(self);
+    return at::_ops::arcsinh_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1600,7 +1600,7 @@ at::Tensor atanh_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(atanh)(self);
+    return at::_ops::atanh::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1615,7 +1615,7 @@ at::Tensor & atanh__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(atanh_)(self);
+    return at::_ops::atanh_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1630,7 +1630,7 @@ at::Tensor arctanh_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(arctanh)(self);
+    return at::_ops::arctanh::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1645,7 +1645,7 @@ at::Tensor & arctanh__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(arctanh_)(self);
+    return at::_ops::arctanh_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1660,7 +1660,7 @@ at::Tensor as_strided_generated_plumbing(const at::Tensor & self, at::IntArrayRe
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(as_strided)(self, size, stride, storage_offset);
+    return at::_ops::as_strided::call(self, size, stride, storage_offset);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1675,7 +1675,7 @@ at::Tensor asin_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(asin)(self);
+    return at::_ops::asin::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1690,7 +1690,7 @@ at::Tensor & asin__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(asin_)(self);
+    return at::_ops::asin_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1705,7 +1705,7 @@ at::Tensor arcsin_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(arcsin)(self);
+    return at::_ops::arcsin::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1720,7 +1720,7 @@ at::Tensor & arcsin__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(arcsin_)(self);
+    return at::_ops::arcsin_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1735,7 +1735,7 @@ at::Tensor atan_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(atan)(self);
+    return at::_ops::atan::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1750,7 +1750,7 @@ at::Tensor & atan__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(atan_)(self);
+    return at::_ops::atan_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1765,7 +1765,7 @@ at::Tensor arctan_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(arctan)(self);
+    return at::_ops::arctan::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1780,7 +1780,7 @@ at::Tensor & arctan__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(arctan_)(self);
+    return at::_ops::arctan_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1795,7 +1795,7 @@ at::Tensor atleast_1d_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(atleast_1d)(self);
+    return at::_ops::atleast_1d::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1810,7 +1810,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(atleast_1d, Sequence)(tensors);
+    return at::_ops::atleast_1d_Sequence::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -1823,7 +1823,7 @@ at::Tensor atleast_2d_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(atleast_2d)(self);
+    return at::_ops::atleast_2d::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1838,7 +1838,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(atleast_2d, Sequence)(tensors);
+    return at::_ops::atleast_2d_Sequence::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -1851,7 +1851,7 @@ at::Tensor atleast_3d_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(atleast_3d)(self);
+    return at::_ops::atleast_3d::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1866,7 +1866,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(atleast_3d, Sequence)(tensors);
+    return at::_ops::atleast_3d_Sequence::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -1879,7 +1879,7 @@ at::Tensor baddbmm_generated_plumbing(const at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(batch1, cur_level) && !isBatchedAtLevel(batch2, cur_level)) {
-    return ATEN_FN(baddbmm)(self, batch1, batch2, beta, alpha);
+    return at::_ops::baddbmm::call(self, batch1, batch2, beta, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1900,7 +1900,7 @@ at::Tensor & baddbmm__generated_plumbing(at::Tensor & self, const at::Tensor & b
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(batch1, cur_level) && !isBatchedAtLevel(batch2, cur_level)) {
-    return ATEN_FN(baddbmm_)(self, batch1, batch2, beta, alpha);
+    return at::_ops::baddbmm_::call(self, batch1, batch2, beta, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -1921,7 +1921,7 @@ at::Tensor batch_norm_generated_plumbing(const at::Tensor & input, const c10::op
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level) && !isBatchedAtLevel(running_mean, cur_level) && !isBatchedAtLevel(running_var, cur_level)) {
-    return ATEN_FN(batch_norm)(input, weight, bias, running_mean, running_var, training, momentum, eps, cudnn_enabled);
+    return at::_ops::batch_norm::call(input, weight, bias, running_mean, running_var, training, momentum, eps, cudnn_enabled);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -1956,7 +1956,7 @@ at::Tensor quantized_batch_norm_generated_plumbing(const at::Tensor & input, con
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level) && !isBatchedAtLevel(mean, cur_level) && !isBatchedAtLevel(var, cur_level)) {
-    return ATEN_FN(quantized_batch_norm)(input, weight, bias, mean, var, eps, output_scale, output_zero_point);
+    return at::_ops::quantized_batch_norm::call(input, weight, bias, mean, var, eps, output_scale, output_zero_point);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -1987,7 +1987,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(running_mean, cur_level) && !isBatchedAtLevel(running_var, cur_level) && !isBatchedAtLevel(save_mean, cur_level) && !isBatchedAtLevel(save_var_transform, cur_level) && !isBatchedAtLevel(reservedSpace, cur_level)) {
-    return ATEN_FN(_batch_norm_impl_index_backward)(impl_index, input, grad_output, weight, running_mean, running_var, save_mean, save_var_transform, train, eps, output_mask, reservedSpace);
+    return at::_ops::_batch_norm_impl_index_backward::call(impl_index, input, grad_output, weight, running_mean, running_var, save_mean, save_var_transform, train, eps, output_mask, reservedSpace);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -2033,7 +2033,7 @@ at::Tensor bernoulli_generated_plumbing(const at::Tensor & self, c10::optional<a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(bernoulli)(self, generator);
+    return at::_ops::bernoulli::call(self, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2048,7 +2048,7 @@ at::Tensor & bernoulli__Tensor_generated_plumbing(at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(p, cur_level)) {
-    return ATEN_FN2(bernoulli_, Tensor)(self, p, generator);
+    return at::_ops::bernoulli__Tensor::call(self, p, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2066,7 +2066,7 @@ at::Tensor & bernoulli__float_generated_plumbing(at::Tensor & self, double p, c1
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(bernoulli_, float)(self, p, generator);
+    return at::_ops::bernoulli__float::call(self, p, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2081,7 +2081,7 @@ at::Tensor bernoulli_p_generated_plumbing(const at::Tensor & self, double p, c10
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(bernoulli, p)(self, p, generator);
+    return at::_ops::bernoulli_p::call(self, p, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2096,7 +2096,7 @@ at::Tensor bilinear_generated_plumbing(const at::Tensor & input1, const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input1, cur_level) && !isBatchedAtLevel(input2, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(bilinear)(input1, input2, weight, bias);
+    return at::_ops::bilinear::call(input1, input2, weight, bias);
   }
   Tensor input1_value;
   optional<int64_t> input1_bdim;
@@ -2122,7 +2122,7 @@ at::Tensor binary_cross_entropy_generated_plumbing(const at::Tensor & self, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(binary_cross_entropy)(self, target, weight, reduction);
+    return at::_ops::binary_cross_entropy::call(self, target, weight, reduction);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2145,7 +2145,7 @@ at::Tensor binary_cross_entropy_backward_generated_plumbing(const at::Tensor & g
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(binary_cross_entropy_backward)(grad_output, self, target, weight, reduction);
+    return at::_ops::binary_cross_entropy_backward::call(grad_output, self, target, weight, reduction);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -2171,7 +2171,7 @@ at::Tensor binary_cross_entropy_with_logits_generated_plumbing(const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(pos_weight, cur_level)) {
-    return ATEN_FN(binary_cross_entropy_with_logits)(self, target, weight, pos_weight, reduction);
+    return at::_ops::binary_cross_entropy_with_logits::call(self, target, weight, pos_weight, reduction);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2199,7 +2199,7 @@ at::Tensor binary_cross_entropy_with_logits_backward_generated_plumbing(const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(pos_weight, cur_level)) {
-    return ATEN_FN(binary_cross_entropy_with_logits_backward)(grad_output, self, target, weight, pos_weight, reduction);
+    return at::_ops::binary_cross_entropy_with_logits_backward::call(grad_output, self, target, weight, pos_weight, reduction);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -2230,7 +2230,7 @@ at::Tensor bincount_generated_plumbing(const at::Tensor & self, const c10::optio
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weights, cur_level)) {
-    return ATEN_FN(bincount)(self, weights, minlength);
+    return at::_ops::bincount::call(self, weights, minlength);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2250,7 +2250,7 @@ at::Tensor bitwise_not_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(bitwise_not)(self);
+    return at::_ops::bitwise_not::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2265,7 +2265,7 @@ at::Tensor & bitwise_not__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(bitwise_not_)(self);
+    return at::_ops::bitwise_not_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2280,7 +2280,7 @@ at::Tensor copysign_Tensor_generated_plumbing(const at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(copysign, Tensor)(self, other);
+    return at::_ops::copysign_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2298,7 +2298,7 @@ at::Tensor & copysign__Tensor_generated_plumbing(at::Tensor & self, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(copysign_, Tensor)(self, other);
+    return at::_ops::copysign__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2316,7 +2316,7 @@ at::Tensor copysign_Scalar_generated_plumbing(const at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(copysign, Scalar)(self, other);
+    return at::_ops::copysign_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2331,7 +2331,7 @@ at::Tensor & copysign__Scalar_generated_plumbing(at::Tensor & self, const at::Sc
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(copysign_, Scalar)(self, other);
+    return at::_ops::copysign__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2346,7 +2346,7 @@ at::Tensor logical_not_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(logical_not)(self);
+    return at::_ops::logical_not::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2361,7 +2361,7 @@ at::Tensor & logical_not__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(logical_not_)(self);
+    return at::_ops::logical_not_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2376,7 +2376,7 @@ at::Tensor logical_xor_generated_plumbing(const at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(logical_xor)(self, other);
+    return at::_ops::logical_xor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2394,7 +2394,7 @@ at::Tensor & logical_xor__generated_plumbing(at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(logical_xor_)(self, other);
+    return at::_ops::logical_xor_::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2412,7 +2412,7 @@ at::Tensor logical_and_generated_plumbing(const at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(logical_and)(self, other);
+    return at::_ops::logical_and::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2430,7 +2430,7 @@ at::Tensor & logical_and__generated_plumbing(at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(logical_and_)(self, other);
+    return at::_ops::logical_and_::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2448,7 +2448,7 @@ at::Tensor logical_or_generated_plumbing(const at::Tensor & self, const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(logical_or)(self, other);
+    return at::_ops::logical_or::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2466,7 +2466,7 @@ at::Tensor & logical_or__generated_plumbing(at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(logical_or_)(self, other);
+    return at::_ops::logical_or_::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2484,7 +2484,7 @@ at::Tensor bmm_generated_plumbing(const at::Tensor & self, const at::Tensor & ma
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mat2, cur_level)) {
-    return ATEN_FN(bmm)(self, mat2);
+    return at::_ops::bmm::call(self, mat2);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2502,7 +2502,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(broadcast_tensors)(tensors);
+    return at::_ops::broadcast_tensors::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -2515,7 +2515,7 @@ at::Tensor broadcast_to_generated_plumbing(const at::Tensor & self, at::IntArray
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(broadcast_to)(self, size);
+    return at::_ops::broadcast_to::call(self, size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2530,7 +2530,7 @@ at::Tensor _sparse_broadcast_to_generated_plumbing(const at::Tensor & self, at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_sparse_broadcast_to)(self, size);
+    return at::_ops::_sparse_broadcast_to::call(self, size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2545,7 +2545,7 @@ at::Tensor cat_generated_plumbing(at::TensorList tensors, int64_t dim) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(cat)(tensors, dim);
+    return at::_ops::cat::call(tensors, dim);
   }
 
   auto results = batch_rule(tensors, dim);
@@ -2558,7 +2558,7 @@ at::Tensor cat_names_generated_plumbing(at::TensorList tensors, at::Dimname dim)
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(cat, names)(tensors, dim);
+    return at::_ops::cat_names::call(tensors, dim);
   }
 
   auto results = batch_rule(tensors, dim);
@@ -2571,7 +2571,7 @@ at::Tensor concat_generated_plumbing(at::TensorList tensors, int64_t dim) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(concat)(tensors, dim);
+    return at::_ops::concat::call(tensors, dim);
   }
 
   auto results = batch_rule(tensors, dim);
@@ -2584,7 +2584,7 @@ at::Tensor concat_names_generated_plumbing(at::TensorList tensors, at::Dimname d
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(concat, names)(tensors, dim);
+    return at::_ops::concat_names::call(tensors, dim);
   }
 
   auto results = batch_rule(tensors, dim);
@@ -2597,7 +2597,7 @@ at::Tensor block_diag_generated_plumbing(at::TensorList tensors) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(block_diag)(tensors);
+    return at::_ops::block_diag::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -2610,7 +2610,7 @@ at::Tensor ceil_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(ceil)(self);
+    return at::_ops::ceil::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2625,7 +2625,7 @@ at::Tensor & ceil__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(ceil_)(self);
+    return at::_ops::ceil_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2640,7 +2640,7 @@ at::Tensor chain_matmul_generated_plumbing(at::TensorList matrices) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(matrices, cur_level)) {
-    return ATEN_FN(chain_matmul)(matrices);
+    return at::_ops::chain_matmul::call(matrices);
   }
 
   auto results = batch_rule(matrices);
@@ -2653,7 +2653,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(unsafe_chunk)(self, chunks, dim);
+    return at::_ops::unsafe_chunk::call(self, chunks, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2668,7 +2668,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(chunk)(self, chunks, dim);
+    return at::_ops::chunk::call(self, chunks, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2683,7 +2683,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(tensor_split, sections)(self, sections, dim);
+    return at::_ops::tensor_split_sections::call(self, sections, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2698,7 +2698,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(tensor_split, indices)(self, indices, dim);
+    return at::_ops::tensor_split_indices::call(self, indices, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2713,7 +2713,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(tensor_indices_or_sections, cur_level)) {
-    return ATEN_FN2(tensor_split, tensor_indices_or_sections)(self, tensor_indices_or_sections, dim);
+    return at::_ops::tensor_split_tensor_indices_or_sections::call(self, tensor_indices_or_sections, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2731,7 +2731,7 @@ at::Tensor clamp_generated_plumbing(const at::Tensor & self, const c10::optional
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(clamp)(self, min, max);
+    return at::_ops::clamp::call(self, min, max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2746,7 +2746,7 @@ at::Tensor clamp_Tensor_generated_plumbing(const at::Tensor & self, const c10::o
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(min, cur_level) && !isBatchedAtLevel(max, cur_level)) {
-    return ATEN_FN2(clamp, Tensor)(self, min, max);
+    return at::_ops::clamp_Tensor::call(self, min, max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2771,7 +2771,7 @@ at::Tensor & clamp__generated_plumbing(at::Tensor & self, const c10::optional<at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(clamp_)(self, min, max);
+    return at::_ops::clamp_::call(self, min, max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2786,7 +2786,7 @@ at::Tensor & clamp__Tensor_generated_plumbing(at::Tensor & self, const c10::opti
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(min, cur_level) && !isBatchedAtLevel(max, cur_level)) {
-    return ATEN_FN2(clamp_, Tensor)(self, min, max);
+    return at::_ops::clamp__Tensor::call(self, min, max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2811,7 +2811,7 @@ at::Tensor clamp_max_generated_plumbing(const at::Tensor & self, const at::Scala
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(clamp_max)(self, max);
+    return at::_ops::clamp_max::call(self, max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2826,7 +2826,7 @@ at::Tensor clamp_max_Tensor_generated_plumbing(const at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(max, cur_level)) {
-    return ATEN_FN2(clamp_max, Tensor)(self, max);
+    return at::_ops::clamp_max_Tensor::call(self, max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2844,7 +2844,7 @@ at::Tensor & clamp_max__generated_plumbing(at::Tensor & self, const at::Scalar &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(clamp_max_)(self, max);
+    return at::_ops::clamp_max_::call(self, max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2859,7 +2859,7 @@ at::Tensor & clamp_max__Tensor_generated_plumbing(at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(max, cur_level)) {
-    return ATEN_FN2(clamp_max_, Tensor)(self, max);
+    return at::_ops::clamp_max__Tensor::call(self, max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2877,7 +2877,7 @@ at::Tensor clamp_min_generated_plumbing(const at::Tensor & self, const at::Scala
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(clamp_min)(self, min);
+    return at::_ops::clamp_min::call(self, min);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2892,7 +2892,7 @@ at::Tensor clamp_min_Tensor_generated_plumbing(const at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(min, cur_level)) {
-    return ATEN_FN2(clamp_min, Tensor)(self, min);
+    return at::_ops::clamp_min_Tensor::call(self, min);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2910,7 +2910,7 @@ at::Tensor & clamp_min__generated_plumbing(at::Tensor & self, const at::Scalar &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(clamp_min_)(self, min);
+    return at::_ops::clamp_min_::call(self, min);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2925,7 +2925,7 @@ at::Tensor & clamp_min__Tensor_generated_plumbing(at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(min, cur_level)) {
-    return ATEN_FN2(clamp_min_, Tensor)(self, min);
+    return at::_ops::clamp_min__Tensor::call(self, min);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2943,7 +2943,7 @@ at::Tensor clip_generated_plumbing(const at::Tensor & self, const c10::optional<
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(clip)(self, min, max);
+    return at::_ops::clip::call(self, min, max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2958,7 +2958,7 @@ at::Tensor clip_Tensor_generated_plumbing(const at::Tensor & self, const c10::op
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(min, cur_level) && !isBatchedAtLevel(max, cur_level)) {
-    return ATEN_FN2(clip, Tensor)(self, min, max);
+    return at::_ops::clip_Tensor::call(self, min, max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2983,7 +2983,7 @@ at::Tensor & clip__generated_plumbing(at::Tensor & self, const c10::optional<at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(clip_)(self, min, max);
+    return at::_ops::clip_::call(self, min, max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -2998,7 +2998,7 @@ at::Tensor & clip__Tensor_generated_plumbing(at::Tensor & self, const c10::optio
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(min, cur_level) && !isBatchedAtLevel(max, cur_level)) {
-    return ATEN_FN2(clip_, Tensor)(self, min, max);
+    return at::_ops::clip__Tensor::call(self, min, max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3023,7 +3023,7 @@ at::Tensor complex_generated_plumbing(const at::Tensor & real, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(real, cur_level) && !isBatchedAtLevel(imag, cur_level)) {
-    return ATEN_FN(complex)(real, imag);
+    return at::_ops::complex::call(real, imag);
   }
   Tensor real_value;
   optional<int64_t> real_bdim;
@@ -3041,7 +3041,7 @@ at::Tensor polar_generated_plumbing(const at::Tensor & abs, const at::Tensor & a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(abs, cur_level) && !isBatchedAtLevel(angle, cur_level)) {
-    return ATEN_FN(polar)(abs, angle);
+    return at::_ops::polar::call(abs, angle);
   }
   Tensor abs_value;
   optional<int64_t> abs_bdim;
@@ -3059,7 +3059,7 @@ at::Tensor constant_pad_nd_generated_plumbing(const at::Tensor & self, at::IntAr
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(constant_pad_nd)(self, pad, value);
+    return at::_ops::constant_pad_nd::call(self, pad, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3074,7 +3074,7 @@ at::Tensor contiguous_generated_plumbing(const at::Tensor & self, at::MemoryForm
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(contiguous)(self, memory_format);
+    return at::_ops::contiguous::call(self, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3089,7 +3089,7 @@ at::Tensor convolution_generated_plumbing(const at::Tensor & input, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(convolution)(input, weight, bias, stride, padding, dilation, transposed, output_padding, groups);
+    return at::_ops::convolution::call(input, weight, bias, stride, padding, dilation, transposed, output_padding, groups);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3112,7 +3112,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(convolution_backward)(grad_output, input, weight, bias_sizes, stride, padding, dilation, transposed, output_padding, groups, output_mask);
+    return at::_ops::convolution_backward::call(grad_output, input, weight, bias_sizes, stride, padding, dilation, transposed, output_padding, groups, output_mask);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -3133,7 +3133,7 @@ at::Tensor convolution_overrideable_generated_plumbing(const at::Tensor & input,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(convolution_overrideable)(input, weight, bias, stride, padding, dilation, transposed, output_padding, groups);
+    return at::_ops::convolution_overrideable::call(input, weight, bias, stride, padding, dilation, transposed, output_padding, groups);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3156,7 +3156,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(convolution_backward_overrideable)(grad_output, input, weight, stride, padding, dilation, transposed, output_padding, groups, output_mask);
+    return at::_ops::convolution_backward_overrideable::call(grad_output, input, weight, stride, padding, dilation, transposed, output_padding, groups, output_mask);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -3177,7 +3177,7 @@ at::Tensor _convolution_generated_plumbing(const at::Tensor & input, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(_convolution)(input, weight, bias, stride, padding, dilation, transposed, output_padding, groups, benchmark, deterministic, cudnn_enabled, allow_tf32);
+    return at::_ops::_convolution::call(input, weight, bias, stride, padding, dilation, transposed, output_padding, groups, benchmark, deterministic, cudnn_enabled, allow_tf32);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3200,7 +3200,7 @@ at::Tensor _convolution_deprecated_generated_plumbing(const at::Tensor & input, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN2(_convolution, deprecated)(input, weight, bias, stride, padding, dilation, transposed, output_padding, groups, benchmark, deterministic, cudnn_enabled);
+    return at::_ops::_convolution_deprecated::call(input, weight, bias, stride, padding, dilation, transposed, output_padding, groups, benchmark, deterministic, cudnn_enabled);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3223,7 +3223,7 @@ at::Tensor _convolution_mode_generated_plumbing(const at::Tensor & input, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(_convolution_mode)(input, weight, bias, stride, padding, dilation, groups);
+    return at::_ops::_convolution_mode::call(input, weight, bias, stride, padding, dilation, groups);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3246,7 +3246,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(ggI, cur_level) && !isBatchedAtLevel(ggW, cur_level) && !isBatchedAtLevel(ggb, cur_level) && !isBatchedAtLevel(gO, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_convolution_double_backward)(ggI, ggW, ggb, gO, weight, self, stride, padding, dilation, transposed, output_padding, groups, output_mask);
+    return at::_ops::_convolution_double_backward::call(ggI, ggW, ggb, gO, weight, self, stride, padding, dilation, transposed, output_padding, groups, output_mask);
   }
   Tensor gO_value;
   optional<int64_t> gO_bdim;
@@ -3282,7 +3282,7 @@ at::Tensor conv1d_generated_plumbing(const at::Tensor & input, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(conv1d)(input, weight, bias, stride, padding, dilation, groups);
+    return at::_ops::conv1d::call(input, weight, bias, stride, padding, dilation, groups);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3305,7 +3305,7 @@ at::Tensor conv2d_generated_plumbing(const at::Tensor & input, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(conv2d)(input, weight, bias, stride, padding, dilation, groups);
+    return at::_ops::conv2d::call(input, weight, bias, stride, padding, dilation, groups);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3328,7 +3328,7 @@ at::Tensor conv3d_generated_plumbing(const at::Tensor & input, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(conv3d)(input, weight, bias, stride, padding, dilation, groups);
+    return at::_ops::conv3d::call(input, weight, bias, stride, padding, dilation, groups);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3351,7 +3351,7 @@ at::Tensor conv1d_padding_generated_plumbing(const at::Tensor & input, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN2(conv1d, padding)(input, weight, bias, stride, padding, dilation, groups);
+    return at::_ops::conv1d_padding::call(input, weight, bias, stride, padding, dilation, groups);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3374,7 +3374,7 @@ at::Tensor conv2d_padding_generated_plumbing(const at::Tensor & input, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN2(conv2d, padding)(input, weight, bias, stride, padding, dilation, groups);
+    return at::_ops::conv2d_padding::call(input, weight, bias, stride, padding, dilation, groups);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3397,7 +3397,7 @@ at::Tensor conv3d_padding_generated_plumbing(const at::Tensor & input, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN2(conv3d, padding)(input, weight, bias, stride, padding, dilation, groups);
+    return at::_ops::conv3d_padding::call(input, weight, bias, stride, padding, dilation, groups);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3420,7 +3420,7 @@ at::Tensor conv_tbc_generated_plumbing(const at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(conv_tbc)(self, weight, bias, pad);
+    return at::_ops::conv_tbc::call(self, weight, bias, pad);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3441,7 +3441,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(conv_tbc_backward)(self, input, weight, bias, pad);
+    return at::_ops::conv_tbc_backward::call(self, input, weight, bias, pad);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3465,7 +3465,7 @@ at::Tensor conv_transpose1d_generated_plumbing(const at::Tensor & input, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(conv_transpose1d)(input, weight, bias, stride, padding, output_padding, groups, dilation);
+    return at::_ops::conv_transpose1d::call(input, weight, bias, stride, padding, output_padding, groups, dilation);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3488,7 +3488,7 @@ at::Tensor conv_transpose2d_input_generated_plumbing(const at::Tensor & input, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN2(conv_transpose2d, input)(input, weight, bias, stride, padding, output_padding, groups, dilation);
+    return at::_ops::conv_transpose2d_input::call(input, weight, bias, stride, padding, output_padding, groups, dilation);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3511,7 +3511,7 @@ at::Tensor conv_transpose3d_input_generated_plumbing(const at::Tensor & input, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN2(conv_transpose3d, input)(input, weight, bias, stride, padding, output_padding, groups, dilation);
+    return at::_ops::conv_transpose3d_input::call(input, weight, bias, stride, padding, output_padding, groups, dilation);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3534,7 +3534,7 @@ at::Tensor & copy__generated_plumbing(at::Tensor & self, const at::Tensor & src,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(src, cur_level)) {
-    return ATEN_FN(copy_)(self, src, non_blocking);
+    return at::_ops::copy_::call(self, src, non_blocking);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3552,7 +3552,7 @@ at::Tensor _copy_from_generated_plumbing(const at::Tensor & self, const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(dst, cur_level)) {
-    return ATEN_FN(_copy_from)(self, dst, non_blocking);
+    return at::_ops::_copy_from::call(self, dst, non_blocking);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3570,7 +3570,7 @@ at::Tensor _copy_from_and_resize_generated_plumbing(const at::Tensor & self, con
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(dst, cur_level)) {
-    return ATEN_FN(_copy_from_and_resize)(self, dst);
+    return at::_ops::_copy_from_and_resize::call(self, dst);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3588,7 +3588,7 @@ at::Tensor cos_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(cos)(self);
+    return at::_ops::cos::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3603,7 +3603,7 @@ at::Tensor & cos__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(cos_)(self);
+    return at::_ops::cos_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3618,7 +3618,7 @@ at::Tensor cosh_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(cosh)(self);
+    return at::_ops::cosh::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3633,7 +3633,7 @@ at::Tensor & cosh__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(cosh_)(self);
+    return at::_ops::cosh_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3648,7 +3648,7 @@ at::Tensor cosine_embedding_loss_generated_plumbing(const at::Tensor & input1, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input1, cur_level) && !isBatchedAtLevel(input2, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(cosine_embedding_loss)(input1, input2, target, margin, reduction);
+    return at::_ops::cosine_embedding_loss::call(input1, input2, target, margin, reduction);
   }
   Tensor input1_value;
   optional<int64_t> input1_bdim;
@@ -3669,7 +3669,7 @@ at::Tensor count_nonzero_dim_IntList_generated_plumbing(const at::Tensor & self,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(count_nonzero, dim_IntList)(self, dim);
+    return at::_ops::count_nonzero_dim_IntList::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3684,7 +3684,7 @@ at::Tensor count_nonzero_generated_plumbing(const at::Tensor & self, c10::option
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(count_nonzero)(self, dim);
+    return at::_ops::count_nonzero::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3699,7 +3699,7 @@ at::Tensor cov_generated_plumbing(const at::Tensor & self, int64_t correction, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(fweights, cur_level) && !isBatchedAtLevel(aweights, cur_level)) {
-    return ATEN_FN(cov)(self, correction, fweights, aweights);
+    return at::_ops::cov::call(self, correction, fweights, aweights);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3724,7 +3724,7 @@ at::Tensor corrcoef_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(corrcoef)(self);
+    return at::_ops::corrcoef::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3739,7 +3739,7 @@ at::Tensor cudnn_affine_grid_generator_generated_plumbing(const at::Tensor & the
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(theta, cur_level)) {
-    return ATEN_FN(cudnn_affine_grid_generator)(theta, N, C, H, W);
+    return at::_ops::cudnn_affine_grid_generator::call(theta, N, C, H, W);
   }
   Tensor theta_value;
   optional<int64_t> theta_bdim;
@@ -3754,7 +3754,7 @@ at::Tensor cudnn_affine_grid_generator_backward_generated_plumbing(const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level)) {
-    return ATEN_FN(cudnn_affine_grid_generator_backward)(grad, N, C, H, W);
+    return at::_ops::cudnn_affine_grid_generator_backward::call(grad, N, C, H, W);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -3769,7 +3769,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level) && !isBatchedAtLevel(running_mean, cur_level) && !isBatchedAtLevel(running_var, cur_level)) {
-    return ATEN_FN(cudnn_batch_norm)(input, weight, bias, running_mean, running_var, training, exponential_average_factor, epsilon);
+    return at::_ops::cudnn_batch_norm::call(input, weight, bias, running_mean, running_var, training, exponential_average_factor, epsilon);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3802,7 +3802,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(running_mean, cur_level) && !isBatchedAtLevel(running_var, cur_level) && !isBatchedAtLevel(save_mean, cur_level) && !isBatchedAtLevel(save_var, cur_level) && !isBatchedAtLevel(reserveSpace, cur_level)) {
-    return ATEN_FN(cudnn_batch_norm_backward)(input, grad_output, weight, running_mean, running_var, save_mean, save_var, epsilon, reserveSpace);
+    return at::_ops::cudnn_batch_norm_backward::call(input, grad_output, weight, running_mean, running_var, save_mean, save_var, epsilon, reserveSpace);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -3846,7 +3846,7 @@ at::Tensor cudnn_convolution_generated_plumbing(const at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(cudnn_convolution)(self, weight, padding, stride, dilation, groups, benchmark, deterministic, allow_tf32);
+    return at::_ops::cudnn_convolution::call(self, weight, padding, stride, dilation, groups, benchmark, deterministic, allow_tf32);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3864,7 +3864,7 @@ at::Tensor cudnn_convolution_transpose_generated_plumbing(const at::Tensor & sel
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(cudnn_convolution_transpose)(self, weight, padding, output_padding, stride, dilation, groups, benchmark, deterministic, allow_tf32);
+    return at::_ops::cudnn_convolution_transpose::call(self, weight, padding, output_padding, stride, dilation, groups, benchmark, deterministic, allow_tf32);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3882,7 +3882,7 @@ at::Tensor cudnn_convolution_relu_generated_plumbing(const at::Tensor & self, co
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(cudnn_convolution_relu)(self, weight, bias, stride, padding, dilation, groups);
+    return at::_ops::cudnn_convolution_relu::call(self, weight, bias, stride, padding, dilation, groups);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3905,7 +3905,7 @@ at::Tensor cudnn_convolution_add_relu_generated_plumbing(const at::Tensor & self
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(z, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(cudnn_convolution_add_relu)(self, weight, z, alpha, bias, stride, padding, dilation, groups);
+    return at::_ops::cudnn_convolution_add_relu::call(self, weight, z, alpha, bias, stride, padding, dilation, groups);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3931,7 +3931,7 @@ at::Tensor cudnn_grid_sampler_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(grid, cur_level)) {
-    return ATEN_FN(cudnn_grid_sampler)(self, grid);
+    return at::_ops::cudnn_grid_sampler::call(self, grid);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3949,7 +3949,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(grid, cur_level) && !isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(cudnn_grid_sampler_backward)(self, grid, grad_output);
+    return at::_ops::cudnn_grid_sampler_backward::call(self, grid, grad_output);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3970,7 +3970,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(cummax)(self, dim);
+    return at::_ops::cummax::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -3985,7 +3985,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(cummax, dimname)(self, dim);
+    return at::_ops::cummax_dimname::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4000,7 +4000,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(cummin)(self, dim);
+    return at::_ops::cummin::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4015,7 +4015,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(cummin, dimname)(self, dim);
+    return at::_ops::cummin_dimname::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4030,7 +4030,7 @@ at::Tensor cummaxmin_backward_generated_plumbing(const at::Tensor & grad, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(cummaxmin_backward)(grad, input, indices, dim);
+    return at::_ops::cummaxmin_backward::call(grad, input, indices, dim);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -4051,7 +4051,7 @@ at::Tensor cumprod_generated_plumbing(const at::Tensor & self, int64_t dim, c10:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(cumprod)(self, dim, dtype);
+    return at::_ops::cumprod::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4066,7 +4066,7 @@ at::Tensor & cumprod__generated_plumbing(at::Tensor & self, int64_t dim, c10::op
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(cumprod_)(self, dim, dtype);
+    return at::_ops::cumprod_::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4081,7 +4081,7 @@ at::Tensor cumprod_dimname_generated_plumbing(const at::Tensor & self, at::Dimna
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(cumprod, dimname)(self, dim, dtype);
+    return at::_ops::cumprod_dimname::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4096,7 +4096,7 @@ at::Tensor & cumprod__dimname_generated_plumbing(at::Tensor & self, at::Dimname 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(cumprod_, dimname)(self, dim, dtype);
+    return at::_ops::cumprod__dimname::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4111,7 +4111,7 @@ at::Tensor cumprod_backward_generated_plumbing(const at::Tensor & grad, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(output, cur_level)) {
-    return ATEN_FN(cumprod_backward)(grad, input, dim, output);
+    return at::_ops::cumprod_backward::call(grad, input, dim, output);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -4132,7 +4132,7 @@ at::Tensor cumsum_generated_plumbing(const at::Tensor & self, int64_t dim, c10::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(cumsum)(self, dim, dtype);
+    return at::_ops::cumsum::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4147,7 +4147,7 @@ at::Tensor & cumsum__generated_plumbing(at::Tensor & self, int64_t dim, c10::opt
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(cumsum_)(self, dim, dtype);
+    return at::_ops::cumsum_::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4162,7 +4162,7 @@ at::Tensor cumsum_dimname_generated_plumbing(const at::Tensor & self, at::Dimnam
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(cumsum, dimname)(self, dim, dtype);
+    return at::_ops::cumsum_dimname::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4177,7 +4177,7 @@ at::Tensor & cumsum__dimname_generated_plumbing(at::Tensor & self, at::Dimname d
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(cumsum_, dimname)(self, dim, dtype);
+    return at::_ops::cumsum__dimname::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4192,7 +4192,7 @@ at::Tensor cumulative_trapezoid_x_generated_plumbing(const at::Tensor & y, const
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(y, cur_level) && !isBatchedAtLevel(x, cur_level)) {
-    return ATEN_FN2(cumulative_trapezoid, x)(y, x, dim);
+    return at::_ops::cumulative_trapezoid_x::call(y, x, dim);
   }
   Tensor y_value;
   optional<int64_t> y_bdim;
@@ -4210,7 +4210,7 @@ at::Tensor cumulative_trapezoid_dx_generated_plumbing(const at::Tensor & y, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(y, cur_level)) {
-    return ATEN_FN2(cumulative_trapezoid, dx)(y, dx, dim);
+    return at::_ops::cumulative_trapezoid_dx::call(y, dx, dim);
   }
   Tensor y_value;
   optional<int64_t> y_bdim;
@@ -4225,7 +4225,7 @@ at::Tensor ctc_loss_IntList_generated_plumbing(const at::Tensor & log_probs, con
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(log_probs, cur_level) && !isBatchedAtLevel(targets, cur_level)) {
-    return ATEN_FN2(ctc_loss, IntList)(log_probs, targets, input_lengths, target_lengths, blank, reduction, zero_infinity);
+    return at::_ops::ctc_loss_IntList::call(log_probs, targets, input_lengths, target_lengths, blank, reduction, zero_infinity);
   }
   Tensor log_probs_value;
   optional<int64_t> log_probs_bdim;
@@ -4243,7 +4243,7 @@ at::Tensor ctc_loss_Tensor_generated_plumbing(const at::Tensor & log_probs, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(log_probs, cur_level) && !isBatchedAtLevel(targets, cur_level) && !isBatchedAtLevel(input_lengths, cur_level) && !isBatchedAtLevel(target_lengths, cur_level)) {
-    return ATEN_FN2(ctc_loss, Tensor)(log_probs, targets, input_lengths, target_lengths, blank, reduction, zero_infinity);
+    return at::_ops::ctc_loss_Tensor::call(log_probs, targets, input_lengths, target_lengths, blank, reduction, zero_infinity);
   }
   Tensor log_probs_value;
   optional<int64_t> log_probs_bdim;
@@ -4267,7 +4267,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(log_probs, cur_level) && !isBatchedAtLevel(targets, cur_level)) {
-    return ATEN_FN(_ctc_loss)(log_probs, targets, input_lengths, target_lengths, blank, zero_infinity);
+    return at::_ops::_ctc_loss::call(log_probs, targets, input_lengths, target_lengths, blank, zero_infinity);
   }
   Tensor log_probs_value;
   optional<int64_t> log_probs_bdim;
@@ -4285,7 +4285,7 @@ at::Tensor _ctc_loss_backward_generated_plumbing(const at::Tensor & grad, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(log_probs, cur_level) && !isBatchedAtLevel(targets, cur_level) && !isBatchedAtLevel(neg_log_likelihood, cur_level) && !isBatchedAtLevel(log_alpha, cur_level)) {
-    return ATEN_FN(_ctc_loss_backward)(grad, log_probs, targets, input_lengths, target_lengths, neg_log_likelihood, log_alpha, blank, zero_infinity);
+    return at::_ops::_ctc_loss_backward::call(grad, log_probs, targets, input_lengths, target_lengths, neg_log_likelihood, log_alpha, blank, zero_infinity);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -4312,7 +4312,7 @@ at::Tensor diag_embed_generated_plumbing(const at::Tensor & self, int64_t offset
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(diag_embed)(self, offset, dim1, dim2);
+    return at::_ops::diag_embed::call(self, offset, dim1, dim2);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4327,7 +4327,7 @@ at::Tensor diagflat_generated_plumbing(const at::Tensor & self, int64_t offset) 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(diagflat)(self, offset);
+    return at::_ops::diagflat::call(self, offset);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4342,7 +4342,7 @@ at::Tensor diagonal_generated_plumbing(const at::Tensor & self, int64_t offset, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(diagonal)(self, offset, dim1, dim2);
+    return at::_ops::diagonal::call(self, offset, dim1, dim2);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4357,7 +4357,7 @@ at::Tensor linalg_diagonal_generated_plumbing(const at::Tensor & A, int64_t offs
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(A, cur_level)) {
-    return ATEN_FN(linalg_diagonal)(A, offset, dim1, dim2);
+    return at::_ops::linalg_diagonal::call(A, offset, dim1, dim2);
   }
   Tensor A_value;
   optional<int64_t> A_bdim;
@@ -4372,7 +4372,7 @@ at::Tensor diagonal_Dimname_generated_plumbing(const at::Tensor & self, at::Dimn
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(diagonal, Dimname)(self, outdim, dim1, dim2, offset);
+    return at::_ops::diagonal_Dimname::call(self, outdim, dim1, dim2, offset);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4387,7 +4387,7 @@ at::Tensor diagonal_backward_generated_plumbing(const at::Tensor & grad_output, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(diagonal_backward)(grad_output, input_sizes, offset, dim1, dim2);
+    return at::_ops::diagonal_backward::call(grad_output, input_sizes, offset, dim1, dim2);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -4402,7 +4402,7 @@ at::Tensor & fill_diagonal__generated_plumbing(at::Tensor & self, const at::Scal
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fill_diagonal_)(self, fill_value, wrap);
+    return at::_ops::fill_diagonal_::call(self, fill_value, wrap);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4417,7 +4417,7 @@ at::Tensor diff_generated_plumbing(const at::Tensor & self, int64_t n, int64_t d
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(prepend, cur_level) && !isBatchedAtLevel(append, cur_level)) {
-    return ATEN_FN(diff)(self, n, dim, prepend, append);
+    return at::_ops::diff::call(self, n, dim, prepend, append);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4442,7 +4442,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(gradient, scalarint)(self, spacing, dim, edge_order);
+    return at::_ops::gradient_scalarint::call(self, spacing, dim, edge_order);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4457,7 +4457,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(gradient, scalararray)(self, spacing, dim, edge_order);
+    return at::_ops::gradient_scalararray::call(self, spacing, dim, edge_order);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4472,7 +4472,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(gradient, array)(self, dim, edge_order);
+    return at::_ops::gradient_array::call(self, dim, edge_order);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4487,7 +4487,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(gradient, scalarrayint)(self, spacing, dim, edge_order);
+    return at::_ops::gradient_scalarrayint::call(self, spacing, dim, edge_order);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4502,7 +4502,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(gradient, scalarrayarray)(self, spacing, dim, edge_order);
+    return at::_ops::gradient_scalarrayarray::call(self, spacing, dim, edge_order);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4517,7 +4517,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(spacing, cur_level)) {
-    return ATEN_FN2(gradient, tensorarrayint)(self, spacing, dim, edge_order);
+    return at::_ops::gradient_tensorarrayint::call(self, spacing, dim, edge_order);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4532,7 +4532,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(spacing, cur_level)) {
-    return ATEN_FN2(gradient, tensorarray)(self, spacing, dim, edge_order);
+    return at::_ops::gradient_tensorarray::call(self, spacing, dim, edge_order);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4547,7 +4547,7 @@ at::Tensor div_Tensor_generated_plumbing(const at::Tensor & self, const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(div, Tensor)(self, other);
+    return at::_ops::div_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4565,7 +4565,7 @@ at::Tensor & div__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(div_, Tensor)(self, other);
+    return at::_ops::div__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4583,7 +4583,7 @@ at::Tensor div_Tensor_mode_generated_plumbing(const at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(div, Tensor_mode)(self, other, rounding_mode);
+    return at::_ops::div_Tensor_mode::call(self, other, rounding_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4601,7 +4601,7 @@ at::Tensor & div__Tensor_mode_generated_plumbing(at::Tensor & self, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(div_, Tensor_mode)(self, other, rounding_mode);
+    return at::_ops::div__Tensor_mode::call(self, other, rounding_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4619,7 +4619,7 @@ at::Tensor div_Scalar_generated_plumbing(const at::Tensor & self, const at::Scal
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(div, Scalar)(self, other);
+    return at::_ops::div_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4634,7 +4634,7 @@ at::Tensor & div__Scalar_generated_plumbing(at::Tensor & self, const at::Scalar 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(div_, Scalar)(self, other);
+    return at::_ops::div__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4649,7 +4649,7 @@ at::Tensor div_Scalar_mode_generated_plumbing(const at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(div, Scalar_mode)(self, other, rounding_mode);
+    return at::_ops::div_Scalar_mode::call(self, other, rounding_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4664,7 +4664,7 @@ at::Tensor & div__Scalar_mode_generated_plumbing(at::Tensor & self, const at::Sc
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(div_, Scalar_mode)(self, other, rounding_mode);
+    return at::_ops::div__Scalar_mode::call(self, other, rounding_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4679,7 +4679,7 @@ at::Tensor divide_Tensor_generated_plumbing(const at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(divide, Tensor)(self, other);
+    return at::_ops::divide_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4697,7 +4697,7 @@ at::Tensor & divide__Tensor_generated_plumbing(at::Tensor & self, const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(divide_, Tensor)(self, other);
+    return at::_ops::divide__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4715,7 +4715,7 @@ at::Tensor divide_Scalar_generated_plumbing(const at::Tensor & self, const at::S
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(divide, Scalar)(self, other);
+    return at::_ops::divide_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4730,7 +4730,7 @@ at::Tensor & divide__Scalar_generated_plumbing(at::Tensor & self, const at::Scal
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(divide_, Scalar)(self, other);
+    return at::_ops::divide__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4745,7 +4745,7 @@ at::Tensor divide_Tensor_mode_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(divide, Tensor_mode)(self, other, rounding_mode);
+    return at::_ops::divide_Tensor_mode::call(self, other, rounding_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4763,7 +4763,7 @@ at::Tensor & divide__Tensor_mode_generated_plumbing(at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(divide_, Tensor_mode)(self, other, rounding_mode);
+    return at::_ops::divide__Tensor_mode::call(self, other, rounding_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4781,7 +4781,7 @@ at::Tensor divide_Scalar_mode_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(divide, Scalar_mode)(self, other, rounding_mode);
+    return at::_ops::divide_Scalar_mode::call(self, other, rounding_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4796,7 +4796,7 @@ at::Tensor & divide__Scalar_mode_generated_plumbing(at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(divide_, Scalar_mode)(self, other, rounding_mode);
+    return at::_ops::divide__Scalar_mode::call(self, other, rounding_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4811,7 +4811,7 @@ at::Tensor true_divide_Tensor_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(true_divide, Tensor)(self, other);
+    return at::_ops::true_divide_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4829,7 +4829,7 @@ at::Tensor & true_divide__Tensor_generated_plumbing(at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(true_divide_, Tensor)(self, other);
+    return at::_ops::true_divide__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4847,7 +4847,7 @@ at::Tensor true_divide_Scalar_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(true_divide, Scalar)(self, other);
+    return at::_ops::true_divide_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4862,7 +4862,7 @@ at::Tensor & true_divide__Scalar_generated_plumbing(at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(true_divide_, Scalar)(self, other);
+    return at::_ops::true_divide__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4877,7 +4877,7 @@ at::Tensor dot_generated_plumbing(const at::Tensor & self, const at::Tensor & te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(tensor, cur_level)) {
-    return ATEN_FN(dot)(self, tensor);
+    return at::_ops::dot::call(self, tensor);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4895,7 +4895,7 @@ at::Tensor vdot_generated_plumbing(const at::Tensor & self, const at::Tensor & o
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(vdot)(self, other);
+    return at::_ops::vdot::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4913,7 +4913,7 @@ at::Tensor einsum_generated_plumbing(c10::string_view equation, at::TensorList t
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(einsum)(equation, tensors);
+    return at::_ops::einsum::call(equation, tensors);
   }
 
   auto results = batch_rule(equation, tensors);
@@ -4926,7 +4926,7 @@ at::Tensor embedding_generated_plumbing(const at::Tensor & weight, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(embedding)(weight, indices, padding_idx, scale_grad_by_freq, sparse);
+    return at::_ops::embedding::call(weight, indices, padding_idx, scale_grad_by_freq, sparse);
   }
   Tensor weight_value;
   optional<int64_t> weight_bdim;
@@ -4944,7 +4944,7 @@ at::Tensor embedding_backward_generated_plumbing(const at::Tensor & grad, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(embedding_backward)(grad, indices, num_weights, padding_idx, scale_grad_by_freq, sparse);
+    return at::_ops::embedding_backward::call(grad, indices, num_weights, padding_idx, scale_grad_by_freq, sparse);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -4962,7 +4962,7 @@ at::Tensor embedding_dense_backward_generated_plumbing(const at::Tensor & grad_o
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(embedding_dense_backward)(grad_output, indices, num_weights, padding_idx, scale_grad_by_freq);
+    return at::_ops::embedding_dense_backward::call(grad_output, indices, num_weights, padding_idx, scale_grad_by_freq);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -4980,7 +4980,7 @@ at::Tensor & embedding_renorm__generated_plumbing(at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(embedding_renorm_)(self, indices, max_norm, norm_type);
+    return at::_ops::embedding_renorm_::call(self, indices, max_norm, norm_type);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -4998,7 +4998,7 @@ at::Tensor embedding_sparse_backward_generated_plumbing(const at::Tensor & grad,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(embedding_sparse_backward)(grad, indices, num_weights, padding_idx, scale_grad_by_freq);
+    return at::_ops::embedding_sparse_backward::call(grad, indices, num_weights, padding_idx, scale_grad_by_freq);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -5016,7 +5016,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(offsets, cur_level) && !isBatchedAtLevel(per_sample_weights, cur_level)) {
-    return ATEN_FN(_embedding_bag_forward_only)(weight, indices, offsets, scale_grad_by_freq, mode, sparse, per_sample_weights, include_last_offset, padding_idx);
+    return at::_ops::_embedding_bag_forward_only::call(weight, indices, offsets, scale_grad_by_freq, mode, sparse, per_sample_weights, include_last_offset, padding_idx);
   }
   Tensor weight_value;
   optional<int64_t> weight_bdim;
@@ -5042,7 +5042,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(mask, cur_level)) {
-    return ATEN_FN(_rowwise_prune)(weight, mask, compressed_indices_dtype);
+    return at::_ops::_rowwise_prune::call(weight, mask, compressed_indices_dtype);
   }
   Tensor weight_value;
   optional<int64_t> weight_bdim;
@@ -5060,7 +5060,7 @@ at::Tensor row_stack_generated_plumbing(at::TensorList tensors) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(row_stack)(tensors);
+    return at::_ops::row_stack::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -5073,7 +5073,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(offsets, cur_level) && !isBatchedAtLevel(per_sample_weights, cur_level)) {
-    return ATEN_FN(embedding_bag)(weight, indices, offsets, scale_grad_by_freq, mode, sparse, per_sample_weights, include_last_offset);
+    return at::_ops::embedding_bag::call(weight, indices, offsets, scale_grad_by_freq, mode, sparse, per_sample_weights, include_last_offset);
   }
   Tensor weight_value;
   optional<int64_t> weight_bdim;
@@ -5099,7 +5099,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(offsets, cur_level) && !isBatchedAtLevel(per_sample_weights, cur_level)) {
-    return ATEN_FN2(embedding_bag, padding_idx)(weight, indices, offsets, scale_grad_by_freq, mode, sparse, per_sample_weights, include_last_offset, padding_idx);
+    return at::_ops::embedding_bag_padding_idx::call(weight, indices, offsets, scale_grad_by_freq, mode, sparse, per_sample_weights, include_last_offset, padding_idx);
   }
   Tensor weight_value;
   optional<int64_t> weight_bdim;
@@ -5125,7 +5125,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(offsets, cur_level) && !isBatchedAtLevel(per_sample_weights, cur_level)) {
-    return ATEN_FN(_embedding_bag)(weight, indices, offsets, scale_grad_by_freq, mode, sparse, per_sample_weights, include_last_offset, padding_idx);
+    return at::_ops::_embedding_bag::call(weight, indices, offsets, scale_grad_by_freq, mode, sparse, per_sample_weights, include_last_offset, padding_idx);
   }
   Tensor weight_value;
   optional<int64_t> weight_bdim;
@@ -5151,7 +5151,7 @@ at::Tensor _embedding_bag_backward_generated_plumbing(const at::Tensor & grad, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(offsets, cur_level) && !isBatchedAtLevel(offset2bag, cur_level) && !isBatchedAtLevel(bag_size, cur_level) && !isBatchedAtLevel(maximum_indices, cur_level) && !isBatchedAtLevel(per_sample_weights, cur_level)) {
-    return ATEN_FN(_embedding_bag_backward)(grad, indices, offsets, offset2bag, bag_size, maximum_indices, num_weights, scale_grad_by_freq, mode, sparse, per_sample_weights, padding_idx);
+    return at::_ops::_embedding_bag_backward::call(grad, indices, offsets, offset2bag, bag_size, maximum_indices, num_weights, scale_grad_by_freq, mode, sparse, per_sample_weights, padding_idx);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -5186,7 +5186,7 @@ at::Tensor _embedding_bag_sparse_backward_generated_plumbing(const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(offsets, cur_level) && !isBatchedAtLevel(offset2bag, cur_level) && !isBatchedAtLevel(bag_size, cur_level) && !isBatchedAtLevel(per_sample_weights, cur_level)) {
-    return ATEN_FN(_embedding_bag_sparse_backward)(grad, indices, offsets, offset2bag, bag_size, num_weights, scale_grad_by_freq, mode, per_sample_weights, padding_idx);
+    return at::_ops::_embedding_bag_sparse_backward::call(grad, indices, offsets, offset2bag, bag_size, num_weights, scale_grad_by_freq, mode, per_sample_weights, padding_idx);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -5218,7 +5218,7 @@ at::Tensor _embedding_bag_dense_backward_generated_plumbing(const at::Tensor & g
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(offset2bag, cur_level) && !isBatchedAtLevel(bag_size, cur_level) && !isBatchedAtLevel(maximum_indices, cur_level) && !isBatchedAtLevel(per_sample_weights, cur_level)) {
-    return ATEN_FN(_embedding_bag_dense_backward)(grad, indices, offset2bag, bag_size, maximum_indices, num_weights, scale_grad_by_freq, mode, per_sample_weights, padding_idx);
+    return at::_ops::_embedding_bag_dense_backward::call(grad, indices, offset2bag, bag_size, maximum_indices, num_weights, scale_grad_by_freq, mode, per_sample_weights, padding_idx);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -5250,7 +5250,7 @@ at::Tensor _embedding_bag_per_sample_weights_backward_generated_plumbing(const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(offsets, cur_level) && !isBatchedAtLevel(offset2bag, cur_level)) {
-    return ATEN_FN(_embedding_bag_per_sample_weights_backward)(grad, weight, indices, offsets, offset2bag, mode, padding_idx);
+    return at::_ops::_embedding_bag_per_sample_weights_backward::call(grad, weight, indices, offsets, offset2bag, mode, padding_idx);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -5277,7 +5277,7 @@ at::Tensor new_empty_generated_plumbing(const at::Tensor & self, at::IntArrayRef
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(new_empty)(self, size, dtype, layout, device, pin_memory);
+    return at::_ops::new_empty::call(self, size, dtype, layout, device, pin_memory);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5292,7 +5292,7 @@ at::Tensor new_empty_strided_generated_plumbing(const at::Tensor & self, at::Int
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(new_empty_strided)(self, size, stride, dtype, layout, device, pin_memory);
+    return at::_ops::new_empty_strided::call(self, size, stride, dtype, layout, device, pin_memory);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5307,7 +5307,7 @@ at::Tensor new_full_generated_plumbing(const at::Tensor & self, at::IntArrayRef 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(new_full)(self, size, fill_value, dtype, layout, device, pin_memory);
+    return at::_ops::new_full::call(self, size, fill_value, dtype, layout, device, pin_memory);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5322,7 +5322,7 @@ at::Tensor new_zeros_generated_plumbing(const at::Tensor & self, at::IntArrayRef
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(new_zeros)(self, size, dtype, layout, device, pin_memory);
+    return at::_ops::new_zeros::call(self, size, dtype, layout, device, pin_memory);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5337,7 +5337,7 @@ at::Tensor new_ones_generated_plumbing(const at::Tensor & self, at::IntArrayRef 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(new_ones)(self, size, dtype, layout, device, pin_memory);
+    return at::_ops::new_ones::call(self, size, dtype, layout, device, pin_memory);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5352,7 +5352,7 @@ at::Tensor _empty_per_channel_affine_quantized_generated_plumbing(at::IntArrayRe
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(scales, cur_level) && !isBatchedAtLevel(zero_points, cur_level)) {
-    return ATEN_FN(_empty_per_channel_affine_quantized)(size, scales, zero_points, axis, dtype, layout, device, pin_memory, memory_format);
+    return at::_ops::_empty_per_channel_affine_quantized::call(size, scales, zero_points, axis, dtype, layout, device, pin_memory, memory_format);
   }
   Tensor scales_value;
   optional<int64_t> scales_bdim;
@@ -5370,7 +5370,7 @@ const at::Tensor & resize__generated_plumbing(const at::Tensor & self, at::IntAr
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(resize_)(self, size, memory_format);
+    return at::_ops::resize_::call(self, size, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5385,7 +5385,7 @@ at::Tensor empty_quantized_generated_plumbing(at::IntArrayRef size, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(qtensor, cur_level)) {
-    return ATEN_FN(empty_quantized)(size, qtensor, dtype, layout, device, pin_memory, memory_format);
+    return at::_ops::empty_quantized::call(size, qtensor, dtype, layout, device, pin_memory, memory_format);
   }
   Tensor qtensor_value;
   optional<int64_t> qtensor_bdim;
@@ -5400,7 +5400,7 @@ at::Tensor empty_like_generated_plumbing(const at::Tensor & self, c10::optional<
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(empty_like)(self, dtype, layout, device, pin_memory, memory_format);
+    return at::_ops::empty_like::call(self, dtype, layout, device, pin_memory, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5415,7 +5415,7 @@ at::Tensor erf_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(erf)(self);
+    return at::_ops::erf::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5430,7 +5430,7 @@ at::Tensor & erf__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(erf_)(self);
+    return at::_ops::erf_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5445,7 +5445,7 @@ at::Tensor erfc_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(erfc)(self);
+    return at::_ops::erfc::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5460,7 +5460,7 @@ at::Tensor & erfc__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(erfc_)(self);
+    return at::_ops::erfc_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5475,7 +5475,7 @@ at::Tensor exp_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(exp)(self);
+    return at::_ops::exp::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5490,7 +5490,7 @@ at::Tensor & exp__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(exp_)(self);
+    return at::_ops::exp_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5505,7 +5505,7 @@ at::Tensor exp2_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(exp2)(self);
+    return at::_ops::exp2::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5520,7 +5520,7 @@ at::Tensor & exp2__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(exp2_)(self);
+    return at::_ops::exp2_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5535,7 +5535,7 @@ at::Tensor expm1_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(expm1)(self);
+    return at::_ops::expm1::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5550,7 +5550,7 @@ at::Tensor & expm1__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(expm1_)(self);
+    return at::_ops::expm1_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5565,7 +5565,7 @@ at::Tensor expand_generated_plumbing(const at::Tensor & self, at::IntArrayRef si
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(expand)(self, size, implicit);
+    return at::_ops::expand::call(self, size, implicit);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5580,7 +5580,7 @@ at::Tensor expand_as_generated_plumbing(const at::Tensor & self, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(expand_as)(self, other);
+    return at::_ops::expand_as::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5598,7 +5598,7 @@ at::Tensor flatten_using_ints_generated_plumbing(const at::Tensor & self, int64_
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(flatten, using_ints)(self, start_dim, end_dim);
+    return at::_ops::flatten_using_ints::call(self, start_dim, end_dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5613,7 +5613,7 @@ at::Tensor flatten_named_out_dim_generated_plumbing(const at::Tensor & self, int
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(flatten, named_out_dim)(self, start_dim, end_dim, out_dim);
+    return at::_ops::flatten_named_out_dim::call(self, start_dim, end_dim, out_dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5628,7 +5628,7 @@ at::Tensor flatten_using_names_generated_plumbing(const at::Tensor & self, at::D
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(flatten, using_names)(self, start_dim, end_dim, out_dim);
+    return at::_ops::flatten_using_names::call(self, start_dim, end_dim, out_dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5643,7 +5643,7 @@ at::Tensor flatten_DimnameList_generated_plumbing(const at::Tensor & self, at::D
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(flatten, DimnameList)(self, dims, out_dim);
+    return at::_ops::flatten_DimnameList::call(self, dims, out_dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5658,7 +5658,7 @@ at::Tensor unflatten_int_generated_plumbing(const at::Tensor & self, int64_t dim
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(unflatten, int)(self, dim, sizes, names);
+    return at::_ops::unflatten_int::call(self, dim, sizes, names);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5673,7 +5673,7 @@ at::Tensor unflatten_Dimname_generated_plumbing(const at::Tensor & self, at::Dim
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(unflatten, Dimname)(self, dim, sizes, names);
+    return at::_ops::unflatten_Dimname::call(self, dim, sizes, names);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5688,7 +5688,7 @@ at::Tensor & fill__Scalar_generated_plumbing(at::Tensor & self, const at::Scalar
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(fill_, Scalar)(self, value);
+    return at::_ops::fill__Scalar::call(self, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5703,7 +5703,7 @@ at::Tensor & fill__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(value, cur_level)) {
-    return ATEN_FN2(fill_, Tensor)(self, value);
+    return at::_ops::fill__Tensor::call(self, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5721,7 +5721,7 @@ at::Tensor floor_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(floor)(self);
+    return at::_ops::floor::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5736,7 +5736,7 @@ at::Tensor & floor__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(floor_)(self);
+    return at::_ops::floor_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5751,7 +5751,7 @@ at::Tensor floor_divide_generated_plumbing(const at::Tensor & self, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(floor_divide)(self, other);
+    return at::_ops::floor_divide::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5769,7 +5769,7 @@ at::Tensor & floor_divide__Tensor_generated_plumbing(at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(floor_divide_, Tensor)(self, other);
+    return at::_ops::floor_divide__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5787,7 +5787,7 @@ at::Tensor floor_divide_Scalar_generated_plumbing(const at::Tensor & self, const
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(floor_divide, Scalar)(self, other);
+    return at::_ops::floor_divide_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5802,7 +5802,7 @@ at::Tensor & floor_divide__Scalar_generated_plumbing(at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(floor_divide_, Scalar)(self, other);
+    return at::_ops::floor_divide__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5817,7 +5817,7 @@ at::Tensor frac_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(frac)(self);
+    return at::_ops::frac::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5832,7 +5832,7 @@ at::Tensor & frac__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(frac_)(self);
+    return at::_ops::frac_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5847,7 +5847,7 @@ at::Tensor full_like_generated_plumbing(const at::Tensor & self, const at::Scala
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(full_like)(self, fill_value, dtype, layout, device, pin_memory, memory_format);
+    return at::_ops::full_like::call(self, fill_value, dtype, layout, device, pin_memory, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5862,7 +5862,7 @@ at::Tensor gcd_generated_plumbing(const at::Tensor & self, const at::Tensor & ot
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(gcd)(self, other);
+    return at::_ops::gcd::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5880,7 +5880,7 @@ at::Tensor & gcd__generated_plumbing(at::Tensor & self, const at::Tensor & other
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(gcd_)(self, other);
+    return at::_ops::gcd_::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5898,7 +5898,7 @@ at::Tensor lcm_generated_plumbing(const at::Tensor & self, const at::Tensor & ot
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(lcm)(self, other);
+    return at::_ops::lcm::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5916,7 +5916,7 @@ at::Tensor & lcm__generated_plumbing(at::Tensor & self, const at::Tensor & other
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(lcm_)(self, other);
+    return at::_ops::lcm_::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -5934,7 +5934,7 @@ at::Tensor grid_sampler_generated_plumbing(const at::Tensor & input, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(grid, cur_level)) {
-    return ATEN_FN(grid_sampler)(input, grid, interpolation_mode, padding_mode, align_corners);
+    return at::_ops::grid_sampler::call(input, grid, interpolation_mode, padding_mode, align_corners);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -5952,7 +5952,7 @@ at::Tensor grid_sampler_2d_generated_plumbing(const at::Tensor & input, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(grid, cur_level)) {
-    return ATEN_FN(grid_sampler_2d)(input, grid, interpolation_mode, padding_mode, align_corners);
+    return at::_ops::grid_sampler_2d::call(input, grid, interpolation_mode, padding_mode, align_corners);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -5970,7 +5970,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(grid, cur_level)) {
-    return ATEN_FN(grid_sampler_2d_backward)(grad_output, input, grid, interpolation_mode, padding_mode, align_corners, output_mask);
+    return at::_ops::grid_sampler_2d_backward::call(grad_output, input, grid, interpolation_mode, padding_mode, align_corners, output_mask);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -5991,7 +5991,7 @@ at::Tensor _grid_sampler_2d_cpu_fallback_generated_plumbing(const at::Tensor & i
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(grid, cur_level)) {
-    return ATEN_FN(_grid_sampler_2d_cpu_fallback)(input, grid, interpolation_mode, padding_mode, align_corners);
+    return at::_ops::_grid_sampler_2d_cpu_fallback::call(input, grid, interpolation_mode, padding_mode, align_corners);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6009,7 +6009,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(grid, cur_level)) {
-    return ATEN_FN(_grid_sampler_2d_cpu_fallback_backward)(grad_output, input, grid, interpolation_mode, padding_mode, align_corners);
+    return at::_ops::_grid_sampler_2d_cpu_fallback_backward::call(grad_output, input, grid, interpolation_mode, padding_mode, align_corners);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -6030,7 +6030,7 @@ at::Tensor grid_sampler_3d_generated_plumbing(const at::Tensor & input, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(grid, cur_level)) {
-    return ATEN_FN(grid_sampler_3d)(input, grid, interpolation_mode, padding_mode, align_corners);
+    return at::_ops::grid_sampler_3d::call(input, grid, interpolation_mode, padding_mode, align_corners);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6048,7 +6048,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(grid, cur_level)) {
-    return ATEN_FN(grid_sampler_3d_backward)(grad_output, input, grid, interpolation_mode, padding_mode, align_corners, output_mask);
+    return at::_ops::grid_sampler_3d_backward::call(grad_output, input, grid, interpolation_mode, padding_mode, align_corners, output_mask);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -6069,7 +6069,7 @@ at::Tensor hinge_embedding_loss_generated_plumbing(const at::Tensor & self, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(hinge_embedding_loss)(self, target, margin, reduction);
+    return at::_ops::hinge_embedding_loss::call(self, target, margin, reduction);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6087,7 +6087,7 @@ at::Tensor group_norm_generated_plumbing(const at::Tensor & input, int64_t num_g
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(group_norm)(input, num_groups, weight, bias, eps, cudnn_enabled);
+    return at::_ops::group_norm::call(input, num_groups, weight, bias, eps, cudnn_enabled);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6112,7 +6112,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(native_group_norm)(input, weight, bias, N, C, HxW, group, eps);
+    return at::_ops::native_group_norm::call(input, weight, bias, N, C, HxW, group, eps);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6137,7 +6137,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_out, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(mean, cur_level) && !isBatchedAtLevel(rstd, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(native_group_norm_backward)(grad_out, input, mean, rstd, weight, N, C, HxW, group, output_mask);
+    return at::_ops::native_group_norm_backward::call(grad_out, input, mean, rstd, weight, N, C, HxW, group, output_mask);
   }
   Tensor grad_out_value;
   optional<int64_t> grad_out_bdim;
@@ -6166,7 +6166,7 @@ at::Tensor _fft_r2c_generated_plumbing(const at::Tensor & self, at::IntArrayRef 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_fft_r2c)(self, dim, normalization, onesided);
+    return at::_ops::_fft_r2c::call(self, dim, normalization, onesided);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6181,7 +6181,7 @@ at::Tensor _fft_c2r_generated_plumbing(const at::Tensor & self, at::IntArrayRef 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_fft_c2r)(self, dim, normalization, last_dim_size);
+    return at::_ops::_fft_c2r::call(self, dim, normalization, last_dim_size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6196,7 +6196,7 @@ at::Tensor _fft_c2c_generated_plumbing(const at::Tensor & self, at::IntArrayRef 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_fft_c2c)(self, dim, normalization, forward);
+    return at::_ops::_fft_c2c::call(self, dim, normalization, forward);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6211,7 +6211,7 @@ at::Tensor index_Tensor_generated_plumbing(const at::Tensor & self, const c10::L
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN2(index, Tensor)(self, indices);
+    return at::_ops::index_Tensor::call(self, indices);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6226,7 +6226,7 @@ at::Tensor & index_copy__generated_plumbing(at::Tensor & self, int64_t dim, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(source, cur_level)) {
-    return ATEN_FN(index_copy_)(self, dim, index, source);
+    return at::_ops::index_copy_::call(self, dim, index, source);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6247,7 +6247,7 @@ at::Tensor index_copy_generated_plumbing(const at::Tensor & self, int64_t dim, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(source, cur_level)) {
-    return ATEN_FN(index_copy)(self, dim, index, source);
+    return at::_ops::index_copy::call(self, dim, index, source);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6268,7 +6268,7 @@ at::Tensor & index_copy__dimname_generated_plumbing(at::Tensor & self, at::Dimna
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(source, cur_level)) {
-    return ATEN_FN2(index_copy_, dimname)(self, dim, index, source);
+    return at::_ops::index_copy__dimname::call(self, dim, index, source);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6289,7 +6289,7 @@ at::Tensor index_copy_dimname_generated_plumbing(const at::Tensor & self, at::Di
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(source, cur_level)) {
-    return ATEN_FN2(index_copy, dimname)(self, dim, index, source);
+    return at::_ops::index_copy_dimname::call(self, dim, index, source);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6310,7 +6310,7 @@ at::Tensor & index_put__generated_plumbing(at::Tensor & self, const c10::List<c1
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN(index_put_)(self, indices, values, accumulate);
+    return at::_ops::index_put_::call(self, indices, values, accumulate);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6328,7 +6328,7 @@ at::Tensor index_put_generated_plumbing(const at::Tensor & self, const c10::List
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN(index_put)(self, indices, values, accumulate);
+    return at::_ops::index_put::call(self, indices, values, accumulate);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6346,7 +6346,7 @@ at::Tensor & _index_put_impl__generated_plumbing(at::Tensor & self, const c10::L
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN(_index_put_impl_)(self, indices, values, accumulate, unsafe);
+    return at::_ops::_index_put_impl_::call(self, indices, values, accumulate, unsafe);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6364,7 +6364,7 @@ at::Tensor instance_norm_generated_plumbing(const at::Tensor & input, const c10:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level) && !isBatchedAtLevel(running_mean, cur_level) && !isBatchedAtLevel(running_var, cur_level)) {
-    return ATEN_FN(instance_norm)(input, weight, bias, running_mean, running_var, use_input_stats, momentum, eps, cudnn_enabled);
+    return at::_ops::instance_norm::call(input, weight, bias, running_mean, running_var, use_input_stats, momentum, eps, cudnn_enabled);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6399,7 +6399,7 @@ at::Tensor inverse_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(inverse)(self);
+    return at::_ops::inverse::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6414,7 +6414,7 @@ at::Tensor isclose_generated_plumbing(const at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(isclose)(self, other, rtol, atol, equal_nan);
+    return at::_ops::isclose::call(self, other, rtol, atol, equal_nan);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6432,7 +6432,7 @@ at::Tensor isin_Tensor_Tensor_generated_plumbing(const at::Tensor & elements, co
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(elements, cur_level) && !isBatchedAtLevel(test_elements, cur_level)) {
-    return ATEN_FN2(isin, Tensor_Tensor)(elements, test_elements, assume_unique, invert);
+    return at::_ops::isin_Tensor_Tensor::call(elements, test_elements, assume_unique, invert);
   }
   Tensor elements_value;
   optional<int64_t> elements_bdim;
@@ -6450,7 +6450,7 @@ at::Tensor isin_Tensor_Scalar_generated_plumbing(const at::Tensor & elements, co
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(elements, cur_level)) {
-    return ATEN_FN2(isin, Tensor_Scalar)(elements, test_element, assume_unique, invert);
+    return at::_ops::isin_Tensor_Scalar::call(elements, test_element, assume_unique, invert);
   }
   Tensor elements_value;
   optional<int64_t> elements_bdim;
@@ -6465,7 +6465,7 @@ at::Tensor isin_Scalar_Tensor_generated_plumbing(const at::Scalar & element, con
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(test_elements, cur_level)) {
-    return ATEN_FN2(isin, Scalar_Tensor)(element, test_elements, assume_unique, invert);
+    return at::_ops::isin_Scalar_Tensor::call(element, test_elements, assume_unique, invert);
   }
   Tensor test_elements_value;
   optional<int64_t> test_elements_bdim;
@@ -6480,7 +6480,7 @@ at::Tensor isnan_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(isnan)(self);
+    return at::_ops::isnan::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6495,7 +6495,7 @@ at::Tensor isreal_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(isreal)(self);
+    return at::_ops::isreal::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6510,7 +6510,7 @@ at::Tensor kl_div_generated_plumbing(const at::Tensor & self, const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(kl_div)(self, target, reduction, log_target);
+    return at::_ops::kl_div::call(self, target, reduction, log_target);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6528,7 +6528,7 @@ at::Tensor kl_div_backward_generated_plumbing(const at::Tensor & grad_output, co
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(kl_div_backward)(grad_output, self, target, reduction, log_target);
+    return at::_ops::kl_div_backward::call(grad_output, self, target, reduction, log_target);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -6549,7 +6549,7 @@ at::Tensor kron_generated_plumbing(const at::Tensor & self, const at::Tensor & o
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(kron)(self, other);
+    return at::_ops::kron::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6567,7 +6567,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(kthvalue)(self, k, dim, keepdim);
+    return at::_ops::kthvalue::call(self, k, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6582,7 +6582,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(kthvalue, dimname)(self, k, dim, keepdim);
+    return at::_ops::kthvalue_dimname::call(self, k, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6597,7 +6597,7 @@ at::Tensor layer_norm_generated_plumbing(const at::Tensor & input, at::IntArrayR
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(layer_norm)(input, normalized_shape, weight, bias, eps, cudnn_enable);
+    return at::_ops::layer_norm::call(input, normalized_shape, weight, bias, eps, cudnn_enable);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6622,7 +6622,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(native_layer_norm)(input, normalized_shape, weight, bias, eps);
+    return at::_ops::native_layer_norm::call(input, normalized_shape, weight, bias, eps);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6647,7 +6647,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_out, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(mean, cur_level) && !isBatchedAtLevel(rstd, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(native_layer_norm_backward)(grad_out, input, normalized_shape, mean, rstd, weight, bias, output_mask);
+    return at::_ops::native_layer_norm_backward::call(grad_out, input, normalized_shape, mean, rstd, weight, bias, output_mask);
   }
   Tensor grad_out_value;
   optional<int64_t> grad_out_bdim;
@@ -6681,7 +6681,7 @@ at::Tensor nan_to_num_generated_plumbing(const at::Tensor & self, c10::optional<
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(nan_to_num)(self, nan, posinf, neginf);
+    return at::_ops::nan_to_num::call(self, nan, posinf, neginf);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6696,7 +6696,7 @@ at::Tensor & nan_to_num__generated_plumbing(at::Tensor & self, c10::optional<dou
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(nan_to_num_)(self, nan, posinf, neginf);
+    return at::_ops::nan_to_num_::call(self, nan, posinf, neginf);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6711,7 +6711,7 @@ at::Tensor linear_generated_plumbing(const at::Tensor & input, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(linear)(input, weight, bias);
+    return at::_ops::linear::call(input, weight, bias);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6734,7 +6734,7 @@ at::Tensor mkldnn_linear_generated_plumbing(const at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(mkldnn_linear)(self, weight, bias);
+    return at::_ops::mkldnn_linear::call(self, weight, bias);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6757,7 +6757,7 @@ at::Tensor mkldnn_linear_backward_input_generated_plumbing(at::IntArrayRef input
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(mkldnn_linear_backward_input)(input_size, grad_output, weight);
+    return at::_ops::mkldnn_linear_backward_input::call(input_size, grad_output, weight);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -6775,7 +6775,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(mkldnn_linear_backward_weights)(grad_output, input, weight, bias_defined);
+    return at::_ops::mkldnn_linear_backward_weights::call(grad_output, input, weight, bias_defined);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -6796,7 +6796,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(mkldnn_linear_backward)(self, grad_output, weight, output_mask);
+    return at::_ops::mkldnn_linear_backward::call(self, grad_output, weight, output_mask);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6817,7 +6817,7 @@ at::Tensor fbgemm_linear_int8_weight_fp32_activation_generated_plumbing(const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(packed, cur_level) && !isBatchedAtLevel(col_offsets, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(fbgemm_linear_int8_weight_fp32_activation)(input, weight, packed, col_offsets, weight_scale, weight_zero_point, bias);
+    return at::_ops::fbgemm_linear_int8_weight_fp32_activation::call(input, weight, packed, col_offsets, weight_scale, weight_zero_point, bias);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6844,7 +6844,7 @@ at::Tensor fbgemm_linear_int8_weight_generated_plumbing(const at::Tensor & input
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(packed, cur_level) && !isBatchedAtLevel(col_offsets, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(fbgemm_linear_int8_weight)(input, weight, packed, col_offsets, weight_scale, weight_zero_point, bias);
+    return at::_ops::fbgemm_linear_int8_weight::call(input, weight, packed, col_offsets, weight_scale, weight_zero_point, bias);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6871,7 +6871,7 @@ at::Tensor fbgemm_pack_gemm_matrix_fp16_generated_plumbing(const at::Tensor & in
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN(fbgemm_pack_gemm_matrix_fp16)(input);
+    return at::_ops::fbgemm_pack_gemm_matrix_fp16::call(input);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6886,7 +6886,7 @@ at::Tensor fbgemm_linear_fp16_weight_fp32_activation_generated_plumbing(const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(packed_weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(fbgemm_linear_fp16_weight_fp32_activation)(input, packed_weight, bias);
+    return at::_ops::fbgemm_linear_fp16_weight_fp32_activation::call(input, packed_weight, bias);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6907,7 +6907,7 @@ at::Tensor fbgemm_linear_fp16_weight_generated_plumbing(const at::Tensor & input
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(packed_weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(fbgemm_linear_fp16_weight)(input, packed_weight, bias);
+    return at::_ops::fbgemm_linear_fp16_weight::call(input, packed_weight, bias);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6928,7 +6928,7 @@ at::Tensor fbgemm_pack_quantized_matrix_generated_plumbing(const at::Tensor & in
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN(fbgemm_pack_quantized_matrix)(input);
+    return at::_ops::fbgemm_pack_quantized_matrix::call(input);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6943,7 +6943,7 @@ at::Tensor fbgemm_pack_quantized_matrix_KN_generated_plumbing(const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN2(fbgemm_pack_quantized_matrix, KN)(input, K, N);
+    return at::_ops::fbgemm_pack_quantized_matrix_KN::call(input, K, N);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -6958,7 +6958,7 @@ at::Tensor ldexp_Tensor_generated_plumbing(const at::Tensor & self, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(ldexp, Tensor)(self, other);
+    return at::_ops::ldexp_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6976,7 +6976,7 @@ at::Tensor & ldexp__generated_plumbing(at::Tensor & self, const at::Tensor & oth
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(ldexp_)(self, other);
+    return at::_ops::ldexp_::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -6994,7 +6994,7 @@ at::Tensor log_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(log)(self);
+    return at::_ops::log::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7009,7 +7009,7 @@ at::Tensor & log__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(log_)(self);
+    return at::_ops::log_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7024,7 +7024,7 @@ at::Tensor log10_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(log10)(self);
+    return at::_ops::log10::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7039,7 +7039,7 @@ at::Tensor & log10__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(log10_)(self);
+    return at::_ops::log10_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7054,7 +7054,7 @@ at::Tensor log1p_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(log1p)(self);
+    return at::_ops::log1p::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7069,7 +7069,7 @@ at::Tensor & log1p__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(log1p_)(self);
+    return at::_ops::log1p_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7084,7 +7084,7 @@ at::Tensor log2_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(log2)(self);
+    return at::_ops::log2::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7099,7 +7099,7 @@ at::Tensor & log2__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(log2_)(self);
+    return at::_ops::log2_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7114,7 +7114,7 @@ at::Tensor logaddexp_generated_plumbing(const at::Tensor & self, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(logaddexp)(self, other);
+    return at::_ops::logaddexp::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7132,7 +7132,7 @@ at::Tensor logaddexp2_generated_plumbing(const at::Tensor & self, const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(logaddexp2)(self, other);
+    return at::_ops::logaddexp2::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7150,7 +7150,7 @@ at::Tensor xlogy_Tensor_generated_plumbing(const at::Tensor & self, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(xlogy, Tensor)(self, other);
+    return at::_ops::xlogy_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7168,7 +7168,7 @@ at::Tensor xlogy_Scalar_Self_generated_plumbing(const at::Scalar & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(xlogy, Scalar_Self)(self, other);
+    return at::_ops::xlogy_Scalar_Self::call(self, other);
   }
   Tensor other_value;
   optional<int64_t> other_bdim;
@@ -7183,7 +7183,7 @@ at::Tensor xlogy_Scalar_Other_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(xlogy, Scalar_Other)(self, other);
+    return at::_ops::xlogy_Scalar_Other::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7198,7 +7198,7 @@ at::Tensor & xlogy__Tensor_generated_plumbing(at::Tensor & self, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(xlogy_, Tensor)(self, other);
+    return at::_ops::xlogy__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7216,7 +7216,7 @@ at::Tensor & xlogy__Scalar_Other_generated_plumbing(at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(xlogy_, Scalar_Other)(self, other);
+    return at::_ops::xlogy__Scalar_Other::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7231,7 +7231,7 @@ at::Tensor logdet_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(logdet)(self);
+    return at::_ops::logdet::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7246,7 +7246,7 @@ at::Tensor log_softmax_int_generated_plumbing(const at::Tensor & self, int64_t d
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(log_softmax, int)(self, dim, dtype);
+    return at::_ops::log_softmax_int::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7261,7 +7261,7 @@ at::Tensor log_softmax_Dimname_generated_plumbing(const at::Tensor & self, at::D
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(log_softmax, Dimname)(self, dim, dtype);
+    return at::_ops::log_softmax_Dimname::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7276,7 +7276,7 @@ at::Tensor _log_softmax_generated_plumbing(const at::Tensor & self, int64_t dim,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_log_softmax)(self, dim, half_to_float);
+    return at::_ops::_log_softmax::call(self, dim, half_to_float);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7291,7 +7291,7 @@ at::Tensor _log_softmax_backward_data_generated_plumbing(const at::Tensor & grad
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(output, cur_level)) {
-    return ATEN_FN(_log_softmax_backward_data)(grad_output, output, dim, input_dtype);
+    return at::_ops::_log_softmax_backward_data::call(grad_output, output, dim, input_dtype);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -7309,7 +7309,7 @@ at::Tensor _logcumsumexp_generated_plumbing(const at::Tensor & self, int64_t dim
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_logcumsumexp)(self, dim);
+    return at::_ops::_logcumsumexp::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7324,7 +7324,7 @@ at::Tensor logcumsumexp_generated_plumbing(const at::Tensor & self, int64_t dim)
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(logcumsumexp)(self, dim);
+    return at::_ops::logcumsumexp::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7339,7 +7339,7 @@ at::Tensor logcumsumexp_dimname_generated_plumbing(const at::Tensor & self, at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(logcumsumexp, dimname)(self, dim);
+    return at::_ops::logcumsumexp_dimname::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7354,7 +7354,7 @@ at::Tensor logsumexp_generated_plumbing(const at::Tensor & self, at::IntArrayRef
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(logsumexp)(self, dim, keepdim);
+    return at::_ops::logsumexp::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7369,7 +7369,7 @@ at::Tensor logsumexp_names_generated_plumbing(const at::Tensor & self, at::Dimna
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(logsumexp, names)(self, dim, keepdim);
+    return at::_ops::logsumexp_names::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7384,7 +7384,7 @@ at::Tensor margin_ranking_loss_generated_plumbing(const at::Tensor & input1, con
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input1, cur_level) && !isBatchedAtLevel(input2, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(margin_ranking_loss)(input1, input2, target, margin, reduction);
+    return at::_ops::margin_ranking_loss::call(input1, input2, target, margin, reduction);
   }
   Tensor input1_value;
   optional<int64_t> input1_bdim;
@@ -7405,7 +7405,7 @@ at::Tensor matmul_generated_plumbing(const at::Tensor & self, const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(matmul)(self, other);
+    return at::_ops::matmul::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7423,7 +7423,7 @@ at::Tensor matrix_rank_tol_generated_plumbing(const at::Tensor & self, double to
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(matrix_rank, tol)(self, tol, symmetric);
+    return at::_ops::matrix_rank_tol::call(self, tol, symmetric);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7438,7 +7438,7 @@ at::Tensor matrix_rank_generated_plumbing(const at::Tensor & self, bool symmetri
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(matrix_rank)(self, symmetric);
+    return at::_ops::matrix_rank::call(self, symmetric);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7453,7 +7453,7 @@ at::Tensor matrix_power_generated_plumbing(const at::Tensor & self, int64_t n) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(matrix_power)(self, n);
+    return at::_ops::matrix_power::call(self, n);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7468,7 +7468,7 @@ at::Tensor matrix_exp_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(matrix_exp)(self);
+    return at::_ops::matrix_exp::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7483,7 +7483,7 @@ at::Tensor matrix_exp_backward_generated_plumbing(const at::Tensor & self, const
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(grad, cur_level)) {
-    return ATEN_FN(matrix_exp_backward)(self, grad);
+    return at::_ops::matrix_exp_backward::call(self, grad);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7501,7 +7501,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_aminmax)(self);
+    return at::_ops::_aminmax::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7516,7 +7516,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(_aminmax, dim)(self, dim, keepdim);
+    return at::_ops::_aminmax_dim::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7531,7 +7531,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(aminmax)(self, dim, keepdim);
+    return at::_ops::aminmax::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7546,7 +7546,7 @@ at::Tensor _compute_linear_combination_generated_plumbing(const at::Tensor & inp
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(coefficients, cur_level)) {
-    return ATEN_FN(_compute_linear_combination)(input, coefficients);
+    return at::_ops::_compute_linear_combination::call(input, coefficients);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -7564,7 +7564,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(max, dim)(self, dim, keepdim);
+    return at::_ops::max_dim::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7579,7 +7579,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(max, names_dim)(self, dim, keepdim);
+    return at::_ops::max_names_dim::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7594,7 +7594,7 @@ at::Tensor value_selecting_reduction_backward_generated_plumbing(const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(value_selecting_reduction_backward)(grad, dim, indices, sizes, keepdim);
+    return at::_ops::value_selecting_reduction_backward::call(grad, dim, indices, sizes, keepdim);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -7612,7 +7612,7 @@ at::Tensor amax_generated_plumbing(const at::Tensor & self, at::IntArrayRef dim,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(amax)(self, dim, keepdim);
+    return at::_ops::amax::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7627,7 +7627,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(max_pool1d_with_indices)(self, kernel_size, stride, padding, dilation, ceil_mode);
+    return at::_ops::max_pool1d_with_indices::call(self, kernel_size, stride, padding, dilation, ceil_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7642,7 +7642,7 @@ at::Tensor max_pool1d_generated_plumbing(const at::Tensor & self, at::IntArrayRe
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(max_pool1d)(self, kernel_size, stride, padding, dilation, ceil_mode);
+    return at::_ops::max_pool1d::call(self, kernel_size, stride, padding, dilation, ceil_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7657,7 +7657,7 @@ at::Tensor max_pool2d_generated_plumbing(const at::Tensor & self, at::IntArrayRe
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(max_pool2d)(self, kernel_size, stride, padding, dilation, ceil_mode);
+    return at::_ops::max_pool2d::call(self, kernel_size, stride, padding, dilation, ceil_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7672,7 +7672,7 @@ at::Tensor mkldnn_max_pool2d_generated_plumbing(const at::Tensor & self, at::Int
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mkldnn_max_pool2d)(self, kernel_size, stride, padding, dilation, ceil_mode);
+    return at::_ops::mkldnn_max_pool2d::call(self, kernel_size, stride, padding, dilation, ceil_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7687,7 +7687,7 @@ at::Tensor mkldnn_max_pool2d_backward_generated_plumbing(const at::Tensor & grad
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(output, cur_level) && !isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN(mkldnn_max_pool2d_backward)(grad_output, output, input, kernel_size, stride, padding, dilation, ceil_mode);
+    return at::_ops::mkldnn_max_pool2d_backward::call(grad_output, output, input, kernel_size, stride, padding, dilation, ceil_mode);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -7708,7 +7708,7 @@ at::Tensor mkldnn_max_pool3d_generated_plumbing(const at::Tensor & self, at::Int
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mkldnn_max_pool3d)(self, kernel_size, stride, padding, dilation, ceil_mode);
+    return at::_ops::mkldnn_max_pool3d::call(self, kernel_size, stride, padding, dilation, ceil_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7723,7 +7723,7 @@ at::Tensor mkldnn_max_pool3d_backward_generated_plumbing(const at::Tensor & grad
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(output, cur_level) && !isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN(mkldnn_max_pool3d_backward)(grad_output, output, input, kernel_size, stride, padding, dilation, ceil_mode);
+    return at::_ops::mkldnn_max_pool3d_backward::call(grad_output, output, input, kernel_size, stride, padding, dilation, ceil_mode);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -7744,7 +7744,7 @@ at::Tensor quantized_max_pool1d_generated_plumbing(const at::Tensor & self, at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(quantized_max_pool1d)(self, kernel_size, stride, padding, dilation, ceil_mode);
+    return at::_ops::quantized_max_pool1d::call(self, kernel_size, stride, padding, dilation, ceil_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7759,7 +7759,7 @@ at::Tensor quantized_max_pool2d_generated_plumbing(const at::Tensor & self, at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(quantized_max_pool2d)(self, kernel_size, stride, padding, dilation, ceil_mode);
+    return at::_ops::quantized_max_pool2d::call(self, kernel_size, stride, padding, dilation, ceil_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7774,7 +7774,7 @@ at::Tensor max_pool3d_generated_plumbing(const at::Tensor & self, at::IntArrayRe
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(max_pool3d)(self, kernel_size, stride, padding, dilation, ceil_mode);
+    return at::_ops::max_pool3d::call(self, kernel_size, stride, padding, dilation, ceil_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7789,7 +7789,7 @@ at::Tensor mean_generated_plumbing(const at::Tensor & self, c10::optional<at::Sc
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mean)(self, dtype);
+    return at::_ops::mean::call(self, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7804,7 +7804,7 @@ at::Tensor mean_dim_generated_plumbing(const at::Tensor & self, at::IntArrayRef 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(mean, dim)(self, dim, keepdim, dtype);
+    return at::_ops::mean_dim::call(self, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7819,7 +7819,7 @@ at::Tensor mean_names_dim_generated_plumbing(const at::Tensor & self, at::Dimnam
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(mean, names_dim)(self, dim, keepdim, dtype);
+    return at::_ops::mean_names_dim::call(self, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7834,7 +7834,7 @@ at::Tensor nanmean_generated_plumbing(const at::Tensor & self, at::IntArrayRef d
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(nanmean)(self, dim, keepdim, dtype);
+    return at::_ops::nanmean::call(self, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7849,7 +7849,7 @@ at::Tensor median_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(median)(self);
+    return at::_ops::median::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7864,7 +7864,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(median, dim)(self, dim, keepdim);
+    return at::_ops::median_dim::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7879,7 +7879,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(median, names_dim)(self, dim, keepdim);
+    return at::_ops::median_names_dim::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7894,7 +7894,7 @@ at::Tensor nanmedian_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(nanmedian)(self);
+    return at::_ops::nanmedian::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7909,7 +7909,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(nanmedian, dim)(self, dim, keepdim);
+    return at::_ops::nanmedian_dim::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7924,7 +7924,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(nanmedian, names_dim)(self, dim, keepdim);
+    return at::_ops::nanmedian_names_dim::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7939,7 +7939,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(min, dim)(self, dim, keepdim);
+    return at::_ops::min_dim::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7954,7 +7954,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(min, names_dim)(self, dim, keepdim);
+    return at::_ops::min_names_dim::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7969,7 +7969,7 @@ at::Tensor amin_generated_plumbing(const at::Tensor & self, at::IntArrayRef dim,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(amin)(self, dim, keepdim);
+    return at::_ops::amin::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -7984,7 +7984,7 @@ at::Tensor mkldnn_convolution_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(mkldnn_convolution)(self, weight, bias, padding, stride, dilation, groups);
+    return at::_ops::mkldnn_convolution::call(self, weight, bias, padding, stride, dilation, groups);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8007,7 +8007,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level) && !isBatchedAtLevel(running_mean, cur_level) && !isBatchedAtLevel(running_var, cur_level)) {
-    return ATEN_FN(miopen_batch_norm)(input, weight, bias, running_mean, running_var, training, exponential_average_factor, epsilon);
+    return at::_ops::miopen_batch_norm::call(input, weight, bias, running_mean, running_var, training, exponential_average_factor, epsilon);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -8040,7 +8040,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(running_mean, cur_level) && !isBatchedAtLevel(running_var, cur_level) && !isBatchedAtLevel(save_mean, cur_level) && !isBatchedAtLevel(save_var, cur_level)) {
-    return ATEN_FN(miopen_batch_norm_backward)(input, grad_output, weight, running_mean, running_var, save_mean, save_var, epsilon);
+    return at::_ops::miopen_batch_norm_backward::call(input, grad_output, weight, running_mean, running_var, save_mean, save_var, epsilon);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -8081,7 +8081,7 @@ at::Tensor miopen_convolution_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(miopen_convolution)(self, weight, bias, padding, stride, dilation, groups, benchmark, deterministic);
+    return at::_ops::miopen_convolution::call(self, weight, bias, padding, stride, dilation, groups, benchmark, deterministic);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8104,7 +8104,7 @@ at::Tensor miopen_convolution_transpose_generated_plumbing(const at::Tensor & se
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(miopen_convolution_transpose)(self, weight, bias, padding, output_padding, stride, dilation, groups, benchmark, deterministic);
+    return at::_ops::miopen_convolution_transpose::call(self, weight, bias, padding, output_padding, stride, dilation, groups, benchmark, deterministic);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8127,7 +8127,7 @@ at::Tensor miopen_depthwise_convolution_generated_plumbing(const at::Tensor & se
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(miopen_depthwise_convolution)(self, weight, bias, padding, stride, dilation, groups, benchmark, deterministic);
+    return at::_ops::miopen_depthwise_convolution::call(self, weight, bias, padding, stride, dilation, groups, benchmark, deterministic);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8150,7 +8150,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(cx, cur_level) && !isBatchedAtLevel(dropout_state, cur_level)) {
-    return ATEN_FN(miopen_rnn)(input, weight, weight_stride0, hx, cx, mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state);
+    return at::_ops::miopen_rnn::call(input, weight, weight_stride0, hx, cx, mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -8178,7 +8178,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(weight_buf, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(cx, cur_level) && !isBatchedAtLevel(output, cur_level) && !isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(grad_hy, cur_level) && !isBatchedAtLevel(grad_cy, cur_level) && !isBatchedAtLevel(dropout_state, cur_level) && !isBatchedAtLevel(reserve, cur_level)) {
-    return ATEN_FN(miopen_rnn_backward)(input, weight, weight_stride0, weight_buf, hx, cx, output, grad_output, grad_hy, grad_cy, mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state, reserve, output_mask);
+    return at::_ops::miopen_rnn_backward::call(input, weight, weight_stride0, weight_buf, hx, cx, output, grad_output, grad_hy, grad_cy, mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state, reserve, output_mask);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -8230,7 +8230,7 @@ at::Tensor mm_generated_plumbing(const at::Tensor & self, const at::Tensor & mat
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mat2, cur_level)) {
-    return ATEN_FN(mm)(self, mat2);
+    return at::_ops::mm::call(self, mat2);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8248,7 +8248,7 @@ at::Tensor _sparse_mm_generated_plumbing(const at::Tensor & sparse, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(sparse, cur_level) && !isBatchedAtLevel(dense, cur_level)) {
-    return ATEN_FN(_sparse_mm)(sparse, dense);
+    return at::_ops::_sparse_mm::call(sparse, dense);
   }
   Tensor sparse_value;
   optional<int64_t> sparse_bdim;
@@ -8266,7 +8266,7 @@ at::Tensor _sparse_sparse_matmul_generated_plumbing(const at::Tensor & self, con
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(_sparse_sparse_matmul)(self, other);
+    return at::_ops::_sparse_sparse_matmul::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8284,7 +8284,7 @@ at::Tensor _sparse_mask_helper_generated_plumbing(const at::Tensor & t, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(t, cur_level) && !isBatchedAtLevel(mask_indices, cur_level)) {
-    return ATEN_FN(_sparse_mask_helper)(t, mask_indices);
+    return at::_ops::_sparse_mask_helper::call(t, mask_indices);
   }
   Tensor t_value;
   optional<int64_t> t_bdim;
@@ -8302,7 +8302,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mode)(self, dim, keepdim);
+    return at::_ops::mode::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8317,7 +8317,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(mode, dimname)(self, dim, keepdim);
+    return at::_ops::mode_dimname::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8332,7 +8332,7 @@ at::Tensor mul_Tensor_generated_plumbing(const at::Tensor & self, const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(mul, Tensor)(self, other);
+    return at::_ops::mul_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8350,7 +8350,7 @@ at::Tensor & mul__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(mul_, Tensor)(self, other);
+    return at::_ops::mul__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8368,7 +8368,7 @@ at::Tensor mul_Scalar_generated_plumbing(const at::Tensor & self, const at::Scal
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(mul, Scalar)(self, other);
+    return at::_ops::mul_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8383,7 +8383,7 @@ at::Tensor & mul__Scalar_generated_plumbing(at::Tensor & self, const at::Scalar 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(mul_, Scalar)(self, other);
+    return at::_ops::mul__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8398,7 +8398,7 @@ at::Tensor multiply_Tensor_generated_plumbing(const at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(multiply, Tensor)(self, other);
+    return at::_ops::multiply_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8416,7 +8416,7 @@ at::Tensor & multiply__Tensor_generated_plumbing(at::Tensor & self, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(multiply_, Tensor)(self, other);
+    return at::_ops::multiply__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8434,7 +8434,7 @@ at::Tensor multiply_Scalar_generated_plumbing(const at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(multiply, Scalar)(self, other);
+    return at::_ops::multiply_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8449,7 +8449,7 @@ at::Tensor & multiply__Scalar_generated_plumbing(at::Tensor & self, const at::Sc
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(multiply_, Scalar)(self, other);
+    return at::_ops::multiply__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8464,7 +8464,7 @@ at::Tensor mv_generated_plumbing(const at::Tensor & self, const at::Tensor & vec
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(vec, cur_level)) {
-    return ATEN_FN(mv)(self, vec);
+    return at::_ops::mv::call(self, vec);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8482,7 +8482,7 @@ at::Tensor mvlgamma_generated_plumbing(const at::Tensor & self, int64_t p) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mvlgamma)(self, p);
+    return at::_ops::mvlgamma::call(self, p);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8497,7 +8497,7 @@ at::Tensor & mvlgamma__generated_plumbing(at::Tensor & self, int64_t p) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mvlgamma_)(self, p);
+    return at::_ops::mvlgamma_::call(self, p);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8512,7 +8512,7 @@ at::Tensor narrow_copy_generated_plumbing(const at::Tensor & self, int64_t dim, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(narrow_copy)(self, dim, start, length);
+    return at::_ops::narrow_copy::call(self, dim, start, length);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8527,7 +8527,7 @@ at::Tensor narrow_generated_plumbing(const at::Tensor & self, int64_t dim, int64
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(narrow)(self, dim, start, length);
+    return at::_ops::narrow::call(self, dim, start, length);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8542,7 +8542,7 @@ at::Tensor narrow_Tensor_generated_plumbing(const at::Tensor & self, int64_t dim
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(start, cur_level)) {
-    return ATEN_FN2(narrow, Tensor)(self, dim, start, length);
+    return at::_ops::narrow_Tensor::call(self, dim, start, length);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8560,7 +8560,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level) && !isBatchedAtLevel(running_mean, cur_level) && !isBatchedAtLevel(running_var, cur_level)) {
-    return ATEN_FN(native_batch_norm)(input, weight, bias, running_mean, running_var, training, momentum, eps);
+    return at::_ops::native_batch_norm::call(input, weight, bias, running_mean, running_var, training, momentum, eps);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -8595,7 +8595,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN(batch_norm_stats)(input, eps);
+    return at::_ops::batch_norm_stats::call(input, eps);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -8610,7 +8610,7 @@ at::Tensor batch_norm_elemt_generated_plumbing(const at::Tensor & input, const c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level) && !isBatchedAtLevel(mean, cur_level) && !isBatchedAtLevel(invstd, cur_level)) {
-    return ATEN_FN(batch_norm_elemt)(input, weight, bias, mean, invstd, eps);
+    return at::_ops::batch_norm_elemt::call(input, weight, bias, mean, invstd, eps);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -8641,7 +8641,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(mean, cur_level) && !isBatchedAtLevel(invstd, cur_level) && !isBatchedAtLevel(running_mean, cur_level) && !isBatchedAtLevel(running_var, cur_level)) {
-    return ATEN_FN(batch_norm_gather_stats)(input, mean, invstd, running_mean, running_var, momentum, eps, count);
+    return at::_ops::batch_norm_gather_stats::call(input, mean, invstd, running_mean, running_var, momentum, eps, count);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -8672,7 +8672,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(mean, cur_level) && !isBatchedAtLevel(invstd, cur_level) && !isBatchedAtLevel(running_mean, cur_level) && !isBatchedAtLevel(running_var, cur_level) && !isBatchedAtLevel(counts, cur_level)) {
-    return ATEN_FN(batch_norm_gather_stats_with_counts)(input, mean, invstd, running_mean, running_var, momentum, eps, counts);
+    return at::_ops::batch_norm_gather_stats_with_counts::call(input, mean, invstd, running_mean, running_var, momentum, eps, counts);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -8706,7 +8706,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_out, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(running_mean, cur_level) && !isBatchedAtLevel(running_var, cur_level) && !isBatchedAtLevel(save_mean, cur_level) && !isBatchedAtLevel(save_invstd, cur_level)) {
-    return ATEN_FN(native_batch_norm_backward)(grad_out, input, weight, running_mean, running_var, save_mean, save_invstd, train, eps, output_mask);
+    return at::_ops::native_batch_norm_backward::call(grad_out, input, weight, running_mean, running_var, save_mean, save_invstd, train, eps, output_mask);
   }
   Tensor grad_out_value;
   optional<int64_t> grad_out_bdim;
@@ -8749,7 +8749,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_out, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(mean, cur_level) && !isBatchedAtLevel(invstd, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(batch_norm_backward_reduce)(grad_out, input, mean, invstd, weight, input_g, weight_g, bias_g);
+    return at::_ops::batch_norm_backward_reduce::call(grad_out, input, mean, invstd, weight, input_g, weight_g, bias_g);
   }
   Tensor grad_out_value;
   optional<int64_t> grad_out_bdim;
@@ -8778,7 +8778,7 @@ at::Tensor batch_norm_backward_elemt_generated_plumbing(const at::Tensor & grad_
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_out, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(mean, cur_level) && !isBatchedAtLevel(invstd, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(mean_dy, cur_level) && !isBatchedAtLevel(mean_dy_xmu, cur_level) && !isBatchedAtLevel(count, cur_level)) {
-    return ATEN_FN(batch_norm_backward_elemt)(grad_out, input, mean, invstd, weight, mean_dy, mean_dy_xmu, count);
+    return at::_ops::batch_norm_backward_elemt::call(grad_out, input, mean, invstd, weight, mean_dy, mean_dy_xmu, count);
   }
   Tensor grad_out_value;
   optional<int64_t> grad_out_bdim;
@@ -8816,7 +8816,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(running_mean, cur_level) && !isBatchedAtLevel(running_var, cur_level)) {
-    return ATEN_FN(batch_norm_update_stats)(input, running_mean, running_var, momentum);
+    return at::_ops::batch_norm_update_stats::call(input, running_mean, running_var, momentum);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -8841,7 +8841,7 @@ at::Tensor _nnpack_spatial_convolution_generated_plumbing(const at::Tensor & inp
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(_nnpack_spatial_convolution)(input, weight, bias, padding, stride);
+    return at::_ops::_nnpack_spatial_convolution::call(input, weight, bias, padding, stride);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -8864,7 +8864,7 @@ at::Tensor ones_like_generated_plumbing(const at::Tensor & self, c10::optional<a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(ones_like)(self, dtype, layout, device, pin_memory, memory_format);
+    return at::_ops::ones_like::call(self, dtype, layout, device, pin_memory, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8879,7 +8879,7 @@ at::Tensor pairwise_distance_generated_plumbing(const at::Tensor & x1, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(x1, cur_level) && !isBatchedAtLevel(x2, cur_level)) {
-    return ATEN_FN(pairwise_distance)(x1, x2, p, eps, keepdim);
+    return at::_ops::pairwise_distance::call(x1, x2, p, eps, keepdim);
   }
   Tensor x1_value;
   optional<int64_t> x1_bdim;
@@ -8897,7 +8897,7 @@ at::Tensor cdist_generated_plumbing(const at::Tensor & x1, const at::Tensor & x2
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(x1, cur_level) && !isBatchedAtLevel(x2, cur_level)) {
-    return ATEN_FN(cdist)(x1, x2, p, compute_mode);
+    return at::_ops::cdist::call(x1, x2, p, compute_mode);
   }
   Tensor x1_value;
   optional<int64_t> x1_bdim;
@@ -8915,7 +8915,7 @@ at::Tensor _euclidean_dist_generated_plumbing(const at::Tensor & x1, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(x1, cur_level) && !isBatchedAtLevel(x2, cur_level)) {
-    return ATEN_FN(_euclidean_dist)(x1, x2);
+    return at::_ops::_euclidean_dist::call(x1, x2);
   }
   Tensor x1_value;
   optional<int64_t> x1_bdim;
@@ -8933,7 +8933,7 @@ at::Tensor _cdist_forward_generated_plumbing(const at::Tensor & x1, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(x1, cur_level) && !isBatchedAtLevel(x2, cur_level)) {
-    return ATEN_FN(_cdist_forward)(x1, x2, p, compute_mode);
+    return at::_ops::_cdist_forward::call(x1, x2, p, compute_mode);
   }
   Tensor x1_value;
   optional<int64_t> x1_bdim;
@@ -8951,7 +8951,7 @@ at::Tensor _cdist_backward_generated_plumbing(const at::Tensor & grad, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(x1, cur_level) && !isBatchedAtLevel(x2, cur_level) && !isBatchedAtLevel(cdist, cur_level)) {
-    return ATEN_FN(_cdist_backward)(grad, x1, x2, p, cdist);
+    return at::_ops::_cdist_backward::call(grad, x1, x2, p, cdist);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -8975,7 +8975,7 @@ at::Tensor pdist_generated_plumbing(const at::Tensor & self, double p) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(pdist)(self, p);
+    return at::_ops::pdist::call(self, p);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -8990,7 +8990,7 @@ at::Tensor _pdist_forward_generated_plumbing(const at::Tensor & self, double p) 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_pdist_forward)(self, p);
+    return at::_ops::_pdist_forward::call(self, p);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9005,7 +9005,7 @@ at::Tensor _pdist_backward_generated_plumbing(const at::Tensor & grad, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(pdist, cur_level)) {
-    return ATEN_FN(_pdist_backward)(grad, self, p, pdist);
+    return at::_ops::_pdist_backward::call(grad, self, p, pdist);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -9026,7 +9026,7 @@ at::Tensor cosine_similarity_generated_plumbing(const at::Tensor & x1, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(x1, cur_level) && !isBatchedAtLevel(x2, cur_level)) {
-    return ATEN_FN(cosine_similarity)(x1, x2, dim, eps);
+    return at::_ops::cosine_similarity::call(x1, x2, dim, eps);
   }
   Tensor x1_value;
   optional<int64_t> x1_bdim;
@@ -9044,7 +9044,7 @@ at::Tensor permute_generated_plumbing(const at::Tensor & self, at::IntArrayRef d
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(permute)(self, dims);
+    return at::_ops::permute::call(self, dims);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9059,7 +9059,7 @@ at::Tensor movedim_intlist_generated_plumbing(const at::Tensor & self, at::IntAr
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(movedim, intlist)(self, source, destination);
+    return at::_ops::movedim_intlist::call(self, source, destination);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9074,7 +9074,7 @@ at::Tensor movedim_int_generated_plumbing(const at::Tensor & self, int64_t sourc
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(movedim, int)(self, source, destination);
+    return at::_ops::movedim_int::call(self, source, destination);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9089,7 +9089,7 @@ at::Tensor moveaxis_intlist_generated_plumbing(const at::Tensor & self, at::IntA
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(moveaxis, intlist)(self, source, destination);
+    return at::_ops::moveaxis_intlist::call(self, source, destination);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9104,7 +9104,7 @@ at::Tensor moveaxis_int_generated_plumbing(const at::Tensor & self, int64_t sour
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(moveaxis, int)(self, source, destination);
+    return at::_ops::moveaxis_int::call(self, source, destination);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9119,7 +9119,7 @@ at::Tensor numpy_T_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(numpy_T)(self);
+    return at::_ops::numpy_T::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9134,7 +9134,7 @@ at::Tensor matrix_H_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(matrix_H)(self);
+    return at::_ops::matrix_H::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9149,7 +9149,7 @@ at::Tensor mT_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mT)(self);
+    return at::_ops::mT::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9164,7 +9164,7 @@ at::Tensor mH_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mH)(self);
+    return at::_ops::mH::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9179,7 +9179,7 @@ at::Tensor adjoint_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(adjoint)(self);
+    return at::_ops::adjoint::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9194,7 +9194,7 @@ at::Tensor pixel_shuffle_generated_plumbing(const at::Tensor & self, int64_t ups
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(pixel_shuffle)(self, upscale_factor);
+    return at::_ops::pixel_shuffle::call(self, upscale_factor);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9209,7 +9209,7 @@ at::Tensor pixel_unshuffle_generated_plumbing(const at::Tensor & self, int64_t d
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(pixel_unshuffle)(self, downscale_factor);
+    return at::_ops::pixel_unshuffle::call(self, downscale_factor);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9224,7 +9224,7 @@ at::Tensor channel_shuffle_generated_plumbing(const at::Tensor & self, int64_t g
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(channel_shuffle)(self, groups);
+    return at::_ops::channel_shuffle::call(self, groups);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9239,7 +9239,7 @@ at::Tensor native_channel_shuffle_generated_plumbing(const at::Tensor & self, in
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(native_channel_shuffle)(self, groups);
+    return at::_ops::native_channel_shuffle::call(self, groups);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9254,7 +9254,7 @@ at::Tensor pin_memory_generated_plumbing(const at::Tensor & self, c10::optional<
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(pin_memory)(self, device);
+    return at::_ops::pin_memory::call(self, device);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9269,7 +9269,7 @@ at::Tensor _pin_memory_generated_plumbing(const at::Tensor & self, c10::optional
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_pin_memory)(self, device);
+    return at::_ops::_pin_memory::call(self, device);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9284,7 +9284,7 @@ at::Tensor pinverse_generated_plumbing(const at::Tensor & self, double rcond) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(pinverse)(self, rcond);
+    return at::_ops::pinverse::call(self, rcond);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9299,7 +9299,7 @@ at::Tensor poisson_nll_loss_generated_plumbing(const at::Tensor & input, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(poisson_nll_loss)(input, target, log_input, full, eps, reduction);
+    return at::_ops::poisson_nll_loss::call(input, target, log_input, full, eps, reduction);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -9317,7 +9317,7 @@ at::Tensor rad2deg_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(rad2deg)(self);
+    return at::_ops::rad2deg::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9332,7 +9332,7 @@ at::Tensor & rad2deg__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(rad2deg_)(self);
+    return at::_ops::rad2deg_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9347,7 +9347,7 @@ at::Tensor deg2rad_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(deg2rad)(self);
+    return at::_ops::deg2rad::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9362,7 +9362,7 @@ at::Tensor & deg2rad__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(deg2rad_)(self);
+    return at::_ops::deg2rad_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9377,7 +9377,7 @@ at::Tensor rand_like_generated_plumbing(const at::Tensor & self, c10::optional<a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(rand_like)(self, dtype, layout, device, pin_memory, memory_format);
+    return at::_ops::rand_like::call(self, dtype, layout, device, pin_memory, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9392,7 +9392,7 @@ at::Tensor randint_like_generated_plumbing(const at::Tensor & self, int64_t high
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(randint_like)(self, high, dtype, layout, device, pin_memory, memory_format);
+    return at::_ops::randint_like::call(self, high, dtype, layout, device, pin_memory, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9407,7 +9407,7 @@ at::Tensor randint_like_low_dtype_generated_plumbing(const at::Tensor & self, in
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(randint_like, low_dtype)(self, low, high, dtype, layout, device, pin_memory, memory_format);
+    return at::_ops::randint_like_low_dtype::call(self, low, high, dtype, layout, device, pin_memory, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9422,7 +9422,7 @@ at::Tensor randn_like_generated_plumbing(const at::Tensor & self, c10::optional<
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(randn_like)(self, dtype, layout, device, pin_memory, memory_format);
+    return at::_ops::randn_like::call(self, dtype, layout, device, pin_memory, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9437,7 +9437,7 @@ at::Tensor ravel_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(ravel)(self);
+    return at::_ops::ravel::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9452,7 +9452,7 @@ at::Tensor reciprocal_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(reciprocal)(self);
+    return at::_ops::reciprocal::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9467,7 +9467,7 @@ at::Tensor & reciprocal__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(reciprocal_)(self);
+    return at::_ops::reciprocal_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9482,7 +9482,7 @@ at::Tensor neg_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(neg)(self);
+    return at::_ops::neg::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9497,7 +9497,7 @@ at::Tensor & neg__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(neg_)(self);
+    return at::_ops::neg_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9512,7 +9512,7 @@ at::Tensor negative_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(negative)(self);
+    return at::_ops::negative::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9527,7 +9527,7 @@ at::Tensor & negative__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(negative_)(self);
+    return at::_ops::negative_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9542,7 +9542,7 @@ at::Tensor repeat_generated_plumbing(const at::Tensor & self, at::IntArrayRef re
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(repeat)(self, repeats);
+    return at::_ops::repeat::call(self, repeats);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9557,7 +9557,7 @@ at::Tensor repeat_interleave_Tensor_generated_plumbing(const at::Tensor & repeat
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(repeats, cur_level)) {
-    return ATEN_FN2(repeat_interleave, Tensor)(repeats, output_size);
+    return at::_ops::repeat_interleave_Tensor::call(repeats, output_size);
   }
   Tensor repeats_value;
   optional<int64_t> repeats_bdim;
@@ -9572,7 +9572,7 @@ at::Tensor repeat_interleave_self_Tensor_generated_plumbing(const at::Tensor & s
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(repeats, cur_level)) {
-    return ATEN_FN2(repeat_interleave, self_Tensor)(self, repeats, dim, output_size);
+    return at::_ops::repeat_interleave_self_Tensor::call(self, repeats, dim, output_size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9590,7 +9590,7 @@ at::Tensor repeat_interleave_self_int_generated_plumbing(const at::Tensor & self
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(repeat_interleave, self_int)(self, repeats, dim, output_size);
+    return at::_ops::repeat_interleave_self_int::call(self, repeats, dim, output_size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9605,7 +9605,7 @@ at::Tensor reshape_generated_plumbing(const at::Tensor & self, at::IntArrayRef s
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(reshape)(self, shape);
+    return at::_ops::reshape::call(self, shape);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9620,7 +9620,7 @@ at::Tensor _reshape_alias_generated_plumbing(const at::Tensor & self, at::IntArr
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_reshape_alias)(self, size, stride);
+    return at::_ops::_reshape_alias::call(self, size, stride);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9635,7 +9635,7 @@ at::Tensor _mkldnn_reshape_generated_plumbing(const at::Tensor & self, at::IntAr
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_mkldnn_reshape)(self, shape);
+    return at::_ops::_mkldnn_reshape::call(self, shape);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9650,7 +9650,7 @@ at::Tensor reshape_as_generated_plumbing(const at::Tensor & self, const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(reshape_as)(self, other);
+    return at::_ops::reshape_as::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9668,7 +9668,7 @@ at::Tensor round_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(round)(self);
+    return at::_ops::round::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9683,7 +9683,7 @@ at::Tensor & round__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(round_)(self);
+    return at::_ops::round_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9698,7 +9698,7 @@ at::Tensor round_decimals_generated_plumbing(const at::Tensor & self, int64_t de
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(round, decimals)(self, decimals);
+    return at::_ops::round_decimals::call(self, decimals);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9713,7 +9713,7 @@ at::Tensor & round__decimals_generated_plumbing(at::Tensor & self, int64_t decim
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(round_, decimals)(self, decimals);
+    return at::_ops::round__decimals::call(self, decimals);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9728,7 +9728,7 @@ at::Tensor rrelu_generated_plumbing(const at::Tensor & self, const at::Scalar & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(rrelu)(self, lower, upper, training, generator);
+    return at::_ops::rrelu::call(self, lower, upper, training, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9743,7 +9743,7 @@ at::Tensor & rrelu__generated_plumbing(at::Tensor & self, const at::Scalar & low
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(rrelu_)(self, lower, upper, training, generator);
+    return at::_ops::rrelu_::call(self, lower, upper, training, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9758,7 +9758,7 @@ at::Tensor relu_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(relu)(self);
+    return at::_ops::relu::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9773,7 +9773,7 @@ at::Tensor & relu__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(relu_)(self);
+    return at::_ops::relu_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9788,7 +9788,7 @@ at::Tensor relu6_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(relu6)(self);
+    return at::_ops::relu6::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9803,7 +9803,7 @@ at::Tensor & relu6__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(relu6_)(self);
+    return at::_ops::relu6_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9818,7 +9818,7 @@ at::Tensor prelu_generated_plumbing(const at::Tensor & self, const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(prelu)(self, weight);
+    return at::_ops::prelu::call(self, weight);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9836,7 +9836,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(prelu_backward)(grad_output, self, weight);
+    return at::_ops::prelu_backward::call(grad_output, self, weight);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -9857,7 +9857,7 @@ at::Tensor gelu_generated_plumbing(const at::Tensor & self, c10::string_view app
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(gelu)(self, approximate);
+    return at::_ops::gelu::call(self, approximate);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9872,7 +9872,7 @@ at::Tensor gelu_backward_generated_plumbing(const at::Tensor & grad_output, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(gelu_backward)(grad_output, self, approximate);
+    return at::_ops::gelu_backward::call(grad_output, self, approximate);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -9890,7 +9890,7 @@ at::Tensor infinitely_differentiable_gelu_backward_generated_plumbing(const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(infinitely_differentiable_gelu_backward)(grad, self);
+    return at::_ops::infinitely_differentiable_gelu_backward::call(grad, self);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -9908,7 +9908,7 @@ at::Tensor hardshrink_generated_plumbing(const at::Tensor & self, const at::Scal
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(hardshrink)(self, lambd);
+    return at::_ops::hardshrink::call(self, lambd);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9923,7 +9923,7 @@ at::Tensor hardshrink_backward_generated_plumbing(const at::Tensor & grad_out, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_out, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(hardshrink_backward)(grad_out, self, lambd);
+    return at::_ops::hardshrink_backward::call(grad_out, self, lambd);
   }
   Tensor grad_out_value;
   optional<int64_t> grad_out_bdim;
@@ -9941,7 +9941,7 @@ at::Tensor rsqrt_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(rsqrt)(self);
+    return at::_ops::rsqrt::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9956,7 +9956,7 @@ at::Tensor & rsqrt__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(rsqrt_)(self);
+    return at::_ops::rsqrt_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9971,7 +9971,7 @@ at::Tensor select_Dimname_generated_plumbing(const at::Tensor & self, at::Dimnam
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(select, Dimname)(self, dim, index);
+    return at::_ops::select_Dimname::call(self, dim, index);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -9986,7 +9986,7 @@ at::Tensor select_int_generated_plumbing(const at::Tensor & self, int64_t dim, i
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(select, int)(self, dim, index);
+    return at::_ops::select_int::call(self, dim, index);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10001,7 +10001,7 @@ at::Tensor select_backward_generated_plumbing(const at::Tensor & grad_output, at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(select_backward)(grad_output, input_sizes, dim, index);
+    return at::_ops::select_backward::call(grad_output, input_sizes, dim, index);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -10016,7 +10016,7 @@ at::Tensor selu_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(selu)(self);
+    return at::_ops::selu::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10031,7 +10031,7 @@ at::Tensor & selu__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(selu_)(self);
+    return at::_ops::selu_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10046,7 +10046,7 @@ at::Tensor celu_generated_plumbing(const at::Tensor & self, const at::Scalar & a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(celu)(self, alpha);
+    return at::_ops::celu::call(self, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10061,7 +10061,7 @@ at::Tensor & celu__generated_plumbing(at::Tensor & self, const at::Scalar & alph
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(celu_)(self, alpha);
+    return at::_ops::celu_::call(self, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10076,7 +10076,7 @@ at::Tensor silu_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(silu)(self);
+    return at::_ops::silu::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10091,7 +10091,7 @@ at::Tensor & silu__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(silu_)(self);
+    return at::_ops::silu_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10106,7 +10106,7 @@ at::Tensor silu_backward_generated_plumbing(const at::Tensor & grad_output, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(silu_backward)(grad_output, self);
+    return at::_ops::silu_backward::call(grad_output, self);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -10124,7 +10124,7 @@ at::Tensor mish_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mish)(self);
+    return at::_ops::mish::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10139,7 +10139,7 @@ at::Tensor & mish__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mish_)(self);
+    return at::_ops::mish_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10154,7 +10154,7 @@ at::Tensor mish_backward_generated_plumbing(const at::Tensor & grad_output, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mish_backward)(grad_output, self);
+    return at::_ops::mish_backward::call(grad_output, self);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -10172,7 +10172,7 @@ at::Tensor sigmoid_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sigmoid)(self);
+    return at::_ops::sigmoid::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10187,7 +10187,7 @@ at::Tensor & sigmoid__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sigmoid_)(self);
+    return at::_ops::sigmoid_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10202,7 +10202,7 @@ at::Tensor logit_generated_plumbing(const at::Tensor & self, c10::optional<doubl
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(logit)(self, eps);
+    return at::_ops::logit::call(self, eps);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10217,7 +10217,7 @@ at::Tensor & logit__generated_plumbing(at::Tensor & self, c10::optional<double> 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(logit_)(self, eps);
+    return at::_ops::logit_::call(self, eps);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10232,7 +10232,7 @@ at::Tensor sin_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sin)(self);
+    return at::_ops::sin::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10247,7 +10247,7 @@ at::Tensor & sin__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sin_)(self);
+    return at::_ops::sin_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10262,7 +10262,7 @@ at::Tensor sinc_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sinc)(self);
+    return at::_ops::sinc::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10277,7 +10277,7 @@ at::Tensor & sinc__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sinc_)(self);
+    return at::_ops::sinc_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10292,7 +10292,7 @@ at::Tensor sinh_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sinh)(self);
+    return at::_ops::sinh::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10307,7 +10307,7 @@ at::Tensor & sinh__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sinh_)(self);
+    return at::_ops::sinh_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10322,7 +10322,7 @@ at::Tensor detach_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(detach)(self);
+    return at::_ops::detach::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10337,7 +10337,7 @@ at::Tensor slice_Tensor_generated_plumbing(const at::Tensor & self, int64_t dim,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(slice, Tensor)(self, dim, start, end, step);
+    return at::_ops::slice_Tensor::call(self, dim, start, end, step);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10352,7 +10352,7 @@ at::Tensor slice_backward_generated_plumbing(const at::Tensor & grad_output, at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(slice_backward)(grad_output, input_sizes, dim, start, end, step);
+    return at::_ops::slice_backward::call(grad_output, input_sizes, dim, start, end, step);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -10367,7 +10367,7 @@ at::Tensor slice_scatter_generated_plumbing(const at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(src, cur_level)) {
-    return ATEN_FN(slice_scatter)(self, src, dim, start, end, step);
+    return at::_ops::slice_scatter::call(self, src, dim, start, end, step);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10385,7 +10385,7 @@ at::Tensor select_scatter_generated_plumbing(const at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(src, cur_level)) {
-    return ATEN_FN(select_scatter)(self, src, dim, index);
+    return at::_ops::select_scatter::call(self, src, dim, index);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10403,7 +10403,7 @@ at::Tensor diagonal_scatter_generated_plumbing(const at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(src, cur_level)) {
-    return ATEN_FN(diagonal_scatter)(self, src, offset, dim1, dim2);
+    return at::_ops::diagonal_scatter::call(self, src, offset, dim1, dim2);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10421,7 +10421,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(slogdet)(self);
+    return at::_ops::slogdet::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10436,7 +10436,7 @@ at::Tensor smm_generated_plumbing(const at::Tensor & self, const at::Tensor & ma
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mat2, cur_level)) {
-    return ATEN_FN(smm)(self, mat2);
+    return at::_ops::smm::call(self, mat2);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10454,7 +10454,7 @@ at::Tensor softmax_int_generated_plumbing(const at::Tensor & self, int64_t dim, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(softmax, int)(self, dim, dtype);
+    return at::_ops::softmax_int::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10469,7 +10469,7 @@ at::Tensor softmax_Dimname_generated_plumbing(const at::Tensor & self, at::Dimna
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(softmax, Dimname)(self, dim, dtype);
+    return at::_ops::softmax_Dimname::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10484,7 +10484,7 @@ at::Tensor _softmax_generated_plumbing(const at::Tensor & self, int64_t dim, boo
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_softmax)(self, dim, half_to_float);
+    return at::_ops::_softmax::call(self, dim, half_to_float);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10499,7 +10499,7 @@ at::Tensor _softmax_backward_data_generated_plumbing(const at::Tensor & grad_out
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(output, cur_level)) {
-    return ATEN_FN(_softmax_backward_data)(grad_output, output, dim, input_dtype);
+    return at::_ops::_softmax_backward_data::call(grad_output, output, dim, input_dtype);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -10517,7 +10517,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(unsafe_split, Tensor)(self, split_size, dim);
+    return at::_ops::unsafe_split_Tensor::call(self, split_size, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10532,7 +10532,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(split, Tensor)(self, split_size, dim);
+    return at::_ops::split_Tensor::call(self, split_size, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10547,7 +10547,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(unsafe_split_with_sizes)(self, split_sizes, dim);
+    return at::_ops::unsafe_split_with_sizes::call(self, split_sizes, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10562,7 +10562,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(split_with_sizes)(self, split_sizes, dim);
+    return at::_ops::split_with_sizes::call(self, split_sizes, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10577,7 +10577,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(hsplit, int)(self, sections);
+    return at::_ops::hsplit_int::call(self, sections);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10592,7 +10592,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(hsplit, array)(self, indices);
+    return at::_ops::hsplit_array::call(self, indices);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10607,7 +10607,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(vsplit, int)(self, sections);
+    return at::_ops::vsplit_int::call(self, sections);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10622,7 +10622,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(vsplit, array)(self, indices);
+    return at::_ops::vsplit_array::call(self, indices);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10637,7 +10637,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(dsplit, int)(self, sections);
+    return at::_ops::dsplit_int::call(self, sections);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10652,7 +10652,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(dsplit, array)(self, indices);
+    return at::_ops::dsplit_array::call(self, indices);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10667,7 +10667,7 @@ at::Tensor squeeze_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(squeeze)(self);
+    return at::_ops::squeeze::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10682,7 +10682,7 @@ at::Tensor squeeze_dim_generated_plumbing(const at::Tensor & self, int64_t dim) 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(squeeze, dim)(self, dim);
+    return at::_ops::squeeze_dim::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10697,7 +10697,7 @@ at::Tensor squeeze_dimname_generated_plumbing(const at::Tensor & self, at::Dimna
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(squeeze, dimname)(self, dim);
+    return at::_ops::squeeze_dimname::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10712,7 +10712,7 @@ at::Tensor sspaddmm_generated_plumbing(const at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mat1, cur_level) && !isBatchedAtLevel(mat2, cur_level)) {
-    return ATEN_FN(sspaddmm)(self, mat1, mat2, beta, alpha);
+    return at::_ops::sspaddmm::call(self, mat1, mat2, beta, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10733,7 +10733,7 @@ at::Tensor stack_generated_plumbing(at::TensorList tensors, int64_t dim) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(stack)(tensors, dim);
+    return at::_ops::stack::call(tensors, dim);
   }
 
   auto results = batch_rule(tensors, dim);
@@ -10746,7 +10746,7 @@ at::Tensor _stack_generated_plumbing(at::TensorList tensors, int64_t dim) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_stack)(tensors, dim);
+    return at::_ops::_stack::call(tensors, dim);
   }
 
   auto results = batch_rule(tensors, dim);
@@ -10759,7 +10759,7 @@ at::Tensor hstack_generated_plumbing(at::TensorList tensors) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(hstack)(tensors);
+    return at::_ops::hstack::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -10772,7 +10772,7 @@ at::Tensor vstack_generated_plumbing(at::TensorList tensors) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(vstack)(tensors);
+    return at::_ops::vstack::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -10785,7 +10785,7 @@ at::Tensor dstack_generated_plumbing(at::TensorList tensors) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(dstack)(tensors);
+    return at::_ops::dstack::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -10798,7 +10798,7 @@ at::Tensor stft_generated_plumbing(const at::Tensor & self, int64_t n_fft, c10::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(window, cur_level)) {
-    return ATEN_FN(stft)(self, n_fft, hop_length, win_length, window, normalized, onesided, return_complex);
+    return at::_ops::stft::call(self, n_fft, hop_length, win_length, window, normalized, onesided, return_complex);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10818,7 +10818,7 @@ at::Tensor istft_generated_plumbing(const at::Tensor & self, int64_t n_fft, c10:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(window, cur_level)) {
-    return ATEN_FN(istft)(self, n_fft, hop_length, win_length, window, center, normalized, onesided, length, return_complex);
+    return at::_ops::istft::call(self, n_fft, hop_length, win_length, window, center, normalized, onesided, length, return_complex);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10838,7 +10838,7 @@ at::Tensor sum_generated_plumbing(const at::Tensor & self, c10::optional<at::Sca
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sum)(self, dtype);
+    return at::_ops::sum::call(self, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10853,7 +10853,7 @@ at::Tensor sum_dim_IntList_generated_plumbing(const at::Tensor & self, at::IntAr
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(sum, dim_IntList)(self, dim, keepdim, dtype);
+    return at::_ops::sum_dim_IntList::call(self, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10868,7 +10868,7 @@ at::Tensor sum_dim_DimnameList_generated_plumbing(const at::Tensor & self, at::D
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(sum, dim_DimnameList)(self, dim, keepdim, dtype);
+    return at::_ops::sum_dim_DimnameList::call(self, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10883,7 +10883,7 @@ at::Tensor nansum_generated_plumbing(const at::Tensor & self, c10::optional<at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(nansum)(self, dtype);
+    return at::_ops::nansum::call(self, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10898,7 +10898,7 @@ at::Tensor nansum_dim_IntList_generated_plumbing(const at::Tensor & self, at::In
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(nansum, dim_IntList)(self, dim, keepdim, dtype);
+    return at::_ops::nansum_dim_IntList::call(self, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10913,7 +10913,7 @@ at::Tensor sum_to_size_generated_plumbing(const at::Tensor & self, at::IntArrayR
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sum_to_size)(self, size);
+    return at::_ops::sum_to_size::call(self, size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10928,7 +10928,7 @@ at::Tensor sqrt_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sqrt)(self);
+    return at::_ops::sqrt::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10943,7 +10943,7 @@ at::Tensor & sqrt__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sqrt_)(self);
+    return at::_ops::sqrt_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10958,7 +10958,7 @@ at::Tensor square_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(square)(self);
+    return at::_ops::square::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10973,7 +10973,7 @@ at::Tensor & square__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(square_)(self);
+    return at::_ops::square_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -10988,7 +10988,7 @@ at::Tensor std_generated_plumbing(const at::Tensor & self, bool unbiased) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(std)(self, unbiased);
+    return at::_ops::std::call(self, unbiased);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11003,7 +11003,7 @@ at::Tensor std_dim_generated_plumbing(const at::Tensor & self, at::IntArrayRef d
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(std, dim)(self, dim, unbiased, keepdim);
+    return at::_ops::std_dim::call(self, dim, unbiased, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11018,7 +11018,7 @@ at::Tensor std_correction_generated_plumbing(const at::Tensor & self, c10::optio
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(std, correction)(self, dim, correction, keepdim);
+    return at::_ops::std_correction::call(self, dim, correction, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11033,7 +11033,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(std_mean)(self, unbiased);
+    return at::_ops::std_mean::call(self, unbiased);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11048,7 +11048,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(std_mean, dim)(self, dim, unbiased, keepdim);
+    return at::_ops::std_mean_dim::call(self, dim, unbiased, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11063,7 +11063,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(std_mean, correction)(self, dim, correction, keepdim);
+    return at::_ops::std_mean_correction::call(self, dim, correction, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11078,7 +11078,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(std_mean, names_dim)(self, dim, unbiased, keepdim);
+    return at::_ops::std_mean_names_dim::call(self, dim, unbiased, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11093,7 +11093,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(std_mean, correction_names)(self, dim, correction, keepdim);
+    return at::_ops::std_mean_correction_names::call(self, dim, correction, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11108,7 +11108,7 @@ at::Tensor std_names_dim_generated_plumbing(const at::Tensor & self, at::Dimname
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(std, names_dim)(self, dim, unbiased, keepdim);
+    return at::_ops::std_names_dim::call(self, dim, unbiased, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11123,7 +11123,7 @@ at::Tensor std_correction_names_generated_plumbing(const at::Tensor & self, at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(std, correction_names)(self, dim, correction, keepdim);
+    return at::_ops::std_correction_names::call(self, dim, correction, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11138,7 +11138,7 @@ at::Tensor prod_generated_plumbing(const at::Tensor & self, c10::optional<at::Sc
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(prod)(self, dtype);
+    return at::_ops::prod::call(self, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11153,7 +11153,7 @@ at::Tensor prod_dim_int_generated_plumbing(const at::Tensor & self, int64_t dim,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(prod, dim_int)(self, dim, keepdim, dtype);
+    return at::_ops::prod_dim_int::call(self, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11168,7 +11168,7 @@ at::Tensor prod_dim_Dimname_generated_plumbing(const at::Tensor & self, at::Dimn
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(prod, dim_Dimname)(self, dim, keepdim, dtype);
+    return at::_ops::prod_dim_Dimname::call(self, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11183,7 +11183,7 @@ at::Tensor t_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(t)(self);
+    return at::_ops::t::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11198,7 +11198,7 @@ at::Tensor tan_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(tan)(self);
+    return at::_ops::tan::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11213,7 +11213,7 @@ at::Tensor & tan__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(tan_)(self);
+    return at::_ops::tan_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11228,7 +11228,7 @@ at::Tensor tanh_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(tanh)(self);
+    return at::_ops::tanh::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11243,7 +11243,7 @@ at::Tensor & tanh__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(tanh_)(self);
+    return at::_ops::tanh_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11258,7 +11258,7 @@ at::Tensor tensordot_generated_plumbing(const at::Tensor & self, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(tensordot)(self, other, dims_self, dims_other);
+    return at::_ops::tensordot::call(self, other, dims_self, dims_other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11276,7 +11276,7 @@ at::Tensor threshold_generated_plumbing(const at::Tensor & self, const at::Scala
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(threshold)(self, threshold, value);
+    return at::_ops::threshold::call(self, threshold, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11291,7 +11291,7 @@ at::Tensor & threshold__generated_plumbing(at::Tensor & self, const at::Scalar &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(threshold_)(self, threshold, value);
+    return at::_ops::threshold_::call(self, threshold, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11306,7 +11306,7 @@ at::Tensor threshold_backward_generated_plumbing(const at::Tensor & grad_output,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(threshold_backward)(grad_output, self, threshold);
+    return at::_ops::threshold_backward::call(grad_output, self, threshold);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -11324,7 +11324,7 @@ at::Tensor tile_generated_plumbing(const at::Tensor & self, at::IntArrayRef dims
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(tile)(self, dims);
+    return at::_ops::tile::call(self, dims);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11339,7 +11339,7 @@ at::Tensor transpose_int_generated_plumbing(const at::Tensor & self, int64_t dim
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(transpose, int)(self, dim0, dim1);
+    return at::_ops::transpose_int::call(self, dim0, dim1);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11354,7 +11354,7 @@ at::Tensor transpose_Dimname_generated_plumbing(const at::Tensor & self, at::Dim
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(transpose, Dimname)(self, dim0, dim1);
+    return at::_ops::transpose_Dimname::call(self, dim0, dim1);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11369,7 +11369,7 @@ at::Tensor _mkldnn_transpose_generated_plumbing(const at::Tensor & self, int64_t
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_mkldnn_transpose)(self, dim0, dim1);
+    return at::_ops::_mkldnn_transpose::call(self, dim0, dim1);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11384,7 +11384,7 @@ at::Tensor & _mkldnn_transpose__generated_plumbing(at::Tensor & self, int64_t di
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_mkldnn_transpose_)(self, dim0, dim1);
+    return at::_ops::_mkldnn_transpose_::call(self, dim0, dim1);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11399,7 +11399,7 @@ at::Tensor one_hot_generated_plumbing(const at::Tensor & self, int64_t num_class
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(one_hot)(self, num_classes);
+    return at::_ops::one_hot::call(self, num_classes);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11414,7 +11414,7 @@ at::Tensor flip_generated_plumbing(const at::Tensor & self, at::IntArrayRef dims
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(flip)(self, dims);
+    return at::_ops::flip::call(self, dims);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11429,7 +11429,7 @@ at::Tensor fliplr_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fliplr)(self);
+    return at::_ops::fliplr::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11444,7 +11444,7 @@ at::Tensor flipud_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(flipud)(self);
+    return at::_ops::flipud::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11459,7 +11459,7 @@ at::Tensor roll_generated_plumbing(const at::Tensor & self, at::IntArrayRef shif
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(roll)(self, shifts, dims);
+    return at::_ops::roll::call(self, shifts, dims);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11474,7 +11474,7 @@ at::Tensor rot90_generated_plumbing(const at::Tensor & self, int64_t k, at::IntA
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(rot90)(self, k, dims);
+    return at::_ops::rot90::call(self, k, dims);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11489,7 +11489,7 @@ at::Tensor trapezoid_x_generated_plumbing(const at::Tensor & y, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(y, cur_level) && !isBatchedAtLevel(x, cur_level)) {
-    return ATEN_FN2(trapezoid, x)(y, x, dim);
+    return at::_ops::trapezoid_x::call(y, x, dim);
   }
   Tensor y_value;
   optional<int64_t> y_bdim;
@@ -11507,7 +11507,7 @@ at::Tensor trapezoid_dx_generated_plumbing(const at::Tensor & y, const at::Scala
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(y, cur_level)) {
-    return ATEN_FN2(trapezoid, dx)(y, dx, dim);
+    return at::_ops::trapezoid_dx::call(y, dx, dim);
   }
   Tensor y_value;
   optional<int64_t> y_bdim;
@@ -11522,7 +11522,7 @@ at::Tensor trapz_x_generated_plumbing(const at::Tensor & y, const at::Tensor & x
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(y, cur_level) && !isBatchedAtLevel(x, cur_level)) {
-    return ATEN_FN2(trapz, x)(y, x, dim);
+    return at::_ops::trapz_x::call(y, x, dim);
   }
   Tensor y_value;
   optional<int64_t> y_bdim;
@@ -11540,7 +11540,7 @@ at::Tensor trapz_dx_generated_plumbing(const at::Tensor & y, double dx, int64_t 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(y, cur_level)) {
-    return ATEN_FN2(trapz, dx)(y, dx, dim);
+    return at::_ops::trapz_dx::call(y, dx, dim);
   }
   Tensor y_value;
   optional<int64_t> y_bdim;
@@ -11555,7 +11555,7 @@ at::Tensor _trilinear_generated_plumbing(const at::Tensor & i1, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(i1, cur_level) && !isBatchedAtLevel(i2, cur_level) && !isBatchedAtLevel(i3, cur_level)) {
-    return ATEN_FN(_trilinear)(i1, i2, i3, expand1, expand2, expand3, sumdim, unroll_dim);
+    return at::_ops::_trilinear::call(i1, i2, i3, expand1, expand2, expand3, sumdim, unroll_dim);
   }
   Tensor i1_value;
   optional<int64_t> i1_bdim;
@@ -11576,7 +11576,7 @@ at::Tensor triplet_margin_loss_generated_plumbing(const at::Tensor & anchor, con
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(anchor, cur_level) && !isBatchedAtLevel(positive, cur_level) && !isBatchedAtLevel(negative, cur_level)) {
-    return ATEN_FN(triplet_margin_loss)(anchor, positive, negative, margin, p, eps, swap, reduction);
+    return at::_ops::triplet_margin_loss::call(anchor, positive, negative, margin, p, eps, swap, reduction);
   }
   Tensor anchor_value;
   optional<int64_t> anchor_bdim;
@@ -11597,7 +11597,7 @@ at::Tensor trunc_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(trunc)(self);
+    return at::_ops::trunc::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11612,7 +11612,7 @@ at::Tensor & trunc__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(trunc_)(self);
+    return at::_ops::trunc_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11627,7 +11627,7 @@ at::Tensor fix_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fix)(self);
+    return at::_ops::fix::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11642,7 +11642,7 @@ at::Tensor & fix__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fix_)(self);
+    return at::_ops::fix_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11657,7 +11657,7 @@ at::Tensor type_as_generated_plumbing(const at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(type_as)(self, other);
+    return at::_ops::type_as::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11675,7 +11675,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_unique)(self, sorted, return_inverse);
+    return at::_ops::_unique::call(self, sorted, return_inverse);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11690,7 +11690,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(unique_dim)(self, dim, sorted, return_inverse, return_counts);
+    return at::_ops::unique_dim::call(self, dim, sorted, return_inverse, return_counts);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11705,7 +11705,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(unique_consecutive)(self, return_inverse, return_counts, dim);
+    return at::_ops::unique_consecutive::call(self, return_inverse, return_counts, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11720,7 +11720,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(unique_dim_consecutive)(self, dim, return_inverse, return_counts);
+    return at::_ops::unique_dim_consecutive::call(self, dim, return_inverse, return_counts);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11735,7 +11735,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_unique2)(self, sorted, return_inverse, return_counts);
+    return at::_ops::_unique2::call(self, sorted, return_inverse, return_counts);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11750,7 +11750,7 @@ at::Tensor _unsafe_view_generated_plumbing(const at::Tensor & self, at::IntArray
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_unsafe_view)(self, size);
+    return at::_ops::_unsafe_view::call(self, size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11765,7 +11765,7 @@ at::Tensor unsqueeze_generated_plumbing(const at::Tensor & self, int64_t dim) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(unsqueeze)(self, dim);
+    return at::_ops::unsqueeze::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11780,7 +11780,7 @@ at::Tensor vander_generated_plumbing(const at::Tensor & x, c10::optional<int64_t
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(x, cur_level)) {
-    return ATEN_FN(vander)(x, N, increasing);
+    return at::_ops::vander::call(x, N, increasing);
   }
   Tensor x_value;
   optional<int64_t> x_bdim;
@@ -11795,7 +11795,7 @@ at::Tensor var_generated_plumbing(const at::Tensor & self, bool unbiased) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(var)(self, unbiased);
+    return at::_ops::var::call(self, unbiased);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11810,7 +11810,7 @@ at::Tensor var_dim_generated_plumbing(const at::Tensor & self, at::IntArrayRef d
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(var, dim)(self, dim, unbiased, keepdim);
+    return at::_ops::var_dim::call(self, dim, unbiased, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11825,7 +11825,7 @@ at::Tensor var_correction_generated_plumbing(const at::Tensor & self, c10::optio
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(var, correction)(self, dim, correction, keepdim);
+    return at::_ops::var_correction::call(self, dim, correction, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11840,7 +11840,7 @@ at::Tensor var_names_dim_generated_plumbing(const at::Tensor & self, at::Dimname
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(var, names_dim)(self, dim, unbiased, keepdim);
+    return at::_ops::var_names_dim::call(self, dim, unbiased, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11855,7 +11855,7 @@ at::Tensor var_correction_names_generated_plumbing(const at::Tensor & self, at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(var, correction_names)(self, dim, correction, keepdim);
+    return at::_ops::var_correction_names::call(self, dim, correction, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11870,7 +11870,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(var_mean)(self, unbiased);
+    return at::_ops::var_mean::call(self, unbiased);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11885,7 +11885,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(var_mean, dim)(self, dim, unbiased, keepdim);
+    return at::_ops::var_mean_dim::call(self, dim, unbiased, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11900,7 +11900,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(var_mean, correction)(self, dim, correction, keepdim);
+    return at::_ops::var_mean_correction::call(self, dim, correction, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11915,7 +11915,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(var_mean, names_dim)(self, dim, unbiased, keepdim);
+    return at::_ops::var_mean_names_dim::call(self, dim, unbiased, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11930,7 +11930,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(var_mean, correction_names)(self, dim, correction, keepdim);
+    return at::_ops::var_mean_correction_names::call(self, dim, correction, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11945,7 +11945,7 @@ at::Tensor view_as_generated_plumbing(const at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(view_as)(self, other);
+    return at::_ops::view_as::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -11963,7 +11963,7 @@ at::Tensor where_self_generated_plumbing(const at::Tensor & condition, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(condition, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(where, self)(condition, self, other);
+    return at::_ops::where_self::call(condition, self, other);
   }
   Tensor condition_value;
   optional<int64_t> condition_bdim;
@@ -11984,7 +11984,7 @@ at::Tensor where_ScalarSelf_generated_plumbing(const at::Tensor & condition, con
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(condition, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(where, ScalarSelf)(condition, self, other);
+    return at::_ops::where_ScalarSelf::call(condition, self, other);
   }
   Tensor condition_value;
   optional<int64_t> condition_bdim;
@@ -12002,7 +12002,7 @@ at::Tensor where_ScalarOther_generated_plumbing(const at::Tensor & condition, co
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(condition, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(where, ScalarOther)(condition, self, other);
+    return at::_ops::where_ScalarOther::call(condition, self, other);
   }
   Tensor condition_value;
   optional<int64_t> condition_bdim;
@@ -12020,7 +12020,7 @@ at::Tensor where_Scalar_generated_plumbing(const at::Tensor & condition, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(condition, cur_level)) {
-    return ATEN_FN2(where, Scalar)(condition, self, other);
+    return at::_ops::where_Scalar::call(condition, self, other);
   }
   Tensor condition_value;
   optional<int64_t> condition_bdim;
@@ -12035,7 +12035,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(condition, cur_level)) {
-    return ATEN_FN(where)(condition);
+    return at::_ops::where::call(condition);
   }
   Tensor condition_value;
   optional<int64_t> condition_bdim;
@@ -12050,7 +12050,7 @@ at::Tensor norm_except_dim_generated_plumbing(const at::Tensor & v, int64_t pow,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(v, cur_level)) {
-    return ATEN_FN(norm_except_dim)(v, pow, dim);
+    return at::_ops::norm_except_dim::call(v, pow, dim);
   }
   Tensor v_value;
   optional<int64_t> v_bdim;
@@ -12065,7 +12065,7 @@ at::Tensor _weight_norm_generated_plumbing(const at::Tensor & v, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(v, cur_level) && !isBatchedAtLevel(g, cur_level)) {
-    return ATEN_FN(_weight_norm)(v, g, dim);
+    return at::_ops::_weight_norm::call(v, g, dim);
   }
   Tensor v_value;
   optional<int64_t> v_bdim;
@@ -12083,7 +12083,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(v, cur_level) && !isBatchedAtLevel(g, cur_level)) {
-    return ATEN_FN(_weight_norm_cuda_interface)(v, g, dim);
+    return at::_ops::_weight_norm_cuda_interface::call(v, g, dim);
   }
   Tensor v_value;
   optional<int64_t> v_bdim;
@@ -12101,7 +12101,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_w, cur_level) && !isBatchedAtLevel(saved_v, cur_level) && !isBatchedAtLevel(saved_g, cur_level) && !isBatchedAtLevel(saved_norms, cur_level)) {
-    return ATEN_FN(_weight_norm_cuda_interface_backward)(grad_w, saved_v, saved_g, saved_norms, dim);
+    return at::_ops::_weight_norm_cuda_interface_backward::call(grad_w, saved_v, saved_g, saved_norms, dim);
   }
   Tensor grad_w_value;
   optional<int64_t> grad_w_bdim;
@@ -12125,7 +12125,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_w, cur_level) && !isBatchedAtLevel(saved_v, cur_level) && !isBatchedAtLevel(saved_g, cur_level) && !isBatchedAtLevel(saved_norms, cur_level)) {
-    return ATEN_FN(_weight_norm_differentiable_backward)(grad_w, saved_v, saved_g, saved_norms, dim);
+    return at::_ops::_weight_norm_differentiable_backward::call(grad_w, saved_v, saved_g, saved_norms, dim);
   }
   Tensor grad_w_value;
   optional<int64_t> grad_w_bdim;
@@ -12149,7 +12149,7 @@ at::Tensor zeros_like_generated_plumbing(const at::Tensor & self, c10::optional<
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(zeros_like)(self, dtype, layout, device, pin_memory, memory_format);
+    return at::_ops::zeros_like::call(self, dtype, layout, device, pin_memory, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12164,7 +12164,7 @@ at::Tensor _standard_gamma_grad_generated_plumbing(const at::Tensor & self, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(output, cur_level)) {
-    return ATEN_FN(_standard_gamma_grad)(self, output);
+    return at::_ops::_standard_gamma_grad::call(self, output);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12182,7 +12182,7 @@ at::Tensor _standard_gamma_generated_plumbing(const at::Tensor & self, c10::opti
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_standard_gamma)(self, generator);
+    return at::_ops::_standard_gamma::call(self, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12197,7 +12197,7 @@ at::Tensor _dirichlet_grad_generated_plumbing(const at::Tensor & x, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(x, cur_level) && !isBatchedAtLevel(alpha, cur_level) && !isBatchedAtLevel(total, cur_level)) {
-    return ATEN_FN(_dirichlet_grad)(x, alpha, total);
+    return at::_ops::_dirichlet_grad::call(x, alpha, total);
   }
   Tensor x_value;
   optional<int64_t> x_bdim;
@@ -12218,7 +12218,7 @@ at::Tensor _sample_dirichlet_generated_plumbing(const at::Tensor & self, c10::op
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_sample_dirichlet)(self, generator);
+    return at::_ops::_sample_dirichlet::call(self, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12233,7 +12233,7 @@ at::Tensor poisson_generated_plumbing(const at::Tensor & self, c10::optional<at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(poisson)(self, generator);
+    return at::_ops::poisson::call(self, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12248,7 +12248,7 @@ at::Tensor binomial_generated_plumbing(const at::Tensor & count, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(count, cur_level) && !isBatchedAtLevel(prob, cur_level)) {
-    return ATEN_FN(binomial)(count, prob, generator);
+    return at::_ops::binomial::call(count, prob, generator);
   }
   Tensor count_value;
   optional<int64_t> count_bdim;
@@ -12266,7 +12266,7 @@ at::Tensor native_norm_generated_plumbing(const at::Tensor & self, const at::Sca
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(native_norm)(self, p);
+    return at::_ops::native_norm::call(self, p);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12281,7 +12281,7 @@ at::Tensor native_norm_ScalarOpt_dim_dtype_generated_plumbing(const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(native_norm, ScalarOpt_dim_dtype)(self, p, dim, keepdim, dtype);
+    return at::_ops::native_norm_ScalarOpt_dim_dtype::call(self, p, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12296,7 +12296,7 @@ at::Tensor _sparse_sum_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_sparse_sum)(self);
+    return at::_ops::_sparse_sum::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12311,7 +12311,7 @@ at::Tensor _sparse_sum_dtype_generated_plumbing(const at::Tensor & self, at::Sca
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(_sparse_sum, dtype)(self, dtype);
+    return at::_ops::_sparse_sum_dtype::call(self, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12326,7 +12326,7 @@ at::Tensor _sparse_sum_dim_generated_plumbing(const at::Tensor & self, at::IntAr
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(_sparse_sum, dim)(self, dim);
+    return at::_ops::_sparse_sum_dim::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12341,7 +12341,7 @@ at::Tensor _sparse_sum_dim_dtype_generated_plumbing(const at::Tensor & self, at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(_sparse_sum, dim_dtype)(self, dim, dtype);
+    return at::_ops::_sparse_sum_dim_dtype::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12356,7 +12356,7 @@ at::Tensor _sparse_sum_backward_generated_plumbing(const at::Tensor & grad, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_sparse_sum_backward)(grad, self, dim);
+    return at::_ops::_sparse_sum_backward::call(grad, self, dim);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -12374,7 +12374,7 @@ at::Tensor _sparse_softmax_int_generated_plumbing(const at::Tensor & self, int64
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(_sparse_softmax, int)(self, dim, dtype);
+    return at::_ops::_sparse_softmax_int::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12389,7 +12389,7 @@ at::Tensor _sparse_softmax_Dimname_generated_plumbing(const at::Tensor & self, a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(_sparse_softmax, Dimname)(self, dim, dtype);
+    return at::_ops::_sparse_softmax_Dimname::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12404,7 +12404,7 @@ at::Tensor _sparse_softmax_generated_plumbing(const at::Tensor & self, int64_t d
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_sparse_softmax)(self, dim, half_to_float);
+    return at::_ops::_sparse_softmax::call(self, dim, half_to_float);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12419,7 +12419,7 @@ at::Tensor _sparse_softmax_backward_data_generated_plumbing(const at::Tensor & g
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_sparse_softmax_backward_data)(grad_output, output, dim, self);
+    return at::_ops::_sparse_softmax_backward_data::call(grad_output, output, dim, self);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -12440,7 +12440,7 @@ at::Tensor _sparse_log_softmax_int_generated_plumbing(const at::Tensor & self, i
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(_sparse_log_softmax, int)(self, dim, dtype);
+    return at::_ops::_sparse_log_softmax_int::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12455,7 +12455,7 @@ at::Tensor _sparse_log_softmax_Dimname_generated_plumbing(const at::Tensor & sel
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(_sparse_log_softmax, Dimname)(self, dim, dtype);
+    return at::_ops::_sparse_log_softmax_Dimname::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12470,7 +12470,7 @@ at::Tensor _sparse_log_softmax_generated_plumbing(const at::Tensor & self, int64
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_sparse_log_softmax)(self, dim, half_to_float);
+    return at::_ops::_sparse_log_softmax::call(self, dim, half_to_float);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12485,7 +12485,7 @@ at::Tensor _sparse_log_softmax_backward_data_generated_plumbing(const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_sparse_log_softmax_backward_data)(grad_output, output, dim, self);
+    return at::_ops::_sparse_log_softmax_backward_data::call(grad_output, output, dim, self);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -12506,7 +12506,7 @@ at::Tensor norm_ScalarOpt_dtype_generated_plumbing(const at::Tensor & self, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(norm, ScalarOpt_dtype)(self, p, dtype);
+    return at::_ops::norm_ScalarOpt_dtype::call(self, p, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12521,7 +12521,7 @@ at::Tensor norm_Scalar_generated_plumbing(const at::Tensor & self, const at::Sca
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(norm, Scalar)(self, p);
+    return at::_ops::norm_Scalar::call(self, p);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12536,7 +12536,7 @@ at::Tensor norm_ScalarOpt_dim_dtype_generated_plumbing(const at::Tensor & self, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(norm, ScalarOpt_dim_dtype)(self, p, dim, keepdim, dtype);
+    return at::_ops::norm_ScalarOpt_dim_dtype::call(self, p, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12551,7 +12551,7 @@ at::Tensor norm_ScalarOpt_dim_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(norm, ScalarOpt_dim)(self, p, dim, keepdim);
+    return at::_ops::norm_ScalarOpt_dim::call(self, p, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12566,7 +12566,7 @@ at::Tensor norm_names_ScalarOpt_dim_dtype_generated_plumbing(const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(norm, names_ScalarOpt_dim_dtype)(self, p, dim, keepdim, dtype);
+    return at::_ops::norm_names_ScalarOpt_dim_dtype::call(self, p, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12581,7 +12581,7 @@ at::Tensor norm_names_ScalarOpt_dim_generated_plumbing(const at::Tensor & self, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(norm, names_ScalarOpt_dim)(self, p, dim, keepdim);
+    return at::_ops::norm_names_ScalarOpt_dim::call(self, p, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12596,7 +12596,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(frexp, Tensor)(self);
+    return at::_ops::frexp_Tensor::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12611,7 +12611,7 @@ at::Tensor frobenius_norm_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(frobenius_norm)(self);
+    return at::_ops::frobenius_norm::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12626,7 +12626,7 @@ at::Tensor frobenius_norm_dim_generated_plumbing(const at::Tensor & self, at::In
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(frobenius_norm, dim)(self, dim, keepdim);
+    return at::_ops::frobenius_norm_dim::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12641,7 +12641,7 @@ at::Tensor nuclear_norm_generated_plumbing(const at::Tensor & self, bool keepdim
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(nuclear_norm)(self, keepdim);
+    return at::_ops::nuclear_norm::call(self, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12656,7 +12656,7 @@ at::Tensor nuclear_norm_dim_generated_plumbing(const at::Tensor & self, at::IntA
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(nuclear_norm, dim)(self, dim, keepdim);
+    return at::_ops::nuclear_norm_dim::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12671,7 +12671,7 @@ at::Tensor clone_generated_plumbing(const at::Tensor & self, c10::optional<at::M
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(clone)(self, memory_format);
+    return at::_ops::clone::call(self, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12686,7 +12686,7 @@ at::Tensor positive_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(positive)(self);
+    return at::_ops::positive::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12701,7 +12701,7 @@ const at::Tensor & resize_as__generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(the_template, cur_level)) {
-    return ATEN_FN(resize_as_)(self, the_template, memory_format);
+    return at::_ops::resize_as_::call(self, the_template, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12719,7 +12719,7 @@ const at::Tensor & resize_as_sparse__generated_plumbing(const at::Tensor & self,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(the_template, cur_level)) {
-    return ATEN_FN(resize_as_sparse_)(self, the_template);
+    return at::_ops::resize_as_sparse_::call(self, the_template);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12737,7 +12737,7 @@ at::Tensor & zero__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(zero_)(self);
+    return at::_ops::zero_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12752,7 +12752,7 @@ at::Tensor sub_Tensor_generated_plumbing(const at::Tensor & self, const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(sub, Tensor)(self, other, alpha);
+    return at::_ops::sub_Tensor::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12770,7 +12770,7 @@ at::Tensor & sub__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(sub_, Tensor)(self, other, alpha);
+    return at::_ops::sub__Tensor::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12788,7 +12788,7 @@ at::Tensor sub_Scalar_generated_plumbing(const at::Tensor & self, const at::Scal
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(sub, Scalar)(self, other, alpha);
+    return at::_ops::sub_Scalar::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12803,7 +12803,7 @@ at::Tensor & sub__Scalar_generated_plumbing(at::Tensor & self, const at::Scalar 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(sub_, Scalar)(self, other, alpha);
+    return at::_ops::sub__Scalar::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12818,7 +12818,7 @@ at::Tensor subtract_Tensor_generated_plumbing(const at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(subtract, Tensor)(self, other, alpha);
+    return at::_ops::subtract_Tensor::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12836,7 +12836,7 @@ at::Tensor & subtract__Tensor_generated_plumbing(at::Tensor & self, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(subtract_, Tensor)(self, other, alpha);
+    return at::_ops::subtract__Tensor::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12854,7 +12854,7 @@ at::Tensor subtract_Scalar_generated_plumbing(const at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(subtract, Scalar)(self, other, alpha);
+    return at::_ops::subtract_Scalar::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12869,7 +12869,7 @@ at::Tensor & subtract__Scalar_generated_plumbing(at::Tensor & self, const at::Sc
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(subtract_, Scalar)(self, other, alpha);
+    return at::_ops::subtract__Scalar::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12884,7 +12884,7 @@ at::Tensor rsub_Tensor_generated_plumbing(const at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(rsub, Tensor)(self, other, alpha);
+    return at::_ops::rsub_Tensor::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12902,7 +12902,7 @@ at::Tensor heaviside_generated_plumbing(const at::Tensor & self, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN(heaviside)(self, values);
+    return at::_ops::heaviside::call(self, values);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12920,7 +12920,7 @@ at::Tensor & heaviside__generated_plumbing(at::Tensor & self, const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN(heaviside_)(self, values);
+    return at::_ops::heaviside_::call(self, values);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12938,7 +12938,7 @@ at::Tensor rsub_Scalar_generated_plumbing(const at::Tensor & self, const at::Sca
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(rsub, Scalar)(self, other, alpha);
+    return at::_ops::rsub_Scalar::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12953,7 +12953,7 @@ at::Tensor _sparse_addmm_generated_plumbing(const at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(sparse, cur_level) && !isBatchedAtLevel(dense, cur_level)) {
-    return ATEN_FN(_sparse_addmm)(self, sparse, dense, beta, alpha);
+    return at::_ops::_sparse_addmm::call(self, sparse, dense, beta, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12974,7 +12974,7 @@ at::Tensor sparse_sampled_addmm_generated_plumbing(const at::Tensor & self, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mat1, cur_level) && !isBatchedAtLevel(mat2, cur_level)) {
-    return ATEN_FN(sparse_sampled_addmm)(self, mat1, mat2, beta, alpha);
+    return at::_ops::sparse_sampled_addmm::call(self, mat1, mat2, beta, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -12995,7 +12995,7 @@ at::Tensor addmm_generated_plumbing(const at::Tensor & self, const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mat1, cur_level) && !isBatchedAtLevel(mat2, cur_level)) {
-    return ATEN_FN(addmm)(self, mat1, mat2, beta, alpha);
+    return at::_ops::addmm::call(self, mat1, mat2, beta, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13016,7 +13016,7 @@ at::Tensor & addmm__generated_plumbing(at::Tensor & self, const at::Tensor & mat
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mat1, cur_level) && !isBatchedAtLevel(mat2, cur_level)) {
-    return ATEN_FN(addmm_)(self, mat1, mat2, beta, alpha);
+    return at::_ops::addmm_::call(self, mat1, mat2, beta, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13037,7 +13037,7 @@ at::Tensor sparse_csr_tensor_crow_col_value_size_generated_plumbing(const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(crow_indices, cur_level) && !isBatchedAtLevel(col_indices, cur_level) && !isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN2(sparse_csr_tensor, crow_col_value_size)(crow_indices, col_indices, values, size, dtype, layout, device, pin_memory);
+    return at::_ops::sparse_csr_tensor_crow_col_value_size::call(crow_indices, col_indices, values, size, dtype, layout, device, pin_memory);
   }
   Tensor crow_indices_value;
   optional<int64_t> crow_indices_bdim;
@@ -13058,7 +13058,7 @@ at::Tensor sparse_csr_tensor_crow_col_value_generated_plumbing(const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(crow_indices, cur_level) && !isBatchedAtLevel(col_indices, cur_level) && !isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN2(sparse_csr_tensor, crow_col_value)(crow_indices, col_indices, values, dtype, layout, device, pin_memory);
+    return at::_ops::sparse_csr_tensor_crow_col_value::call(crow_indices, col_indices, values, dtype, layout, device, pin_memory);
   }
   Tensor crow_indices_value;
   optional<int64_t> crow_indices_bdim;
@@ -13079,7 +13079,7 @@ at::Tensor _sparse_csr_tensor_unsafe_generated_plumbing(const at::Tensor & crow_
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(crow_indices, cur_level) && !isBatchedAtLevel(col_indices, cur_level) && !isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN(_sparse_csr_tensor_unsafe)(crow_indices, col_indices, values, size, dtype, layout, device, pin_memory);
+    return at::_ops::_sparse_csr_tensor_unsafe::call(crow_indices, col_indices, values, size, dtype, layout, device, pin_memory);
   }
   Tensor crow_indices_value;
   optional<int64_t> crow_indices_bdim;
@@ -13100,7 +13100,7 @@ at::Tensor sparse_coo_tensor_indices_generated_plumbing(const at::Tensor & indic
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN2(sparse_coo_tensor, indices)(indices, values, dtype, layout, device, pin_memory);
+    return at::_ops::sparse_coo_tensor_indices::call(indices, values, dtype, layout, device, pin_memory);
   }
   Tensor indices_value;
   optional<int64_t> indices_bdim;
@@ -13118,7 +13118,7 @@ at::Tensor sparse_coo_tensor_indices_size_generated_plumbing(const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN2(sparse_coo_tensor, indices_size)(indices, values, size, dtype, layout, device, pin_memory);
+    return at::_ops::sparse_coo_tensor_indices_size::call(indices, values, size, dtype, layout, device, pin_memory);
   }
   Tensor indices_value;
   optional<int64_t> indices_bdim;
@@ -13136,7 +13136,7 @@ at::Tensor _sparse_coo_tensor_unsafe_generated_plumbing(const at::Tensor & indic
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN(_sparse_coo_tensor_unsafe)(indices, values, size, dtype, layout, device, pin_memory);
+    return at::_ops::_sparse_coo_tensor_unsafe::call(indices, values, size, dtype, layout, device, pin_memory);
   }
   Tensor indices_value;
   optional<int64_t> indices_bdim;
@@ -13154,7 +13154,7 @@ at::Tensor _sparse_coo_tensor_with_dims_and_tensors_generated_plumbing(int64_t s
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(indices, cur_level) && !isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN(_sparse_coo_tensor_with_dims_and_tensors)(sparse_dim, dense_dim, size, indices, values, dtype, layout, device, pin_memory);
+    return at::_ops::_sparse_coo_tensor_with_dims_and_tensors::call(sparse_dim, dense_dim, size, indices, values, dtype, layout, device, pin_memory);
   }
   Tensor indices_value;
   optional<int64_t> indices_bdim;
@@ -13172,7 +13172,7 @@ const at::Tensor & sparse_resize__generated_plumbing(const at::Tensor & self, at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sparse_resize_)(self, size, sparse_dim, dense_dim);
+    return at::_ops::sparse_resize_::call(self, size, sparse_dim, dense_dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13187,7 +13187,7 @@ const at::Tensor & sparse_resize_and_clear__generated_plumbing(const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sparse_resize_and_clear_)(self, size, sparse_dim, dense_dim);
+    return at::_ops::sparse_resize_and_clear_::call(self, size, sparse_dim, dense_dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13202,7 +13202,7 @@ at::Tensor sparse_mask_generated_plumbing(const at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mask, cur_level)) {
-    return ATEN_FN(sparse_mask)(self, mask);
+    return at::_ops::sparse_mask::call(self, mask);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13220,7 +13220,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_to_cpu)(tensors);
+    return at::_ops::_to_cpu::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -13233,7 +13233,7 @@ at::Tensor to_dense_generated_plumbing(const at::Tensor & self, c10::optional<at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(to_dense)(self, dtype);
+    return at::_ops::to_dense::call(self, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13248,7 +13248,7 @@ at::Tensor to_dense_backward_generated_plumbing(const at::Tensor & grad, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN(to_dense_backward)(grad, input);
+    return at::_ops::to_dense_backward::call(grad, input);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -13266,7 +13266,7 @@ at::Tensor coalesce_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(coalesce)(self);
+    return at::_ops::coalesce::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13281,7 +13281,7 @@ at::Tensor _coalesce_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_coalesce)(self);
+    return at::_ops::_coalesce::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13296,7 +13296,7 @@ at::Tensor _indices_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_indices)(self);
+    return at::_ops::_indices::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13311,7 +13311,7 @@ at::Tensor _values_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_values)(self);
+    return at::_ops::_values::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13326,7 +13326,7 @@ at::Tensor & _coalesced__generated_plumbing(at::Tensor & self, bool coalesced) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_coalesced_)(self, coalesced);
+    return at::_ops::_coalesced_::call(self, coalesced);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13341,7 +13341,7 @@ at::Tensor indices_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(indices)(self);
+    return at::_ops::indices::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13356,7 +13356,7 @@ at::Tensor values_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(values)(self);
+    return at::_ops::values::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13371,7 +13371,7 @@ at::Tensor crow_indices_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(crow_indices)(self);
+    return at::_ops::crow_indices::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13386,7 +13386,7 @@ at::Tensor col_indices_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(col_indices)(self);
+    return at::_ops::col_indices::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13401,7 +13401,7 @@ at::Tensor hspmm_generated_plumbing(const at::Tensor & mat1, const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(mat1, cur_level) && !isBatchedAtLevel(mat2, cur_level)) {
-    return ATEN_FN(hspmm)(mat1, mat2);
+    return at::_ops::hspmm::call(mat1, mat2);
   }
   Tensor mat1_value;
   optional<int64_t> mat1_bdim;
@@ -13419,7 +13419,7 @@ at::Tensor & copy_sparse_to_sparse__generated_plumbing(at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(src, cur_level)) {
-    return ATEN_FN(copy_sparse_to_sparse_)(self, src, non_blocking);
+    return at::_ops::copy_sparse_to_sparse_::call(self, src, non_blocking);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13437,7 +13437,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(unbind, int)(self, dim);
+    return at::_ops::unbind_int::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13452,7 +13452,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(unbind, Dimname)(self, dim);
+    return at::_ops::unbind_Dimname::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13467,7 +13467,7 @@ at::Tensor to_sparse_sparse_dim_generated_plumbing(const at::Tensor & self, int6
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(to_sparse, sparse_dim)(self, sparse_dim);
+    return at::_ops::to_sparse_sparse_dim::call(self, sparse_dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13482,7 +13482,7 @@ at::Tensor to_sparse_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(to_sparse)(self);
+    return at::_ops::to_sparse::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13497,7 +13497,7 @@ at::Tensor to_mkldnn_generated_plumbing(const at::Tensor & self, c10::optional<a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(to_mkldnn)(self, dtype);
+    return at::_ops::to_mkldnn::call(self, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13512,7 +13512,7 @@ at::Tensor mkldnn_reorder_conv2d_weight_generated_plumbing(const at::Tensor & se
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mkldnn_reorder_conv2d_weight)(self, padding, stride, dilation, groups);
+    return at::_ops::mkldnn_reorder_conv2d_weight::call(self, padding, stride, dilation, groups);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13527,7 +13527,7 @@ at::Tensor mkldnn_reorder_conv3d_weight_generated_plumbing(const at::Tensor & se
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mkldnn_reorder_conv3d_weight)(self, padding, stride, dilation, groups);
+    return at::_ops::mkldnn_reorder_conv3d_weight::call(self, padding, stride, dilation, groups);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13542,7 +13542,7 @@ at::Tensor to_mkldnn_backward_generated_plumbing(const at::Tensor & grad, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN(to_mkldnn_backward)(grad, input);
+    return at::_ops::to_mkldnn_backward::call(grad, input);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -13560,7 +13560,7 @@ at::Tensor quantize_per_tensor_dynamic_generated_plumbing(const at::Tensor & sel
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(quantize_per_tensor_dynamic)(self, dtype, reduce_range);
+    return at::_ops::quantize_per_tensor_dynamic::call(self, dtype, reduce_range);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13575,7 +13575,7 @@ at::Tensor quantize_per_tensor_generated_plumbing(const at::Tensor & self, doubl
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(quantize_per_tensor)(self, scale, zero_point, dtype);
+    return at::_ops::quantize_per_tensor::call(self, scale, zero_point, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13590,7 +13590,7 @@ at::Tensor quantize_per_tensor_tensor_qparams_generated_plumbing(const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(scale, cur_level) && !isBatchedAtLevel(zero_point, cur_level)) {
-    return ATEN_FN2(quantize_per_tensor, tensor_qparams)(self, scale, zero_point, dtype);
+    return at::_ops::quantize_per_tensor_tensor_qparams::call(self, scale, zero_point, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13611,7 +13611,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level) && !isBatchedAtLevel(scales, cur_level) && !isBatchedAtLevel(zero_points, cur_level)) {
-    return ATEN_FN2(quantize_per_tensor, tensors)(tensors, scales, zero_points, dtype);
+    return at::_ops::quantize_per_tensor_tensors::call(tensors, scales, zero_points, dtype);
   }
   Tensor scales_value;
   optional<int64_t> scales_bdim;
@@ -13629,7 +13629,7 @@ at::Tensor quantize_per_channel_generated_plumbing(const at::Tensor & self, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(scales, cur_level) && !isBatchedAtLevel(zero_points, cur_level)) {
-    return ATEN_FN(quantize_per_channel)(self, scales, zero_points, axis, dtype);
+    return at::_ops::quantize_per_channel::call(self, scales, zero_points, axis, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13650,7 +13650,7 @@ at::Tensor dequantize_self_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(dequantize, self)(self);
+    return at::_ops::dequantize_self::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13665,7 +13665,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(dequantize, tensors)(tensors);
+    return at::_ops::dequantize_tensors::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -13678,7 +13678,7 @@ at::Tensor q_per_channel_scales_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(q_per_channel_scales)(self);
+    return at::_ops::q_per_channel_scales::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13693,7 +13693,7 @@ at::Tensor q_per_channel_zero_points_generated_plumbing(const at::Tensor & self)
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(q_per_channel_zero_points)(self);
+    return at::_ops::q_per_channel_zero_points::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13708,7 +13708,7 @@ at::Tensor int_repr_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(int_repr)(self);
+    return at::_ops::int_repr::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13723,7 +13723,7 @@ at::Tensor _make_per_tensor_quantized_tensor_generated_plumbing(const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_make_per_tensor_quantized_tensor)(self, scale, zero_point);
+    return at::_ops::_make_per_tensor_quantized_tensor::call(self, scale, zero_point);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13738,7 +13738,7 @@ at::Tensor _make_per_channel_quantized_tensor_generated_plumbing(const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(scale, cur_level) && !isBatchedAtLevel(zero_point, cur_level)) {
-    return ATEN_FN(_make_per_channel_quantized_tensor)(self, scale, zero_point, axis);
+    return at::_ops::_make_per_channel_quantized_tensor::call(self, scale, zero_point, axis);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13759,7 +13759,7 @@ at::Tensor fake_quantize_per_tensor_affine_generated_plumbing(const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fake_quantize_per_tensor_affine)(self, scale, zero_point, quant_min, quant_max);
+    return at::_ops::fake_quantize_per_tensor_affine::call(self, scale, zero_point, quant_min, quant_max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13774,7 +13774,7 @@ at::Tensor fake_quantize_per_tensor_affine_tensor_qparams_generated_plumbing(con
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(scale, cur_level) && !isBatchedAtLevel(zero_point, cur_level)) {
-    return ATEN_FN2(fake_quantize_per_tensor_affine, tensor_qparams)(self, scale, zero_point, quant_min, quant_max);
+    return at::_ops::fake_quantize_per_tensor_affine_tensor_qparams::call(self, scale, zero_point, quant_min, quant_max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13795,7 +13795,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fake_quantize_per_tensor_affine_cachemask)(self, scale, zero_point, quant_min, quant_max);
+    return at::_ops::fake_quantize_per_tensor_affine_cachemask::call(self, scale, zero_point, quant_min, quant_max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13810,7 +13810,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(scale, cur_level) && !isBatchedAtLevel(zero_point, cur_level) && !isBatchedAtLevel(fake_quant_enabled, cur_level)) {
-    return ATEN_FN(_fake_quantize_per_tensor_affine_cachemask_tensor_qparams)(self, scale, zero_point, fake_quant_enabled, quant_min, quant_max);
+    return at::_ops::_fake_quantize_per_tensor_affine_cachemask_tensor_qparams::call(self, scale, zero_point, fake_quant_enabled, quant_min, quant_max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13834,7 +13834,7 @@ at::Tensor fake_quantize_per_tensor_affine_cachemask_backward_generated_plumbing
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(mask, cur_level)) {
-    return ATEN_FN(fake_quantize_per_tensor_affine_cachemask_backward)(grad, mask);
+    return at::_ops::fake_quantize_per_tensor_affine_cachemask_backward::call(grad, mask);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -13852,7 +13852,7 @@ at::Tensor _fake_quantize_learnable_per_tensor_affine_generated_plumbing(const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(scale, cur_level) && !isBatchedAtLevel(zero_point, cur_level)) {
-    return ATEN_FN(_fake_quantize_learnable_per_tensor_affine)(self, scale, zero_point, quant_min, quant_max, grad_factor);
+    return at::_ops::_fake_quantize_learnable_per_tensor_affine::call(self, scale, zero_point, quant_min, quant_max, grad_factor);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13873,7 +13873,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(scale, cur_level) && !isBatchedAtLevel(zero_point, cur_level)) {
-    return ATEN_FN(_fake_quantize_learnable_per_tensor_affine_backward)(grad, self, scale, zero_point, quant_min, quant_max, grad_factor);
+    return at::_ops::_fake_quantize_learnable_per_tensor_affine_backward::call(grad, self, scale, zero_point, quant_min, quant_max, grad_factor);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -13897,7 +13897,7 @@ at::Tensor fake_quantize_per_channel_affine_generated_plumbing(const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(scale, cur_level) && !isBatchedAtLevel(zero_point, cur_level)) {
-    return ATEN_FN(fake_quantize_per_channel_affine)(self, scale, zero_point, axis, quant_min, quant_max);
+    return at::_ops::fake_quantize_per_channel_affine::call(self, scale, zero_point, axis, quant_min, quant_max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13918,7 +13918,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(scale, cur_level) && !isBatchedAtLevel(zero_point, cur_level)) {
-    return ATEN_FN(fake_quantize_per_channel_affine_cachemask)(self, scale, zero_point, axis, quant_min, quant_max);
+    return at::_ops::fake_quantize_per_channel_affine_cachemask::call(self, scale, zero_point, axis, quant_min, quant_max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13939,7 +13939,7 @@ at::Tensor fake_quantize_per_channel_affine_cachemask_backward_generated_plumbin
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(mask, cur_level)) {
-    return ATEN_FN(fake_quantize_per_channel_affine_cachemask_backward)(grad, mask);
+    return at::_ops::fake_quantize_per_channel_affine_cachemask_backward::call(grad, mask);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -13957,7 +13957,7 @@ at::Tensor _fake_quantize_learnable_per_channel_affine_generated_plumbing(const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(scale, cur_level) && !isBatchedAtLevel(zero_point, cur_level)) {
-    return ATEN_FN(_fake_quantize_learnable_per_channel_affine)(self, scale, zero_point, axis, quant_min, quant_max, grad_factor);
+    return at::_ops::_fake_quantize_learnable_per_channel_affine::call(self, scale, zero_point, axis, quant_min, quant_max, grad_factor);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -13978,7 +13978,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(scale, cur_level) && !isBatchedAtLevel(zero_point, cur_level)) {
-    return ATEN_FN(_fake_quantize_learnable_per_channel_affine_backward)(grad, self, scale, zero_point, axis, quant_min, quant_max, grad_factor);
+    return at::_ops::_fake_quantize_learnable_per_channel_affine_backward::call(grad, self, scale, zero_point, axis, quant_min, quant_max, grad_factor);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -14002,7 +14002,7 @@ at::Tensor fused_moving_avg_obs_fake_quant_generated_plumbing(const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(observer_on, cur_level) && !isBatchedAtLevel(fake_quant_on, cur_level) && !isBatchedAtLevel(running_min, cur_level) && !isBatchedAtLevel(running_max, cur_level) && !isBatchedAtLevel(scale, cur_level) && !isBatchedAtLevel(zero_point, cur_level)) {
-    return ATEN_FN(fused_moving_avg_obs_fake_quant)(self, observer_on, fake_quant_on, running_min, running_max, scale, zero_point, averaging_const, quant_min, quant_max, ch_axis, per_row_fake_quant, symmetric_quant);
+    return at::_ops::fused_moving_avg_obs_fake_quant::call(self, observer_on, fake_quant_on, running_min, running_max, scale, zero_point, averaging_const, quant_min, quant_max, ch_axis, per_row_fake_quant, symmetric_quant);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -14035,7 +14035,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(observer_on, cur_level) && !isBatchedAtLevel(fake_quant_on, cur_level) && !isBatchedAtLevel(running_min, cur_level) && !isBatchedAtLevel(running_max, cur_level) && !isBatchedAtLevel(scale, cur_level) && !isBatchedAtLevel(zero_point, cur_level)) {
-    return ATEN_FN(_fused_moving_avg_obs_fq_helper)(self, observer_on, fake_quant_on, running_min, running_max, scale, zero_point, averaging_const, quant_min, quant_max, ch_axis, per_row_fake_quant, symmetric_quant);
+    return at::_ops::_fused_moving_avg_obs_fq_helper::call(self, observer_on, fake_quant_on, running_min, running_max, scale, zero_point, averaging_const, quant_min, quant_max, ch_axis, per_row_fake_quant, symmetric_quant);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -14068,7 +14068,7 @@ at::Tensor _saturate_weight_to_fp16_generated_plumbing(const at::Tensor & weight
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(_saturate_weight_to_fp16)(weight);
+    return at::_ops::_saturate_weight_to_fp16::call(weight);
   }
   Tensor weight_value;
   optional<int64_t> weight_bdim;
@@ -14083,7 +14083,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN(choose_qparams_optimized)(input, numel, n_bins, ratio, bit_width);
+    return at::_ops::choose_qparams_optimized::call(input, numel, n_bins, ratio, bit_width);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -14098,7 +14098,7 @@ at::Tensor _autocast_to_reduced_precision_generated_plumbing(const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_autocast_to_reduced_precision)(self, cuda_enabled, cpu_enabled, cuda_dtype, cpu_dtype);
+    return at::_ops::_autocast_to_reduced_precision::call(self, cuda_enabled, cpu_enabled, cuda_dtype, cpu_dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -14113,7 +14113,7 @@ at::Tensor _autocast_to_full_precision_generated_plumbing(const at::Tensor & sel
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_autocast_to_full_precision)(self, cuda_enabled, cpu_enabled);
+    return at::_ops::_autocast_to_full_precision::call(self, cuda_enabled, cpu_enabled);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -14128,7 +14128,7 @@ at::Tensor _to_copy_generated_plumbing(const at::Tensor & self, c10::optional<at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_to_copy)(self, dtype, layout, device, pin_memory, non_blocking, memory_format);
+    return at::_ops::_to_copy::call(self, dtype, layout, device, pin_memory, non_blocking, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -14143,7 +14143,7 @@ at::Tensor to_dtype_layout_generated_plumbing(const at::Tensor & self, c10::opti
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(to, dtype_layout)(self, dtype, layout, device, pin_memory, non_blocking, copy, memory_format);
+    return at::_ops::to_dtype_layout::call(self, dtype, layout, device, pin_memory, non_blocking, copy, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -14158,7 +14158,7 @@ at::Tensor to_device_generated_plumbing(const at::Tensor & self, at::Device devi
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(to, device)(self, device, dtype, non_blocking, copy, memory_format);
+    return at::_ops::to_device::call(self, device, dtype, non_blocking, copy, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -14173,7 +14173,7 @@ at::Tensor to_dtype_generated_plumbing(const at::Tensor & self, at::ScalarType d
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(to, dtype)(self, dtype, non_blocking, copy, memory_format);
+    return at::_ops::to_dtype::call(self, dtype, non_blocking, copy, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -14188,7 +14188,7 @@ at::Tensor to_other_generated_plumbing(const at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(to, other)(self, other, non_blocking, copy, memory_format);
+    return at::_ops::to_other::call(self, other, non_blocking, copy, memory_format);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -14206,7 +14206,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(meshgrid)(tensors);
+    return at::_ops::meshgrid::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -14219,7 +14219,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(meshgrid, indexing)(tensors, indexing);
+    return at::_ops::meshgrid_indexing::call(tensors, indexing);
   }
 
   auto results = batch_rule(tensors, indexing);
@@ -14232,7 +14232,7 @@ at::Tensor cartesian_prod_generated_plumbing(at::TensorList tensors) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(cartesian_prod)(tensors);
+    return at::_ops::cartesian_prod::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -14245,7 +14245,7 @@ at::Tensor combinations_generated_plumbing(const at::Tensor & self, int64_t r, b
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(combinations)(self, r, with_replacement);
+    return at::_ops::combinations::call(self, r, with_replacement);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -14260,7 +14260,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input_gates, cur_level) && !isBatchedAtLevel(hidden_gates, cur_level) && !isBatchedAtLevel(cx, cur_level) && !isBatchedAtLevel(input_bias, cur_level) && !isBatchedAtLevel(hidden_bias, cur_level)) {
-    return ATEN_FN(_thnn_fused_lstm_cell)(input_gates, hidden_gates, cx, input_bias, hidden_bias);
+    return at::_ops::_thnn_fused_lstm_cell::call(input_gates, hidden_gates, cx, input_bias, hidden_bias);
   }
   Tensor input_gates_value;
   optional<int64_t> input_gates_bdim;
@@ -14291,7 +14291,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_hy, cur_level) && !isBatchedAtLevel(grad_cy, cur_level) && !isBatchedAtLevel(cx, cur_level) && !isBatchedAtLevel(cy, cur_level) && !isBatchedAtLevel(workspace, cur_level)) {
-    return ATEN_FN(_thnn_fused_lstm_cell_backward)(grad_hy, grad_cy, cx, cy, workspace, has_bias);
+    return at::_ops::_thnn_fused_lstm_cell_backward::call(grad_hy, grad_cy, cx, cy, workspace, has_bias);
   }
   Tensor cx_value;
   optional<int64_t> cx_bdim;
@@ -14322,7 +14322,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_hy, cur_level) && !isBatchedAtLevel(grad_cy, cur_level) && !isBatchedAtLevel(input_gates, cur_level) && !isBatchedAtLevel(hidden_gates, cur_level) && !isBatchedAtLevel(input_bias, cur_level) && !isBatchedAtLevel(hidden_bias, cur_level) && !isBatchedAtLevel(cx, cur_level) && !isBatchedAtLevel(cy, cur_level)) {
-    return ATEN_FN(_thnn_differentiable_lstm_cell_backward)(grad_hy, grad_cy, input_gates, hidden_gates, input_bias, hidden_bias, cx, cy);
+    return at::_ops::_thnn_differentiable_lstm_cell_backward::call(grad_hy, grad_cy, input_gates, hidden_gates, input_bias, hidden_bias, cx, cy);
   }
   Tensor input_gates_value;
   optional<int64_t> input_gates_bdim;
@@ -14366,7 +14366,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input_gates, cur_level) && !isBatchedAtLevel(hidden_gates, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(input_bias, cur_level) && !isBatchedAtLevel(hidden_bias, cur_level)) {
-    return ATEN_FN(_thnn_fused_gru_cell)(input_gates, hidden_gates, hx, input_bias, hidden_bias);
+    return at::_ops::_thnn_fused_gru_cell::call(input_gates, hidden_gates, hx, input_bias, hidden_bias);
   }
   Tensor input_gates_value;
   optional<int64_t> input_gates_bdim;
@@ -14397,7 +14397,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_hy, cur_level) && !isBatchedAtLevel(workspace, cur_level)) {
-    return ATEN_FN(_thnn_fused_gru_cell_backward)(grad_hy, workspace, has_bias);
+    return at::_ops::_thnn_fused_gru_cell_backward::call(grad_hy, workspace, has_bias);
   }
   Tensor grad_hy_value;
   optional<int64_t> grad_hy_bdim;
@@ -14415,7 +14415,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_hy, cur_level) && !isBatchedAtLevel(input_gates, cur_level) && !isBatchedAtLevel(hidden_gates, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(input_bias, cur_level) && !isBatchedAtLevel(hidden_bias, cur_level)) {
-    return ATEN_FN(_thnn_differentiable_gru_cell_backward)(grad_hy, input_gates, hidden_gates, hx, input_bias, hidden_bias);
+    return at::_ops::_thnn_differentiable_gru_cell_backward::call(grad_hy, input_gates, hidden_gates, hx, input_bias, hidden_bias);
   }
   Tensor grad_hy_value;
   optional<int64_t> grad_hy_bdim;
@@ -14449,7 +14449,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(params, cur_level)) {
-    return ATEN_FN2(lstm, input)(input, hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first);
+    return at::_ops::lstm_input::call(input, hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -14464,7 +14464,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(data, cur_level) && !isBatchedAtLevel(batch_sizes, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(params, cur_level)) {
-    return ATEN_FN2(lstm, data)(data, batch_sizes, hx, params, has_biases, num_layers, dropout, train, bidirectional);
+    return at::_ops::lstm_data::call(data, batch_sizes, hx, params, has_biases, num_layers, dropout, train, bidirectional);
   }
   Tensor data_value;
   optional<int64_t> data_bdim;
@@ -14482,7 +14482,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(params, cur_level)) {
-    return ATEN_FN2(gru, input)(input, hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first);
+    return at::_ops::gru_input::call(input, hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -14500,7 +14500,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(data, cur_level) && !isBatchedAtLevel(batch_sizes, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(params, cur_level)) {
-    return ATEN_FN2(gru, data)(data, batch_sizes, hx, params, has_biases, num_layers, dropout, train, bidirectional);
+    return at::_ops::gru_data::call(data, batch_sizes, hx, params, has_biases, num_layers, dropout, train, bidirectional);
   }
   Tensor data_value;
   optional<int64_t> data_bdim;
@@ -14521,7 +14521,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(params, cur_level)) {
-    return ATEN_FN2(rnn_tanh, input)(input, hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first);
+    return at::_ops::rnn_tanh_input::call(input, hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -14539,7 +14539,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(data, cur_level) && !isBatchedAtLevel(batch_sizes, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(params, cur_level)) {
-    return ATEN_FN2(rnn_tanh, data)(data, batch_sizes, hx, params, has_biases, num_layers, dropout, train, bidirectional);
+    return at::_ops::rnn_tanh_data::call(data, batch_sizes, hx, params, has_biases, num_layers, dropout, train, bidirectional);
   }
   Tensor data_value;
   optional<int64_t> data_bdim;
@@ -14560,7 +14560,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(params, cur_level)) {
-    return ATEN_FN2(rnn_relu, input)(input, hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first);
+    return at::_ops::rnn_relu_input::call(input, hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -14578,7 +14578,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(data, cur_level) && !isBatchedAtLevel(batch_sizes, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(params, cur_level)) {
-    return ATEN_FN2(rnn_relu, data)(data, batch_sizes, hx, params, has_biases, num_layers, dropout, train, bidirectional);
+    return at::_ops::rnn_relu_data::call(data, batch_sizes, hx, params, has_biases, num_layers, dropout, train, bidirectional);
   }
   Tensor data_value;
   optional<int64_t> data_bdim;
@@ -14599,7 +14599,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(w_ih, cur_level) && !isBatchedAtLevel(w_hh, cur_level) && !isBatchedAtLevel(b_ih, cur_level) && !isBatchedAtLevel(b_hh, cur_level)) {
-    return ATEN_FN(lstm_cell)(input, hx, w_ih, w_hh, b_ih, b_hh);
+    return at::_ops::lstm_cell::call(input, hx, w_ih, w_hh, b_ih, b_hh);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -14630,7 +14630,7 @@ at::Tensor gru_cell_generated_plumbing(const at::Tensor & input, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(w_ih, cur_level) && !isBatchedAtLevel(w_hh, cur_level) && !isBatchedAtLevel(b_ih, cur_level) && !isBatchedAtLevel(b_hh, cur_level)) {
-    return ATEN_FN(gru_cell)(input, hx, w_ih, w_hh, b_ih, b_hh);
+    return at::_ops::gru_cell::call(input, hx, w_ih, w_hh, b_ih, b_hh);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -14664,7 +14664,7 @@ at::Tensor rnn_tanh_cell_generated_plumbing(const at::Tensor & input, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(w_ih, cur_level) && !isBatchedAtLevel(w_hh, cur_level) && !isBatchedAtLevel(b_ih, cur_level) && !isBatchedAtLevel(b_hh, cur_level)) {
-    return ATEN_FN(rnn_tanh_cell)(input, hx, w_ih, w_hh, b_ih, b_hh);
+    return at::_ops::rnn_tanh_cell::call(input, hx, w_ih, w_hh, b_ih, b_hh);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -14698,7 +14698,7 @@ at::Tensor rnn_relu_cell_generated_plumbing(const at::Tensor & input, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(w_ih, cur_level) && !isBatchedAtLevel(w_hh, cur_level) && !isBatchedAtLevel(b_ih, cur_level) && !isBatchedAtLevel(b_hh, cur_level)) {
-    return ATEN_FN(rnn_relu_cell)(input, hx, w_ih, w_hh, b_ih, b_hh);
+    return at::_ops::rnn_relu_cell::call(input, hx, w_ih, w_hh, b_ih, b_hh);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -14732,7 +14732,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(w_ih, cur_level) && !isBatchedAtLevel(w_hh, cur_level) && !isBatchedAtLevel(b_ih, cur_level) && !isBatchedAtLevel(b_hh, cur_level) && !isBatchedAtLevel(packed_ih, cur_level) && !isBatchedAtLevel(packed_hh, cur_level) && !isBatchedAtLevel(col_offsets_ih, cur_level) && !isBatchedAtLevel(col_offsets_hh, cur_level)) {
-    return ATEN_FN(quantized_lstm_cell)(input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh);
+    return at::_ops::quantized_lstm_cell::call(input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -14771,7 +14771,7 @@ at::Tensor quantized_gru_cell_generated_plumbing(const at::Tensor & input, const
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(w_ih, cur_level) && !isBatchedAtLevel(w_hh, cur_level) && !isBatchedAtLevel(b_ih, cur_level) && !isBatchedAtLevel(b_hh, cur_level) && !isBatchedAtLevel(packed_ih, cur_level) && !isBatchedAtLevel(packed_hh, cur_level) && !isBatchedAtLevel(col_offsets_ih, cur_level) && !isBatchedAtLevel(col_offsets_hh, cur_level)) {
-    return ATEN_FN(quantized_gru_cell)(input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh);
+    return at::_ops::quantized_gru_cell::call(input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -14813,7 +14813,7 @@ at::Tensor quantized_rnn_relu_cell_generated_plumbing(const at::Tensor & input, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(w_ih, cur_level) && !isBatchedAtLevel(w_hh, cur_level) && !isBatchedAtLevel(b_ih, cur_level) && !isBatchedAtLevel(b_hh, cur_level) && !isBatchedAtLevel(packed_ih, cur_level) && !isBatchedAtLevel(packed_hh, cur_level) && !isBatchedAtLevel(col_offsets_ih, cur_level) && !isBatchedAtLevel(col_offsets_hh, cur_level)) {
-    return ATEN_FN(quantized_rnn_relu_cell)(input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh);
+    return at::_ops::quantized_rnn_relu_cell::call(input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -14855,7 +14855,7 @@ at::Tensor quantized_rnn_tanh_cell_generated_plumbing(const at::Tensor & input, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(hx, cur_level) && !isBatchedAtLevel(w_ih, cur_level) && !isBatchedAtLevel(w_hh, cur_level) && !isBatchedAtLevel(b_ih, cur_level) && !isBatchedAtLevel(b_hh, cur_level) && !isBatchedAtLevel(packed_ih, cur_level) && !isBatchedAtLevel(packed_hh, cur_level) && !isBatchedAtLevel(col_offsets_ih, cur_level) && !isBatchedAtLevel(col_offsets_hh, cur_level)) {
-    return ATEN_FN(quantized_rnn_tanh_cell)(input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh);
+    return at::_ops::quantized_rnn_tanh_cell::call(input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -14897,7 +14897,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(lengths, cur_level)) {
-    return ATEN_FN(_pack_padded_sequence)(input, lengths, batch_first);
+    return at::_ops::_pack_padded_sequence::call(input, lengths, batch_first);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -14915,7 +14915,7 @@ at::Tensor _pack_padded_sequence_backward_generated_plumbing(const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(batch_sizes, cur_level)) {
-    return ATEN_FN(_pack_padded_sequence_backward)(grad, input_size, batch_sizes, batch_first);
+    return at::_ops::_pack_padded_sequence_backward::call(grad, input_size, batch_sizes, batch_first);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -14933,7 +14933,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(data, cur_level) && !isBatchedAtLevel(batch_sizes, cur_level)) {
-    return ATEN_FN(_pad_packed_sequence)(data, batch_sizes, batch_first, padding_value, total_length);
+    return at::_ops::_pad_packed_sequence::call(data, batch_sizes, batch_first, padding_value, total_length);
   }
   Tensor data_value;
   optional<int64_t> data_bdim;
@@ -14951,7 +14951,7 @@ at::Tensor & set__source_Storage_generated_plumbing(at::Tensor & self, at::Stora
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(set_, source_Storage)(self, source);
+    return at::_ops::set__source_Storage::call(self, source);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -14966,7 +14966,7 @@ at::Tensor & set__source_Storage_storage_offset_generated_plumbing(at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(set_, source_Storage_storage_offset)(self, source, storage_offset, size, stride);
+    return at::_ops::set__source_Storage_storage_offset::call(self, source, storage_offset, size, stride);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -14981,7 +14981,7 @@ at::Tensor & set__source_Tensor_generated_plumbing(at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(source, cur_level)) {
-    return ATEN_FN2(set_, source_Tensor)(self, source);
+    return at::_ops::set__source_Tensor::call(self, source);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -14999,7 +14999,7 @@ at::Tensor & set__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(set_)(self);
+    return at::_ops::set_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15014,7 +15014,7 @@ at::Tensor & masked_fill__Scalar_generated_plumbing(at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mask, cur_level)) {
-    return ATEN_FN2(masked_fill_, Scalar)(self, mask, value);
+    return at::_ops::masked_fill__Scalar::call(self, mask, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15032,7 +15032,7 @@ at::Tensor masked_fill_Scalar_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mask, cur_level)) {
-    return ATEN_FN2(masked_fill, Scalar)(self, mask, value);
+    return at::_ops::masked_fill_Scalar::call(self, mask, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15050,7 +15050,7 @@ at::Tensor & masked_fill__Tensor_generated_plumbing(at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mask, cur_level) && !isBatchedAtLevel(value, cur_level)) {
-    return ATEN_FN2(masked_fill_, Tensor)(self, mask, value);
+    return at::_ops::masked_fill__Tensor::call(self, mask, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15071,7 +15071,7 @@ at::Tensor masked_fill_Tensor_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mask, cur_level) && !isBatchedAtLevel(value, cur_level)) {
-    return ATEN_FN2(masked_fill, Tensor)(self, mask, value);
+    return at::_ops::masked_fill_Tensor::call(self, mask, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15092,7 +15092,7 @@ at::Tensor & masked_scatter__generated_plumbing(at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mask, cur_level) && !isBatchedAtLevel(source, cur_level)) {
-    return ATEN_FN(masked_scatter_)(self, mask, source);
+    return at::_ops::masked_scatter_::call(self, mask, source);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15113,7 +15113,7 @@ at::Tensor masked_scatter_generated_plumbing(const at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mask, cur_level) && !isBatchedAtLevel(source, cur_level)) {
-    return ATEN_FN(masked_scatter)(self, mask, source);
+    return at::_ops::masked_scatter::call(self, mask, source);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15134,7 +15134,7 @@ at::Tensor _masked_softmax_generated_plumbing(const at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mask, cur_level)) {
-    return ATEN_FN(_masked_softmax)(self, mask);
+    return at::_ops::_masked_softmax::call(self, mask);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15152,7 +15152,7 @@ at::Tensor view_generated_plumbing(const at::Tensor & self, at::IntArrayRef size
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(view)(self, size);
+    return at::_ops::view::call(self, size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15167,7 +15167,7 @@ at::Tensor view_dtype_generated_plumbing(const at::Tensor & self, at::ScalarType
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(view, dtype)(self, dtype);
+    return at::_ops::view_dtype::call(self, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15182,7 +15182,7 @@ at::Tensor & put__generated_plumbing(at::Tensor & self, const at::Tensor & index
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(source, cur_level)) {
-    return ATEN_FN(put_)(self, index, source, accumulate);
+    return at::_ops::put_::call(self, index, source, accumulate);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15203,7 +15203,7 @@ at::Tensor put_generated_plumbing(const at::Tensor & self, const at::Tensor & in
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(source, cur_level)) {
-    return ATEN_FN(put)(self, index, source, accumulate);
+    return at::_ops::put::call(self, index, source, accumulate);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15224,7 +15224,7 @@ at::Tensor & index_add__generated_plumbing(at::Tensor & self, int64_t dim, const
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(source, cur_level)) {
-    return ATEN_FN(index_add_)(self, dim, index, source, alpha);
+    return at::_ops::index_add_::call(self, dim, index, source, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15245,7 +15245,7 @@ at::Tensor index_add_generated_plumbing(const at::Tensor & self, int64_t dim, co
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(source, cur_level)) {
-    return ATEN_FN(index_add)(self, dim, index, source, alpha);
+    return at::_ops::index_add::call(self, dim, index, source, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15266,7 +15266,7 @@ at::Tensor index_add_dimname_generated_plumbing(const at::Tensor & self, at::Dim
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(source, cur_level)) {
-    return ATEN_FN2(index_add, dimname)(self, dim, index, source, alpha);
+    return at::_ops::index_add_dimname::call(self, dim, index, source, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15287,7 +15287,7 @@ at::Tensor & index_fill__int_Scalar_generated_plumbing(at::Tensor & self, int64_
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN2(index_fill_, int_Scalar)(self, dim, index, value);
+    return at::_ops::index_fill__int_Scalar::call(self, dim, index, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15305,7 +15305,7 @@ at::Tensor index_fill_int_Scalar_generated_plumbing(const at::Tensor & self, int
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN2(index_fill, int_Scalar)(self, dim, index, value);
+    return at::_ops::index_fill_int_Scalar::call(self, dim, index, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15323,7 +15323,7 @@ at::Tensor & index_fill__int_Tensor_generated_plumbing(at::Tensor & self, int64_
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(value, cur_level)) {
-    return ATEN_FN2(index_fill_, int_Tensor)(self, dim, index, value);
+    return at::_ops::index_fill__int_Tensor::call(self, dim, index, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15344,7 +15344,7 @@ at::Tensor index_fill_int_Tensor_generated_plumbing(const at::Tensor & self, int
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(value, cur_level)) {
-    return ATEN_FN2(index_fill, int_Tensor)(self, dim, index, value);
+    return at::_ops::index_fill_int_Tensor::call(self, dim, index, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15365,7 +15365,7 @@ at::Tensor & index_fill__Dimname_Scalar_generated_plumbing(at::Tensor & self, at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN2(index_fill_, Dimname_Scalar)(self, dim, index, value);
+    return at::_ops::index_fill__Dimname_Scalar::call(self, dim, index, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15383,7 +15383,7 @@ at::Tensor & index_fill__Dimname_Tensor_generated_plumbing(at::Tensor & self, at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(value, cur_level)) {
-    return ATEN_FN2(index_fill_, Dimname_Tensor)(self, dim, index, value);
+    return at::_ops::index_fill__Dimname_Tensor::call(self, dim, index, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15404,7 +15404,7 @@ at::Tensor index_fill_Dimname_Scalar_generated_plumbing(const at::Tensor & self,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN2(index_fill, Dimname_Scalar)(self, dim, index, value);
+    return at::_ops::index_fill_Dimname_Scalar::call(self, dim, index, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15422,7 +15422,7 @@ at::Tensor index_fill_Dimname_Tensor_generated_plumbing(const at::Tensor & self,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(value, cur_level)) {
-    return ATEN_FN2(index_fill, Dimname_Tensor)(self, dim, index, value);
+    return at::_ops::index_fill_Dimname_Tensor::call(self, dim, index, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15443,7 +15443,7 @@ at::Tensor scatter_src_generated_plumbing(const at::Tensor & self, int64_t dim, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(src, cur_level)) {
-    return ATEN_FN2(scatter, src)(self, dim, index, src);
+    return at::_ops::scatter_src::call(self, dim, index, src);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15464,7 +15464,7 @@ at::Tensor & scatter__src_generated_plumbing(at::Tensor & self, int64_t dim, con
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(src, cur_level)) {
-    return ATEN_FN2(scatter_, src)(self, dim, index, src);
+    return at::_ops::scatter__src::call(self, dim, index, src);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15485,7 +15485,7 @@ at::Tensor scatter_value_generated_plumbing(const at::Tensor & self, int64_t dim
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN2(scatter, value)(self, dim, index, value);
+    return at::_ops::scatter_value::call(self, dim, index, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15503,7 +15503,7 @@ at::Tensor & scatter__value_generated_plumbing(at::Tensor & self, int64_t dim, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN2(scatter_, value)(self, dim, index, value);
+    return at::_ops::scatter__value::call(self, dim, index, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15521,7 +15521,7 @@ at::Tensor scatter_reduce_generated_plumbing(const at::Tensor & self, int64_t di
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(src, cur_level)) {
-    return ATEN_FN2(scatter, reduce)(self, dim, index, src, reduce);
+    return at::_ops::scatter_reduce::call(self, dim, index, src, reduce);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15542,7 +15542,7 @@ at::Tensor & scatter__reduce_generated_plumbing(at::Tensor & self, int64_t dim, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(src, cur_level)) {
-    return ATEN_FN2(scatter_, reduce)(self, dim, index, src, reduce);
+    return at::_ops::scatter__reduce::call(self, dim, index, src, reduce);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15563,7 +15563,7 @@ at::Tensor scatter_value_reduce_generated_plumbing(const at::Tensor & self, int6
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN2(scatter, value_reduce)(self, dim, index, value, reduce);
+    return at::_ops::scatter_value_reduce::call(self, dim, index, value, reduce);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15581,7 +15581,7 @@ at::Tensor & scatter__value_reduce_generated_plumbing(at::Tensor & self, int64_t
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN2(scatter_, value_reduce)(self, dim, index, value, reduce);
+    return at::_ops::scatter__value_reduce::call(self, dim, index, value, reduce);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15599,7 +15599,7 @@ at::Tensor scatter_dimname_src_generated_plumbing(const at::Tensor & self, at::D
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(src, cur_level)) {
-    return ATEN_FN2(scatter, dimname_src)(self, dim, index, src);
+    return at::_ops::scatter_dimname_src::call(self, dim, index, src);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15620,7 +15620,7 @@ at::Tensor scatter_dimname_value_generated_plumbing(const at::Tensor & self, at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN2(scatter, dimname_value)(self, dim, index, value);
+    return at::_ops::scatter_dimname_value::call(self, dim, index, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15638,7 +15638,7 @@ at::Tensor scatter_add_generated_plumbing(const at::Tensor & self, int64_t dim, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(src, cur_level)) {
-    return ATEN_FN(scatter_add)(self, dim, index, src);
+    return at::_ops::scatter_add::call(self, dim, index, src);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15659,7 +15659,7 @@ at::Tensor & scatter_add__generated_plumbing(at::Tensor & self, int64_t dim, con
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(src, cur_level)) {
-    return ATEN_FN(scatter_add_)(self, dim, index, src);
+    return at::_ops::scatter_add_::call(self, dim, index, src);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15680,7 +15680,7 @@ at::Tensor scatter_add_dimname_generated_plumbing(const at::Tensor & self, at::D
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(src, cur_level)) {
-    return ATEN_FN2(scatter_add, dimname)(self, dim, index, src);
+    return at::_ops::scatter_add_dimname::call(self, dim, index, src);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15701,7 +15701,7 @@ at::Tensor scatter_reduce_two_generated_plumbing(const at::Tensor & self, int64_
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN2(scatter_reduce, two)(self, dim, index, reduce, output_size);
+    return at::_ops::scatter_reduce_two::call(self, dim, index, reduce, output_size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15719,7 +15719,7 @@ at::Tensor & eq__Scalar_generated_plumbing(at::Tensor & self, const at::Scalar &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(eq_, Scalar)(self, other);
+    return at::_ops::eq__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15734,7 +15734,7 @@ at::Tensor & eq__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(eq_, Tensor)(self, other);
+    return at::_ops::eq__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15752,7 +15752,7 @@ at::Tensor bitwise_and_Scalar_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(bitwise_and, Scalar)(self, other);
+    return at::_ops::bitwise_and_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15767,7 +15767,7 @@ at::Tensor bitwise_and_Tensor_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(bitwise_and, Tensor)(self, other);
+    return at::_ops::bitwise_and_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15785,7 +15785,7 @@ at::Tensor & bitwise_and__Scalar_generated_plumbing(at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(bitwise_and_, Scalar)(self, other);
+    return at::_ops::bitwise_and__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15800,7 +15800,7 @@ at::Tensor & bitwise_and__Tensor_generated_plumbing(at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(bitwise_and_, Tensor)(self, other);
+    return at::_ops::bitwise_and__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15818,7 +15818,7 @@ at::Tensor __and___Scalar_generated_plumbing(const at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(__and__, Scalar)(self, other);
+    return at::_ops::__and___Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15833,7 +15833,7 @@ at::Tensor __and___Tensor_generated_plumbing(const at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(__and__, Tensor)(self, other);
+    return at::_ops::__and___Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15851,7 +15851,7 @@ at::Tensor & __iand___Scalar_generated_plumbing(at::Tensor & self, const at::Sca
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(__iand__, Scalar)(self, other);
+    return at::_ops::__iand___Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15866,7 +15866,7 @@ at::Tensor & __iand___Tensor_generated_plumbing(at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(__iand__, Tensor)(self, other);
+    return at::_ops::__iand___Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15884,7 +15884,7 @@ at::Tensor bitwise_or_Scalar_generated_plumbing(const at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(bitwise_or, Scalar)(self, other);
+    return at::_ops::bitwise_or_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15899,7 +15899,7 @@ at::Tensor bitwise_or_Tensor_generated_plumbing(const at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(bitwise_or, Tensor)(self, other);
+    return at::_ops::bitwise_or_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15917,7 +15917,7 @@ at::Tensor & bitwise_or__Scalar_generated_plumbing(at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(bitwise_or_, Scalar)(self, other);
+    return at::_ops::bitwise_or__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15932,7 +15932,7 @@ at::Tensor & bitwise_or__Tensor_generated_plumbing(at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(bitwise_or_, Tensor)(self, other);
+    return at::_ops::bitwise_or__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15950,7 +15950,7 @@ at::Tensor __or___Scalar_generated_plumbing(const at::Tensor & self, const at::S
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(__or__, Scalar)(self, other);
+    return at::_ops::__or___Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15965,7 +15965,7 @@ at::Tensor __or___Tensor_generated_plumbing(const at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(__or__, Tensor)(self, other);
+    return at::_ops::__or___Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15983,7 +15983,7 @@ at::Tensor & __ior___Scalar_generated_plumbing(at::Tensor & self, const at::Scal
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(__ior__, Scalar)(self, other);
+    return at::_ops::__ior___Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -15998,7 +15998,7 @@ at::Tensor & __ior___Tensor_generated_plumbing(at::Tensor & self, const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(__ior__, Tensor)(self, other);
+    return at::_ops::__ior___Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16016,7 +16016,7 @@ at::Tensor bitwise_xor_Scalar_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(bitwise_xor, Scalar)(self, other);
+    return at::_ops::bitwise_xor_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16031,7 +16031,7 @@ at::Tensor bitwise_xor_Tensor_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(bitwise_xor, Tensor)(self, other);
+    return at::_ops::bitwise_xor_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16049,7 +16049,7 @@ at::Tensor & bitwise_xor__Scalar_generated_plumbing(at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(bitwise_xor_, Scalar)(self, other);
+    return at::_ops::bitwise_xor__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16064,7 +16064,7 @@ at::Tensor & bitwise_xor__Tensor_generated_plumbing(at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(bitwise_xor_, Tensor)(self, other);
+    return at::_ops::bitwise_xor__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16082,7 +16082,7 @@ at::Tensor __xor___Scalar_generated_plumbing(const at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(__xor__, Scalar)(self, other);
+    return at::_ops::__xor___Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16097,7 +16097,7 @@ at::Tensor __xor___Tensor_generated_plumbing(const at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(__xor__, Tensor)(self, other);
+    return at::_ops::__xor___Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16115,7 +16115,7 @@ at::Tensor & __ixor___Scalar_generated_plumbing(at::Tensor & self, const at::Sca
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(__ixor__, Scalar)(self, other);
+    return at::_ops::__ixor___Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16130,7 +16130,7 @@ at::Tensor & __ixor___Tensor_generated_plumbing(at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(__ixor__, Tensor)(self, other);
+    return at::_ops::__ixor___Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16148,7 +16148,7 @@ at::Tensor __lshift___Scalar_generated_plumbing(const at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(__lshift__, Scalar)(self, other);
+    return at::_ops::__lshift___Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16163,7 +16163,7 @@ at::Tensor __lshift___Tensor_generated_plumbing(const at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(__lshift__, Tensor)(self, other);
+    return at::_ops::__lshift___Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16181,7 +16181,7 @@ at::Tensor & __ilshift___Scalar_generated_plumbing(at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(__ilshift__, Scalar)(self, other);
+    return at::_ops::__ilshift___Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16196,7 +16196,7 @@ at::Tensor & __ilshift___Tensor_generated_plumbing(at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(__ilshift__, Tensor)(self, other);
+    return at::_ops::__ilshift___Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16214,7 +16214,7 @@ at::Tensor bitwise_left_shift_Tensor_generated_plumbing(const at::Tensor & self,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(bitwise_left_shift, Tensor)(self, other);
+    return at::_ops::bitwise_left_shift_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16232,7 +16232,7 @@ at::Tensor & bitwise_left_shift__Tensor_generated_plumbing(at::Tensor & self, co
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(bitwise_left_shift_, Tensor)(self, other);
+    return at::_ops::bitwise_left_shift__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16250,7 +16250,7 @@ at::Tensor bitwise_left_shift_Tensor_Scalar_generated_plumbing(const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(bitwise_left_shift, Tensor_Scalar)(self, other);
+    return at::_ops::bitwise_left_shift_Tensor_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16265,7 +16265,7 @@ at::Tensor & bitwise_left_shift__Tensor_Scalar_generated_plumbing(at::Tensor & s
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(bitwise_left_shift_, Tensor_Scalar)(self, other);
+    return at::_ops::bitwise_left_shift__Tensor_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16280,7 +16280,7 @@ at::Tensor bitwise_left_shift_Scalar_Tensor_generated_plumbing(const at::Scalar 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(bitwise_left_shift, Scalar_Tensor)(self, other);
+    return at::_ops::bitwise_left_shift_Scalar_Tensor::call(self, other);
   }
   Tensor other_value;
   optional<int64_t> other_bdim;
@@ -16295,7 +16295,7 @@ at::Tensor __rshift___Scalar_generated_plumbing(const at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(__rshift__, Scalar)(self, other);
+    return at::_ops::__rshift___Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16310,7 +16310,7 @@ at::Tensor __rshift___Tensor_generated_plumbing(const at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(__rshift__, Tensor)(self, other);
+    return at::_ops::__rshift___Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16328,7 +16328,7 @@ at::Tensor & __irshift___Scalar_generated_plumbing(at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(__irshift__, Scalar)(self, other);
+    return at::_ops::__irshift___Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16343,7 +16343,7 @@ at::Tensor & __irshift___Tensor_generated_plumbing(at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(__irshift__, Tensor)(self, other);
+    return at::_ops::__irshift___Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16361,7 +16361,7 @@ at::Tensor bitwise_right_shift_Tensor_generated_plumbing(const at::Tensor & self
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(bitwise_right_shift, Tensor)(self, other);
+    return at::_ops::bitwise_right_shift_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16379,7 +16379,7 @@ at::Tensor & bitwise_right_shift__Tensor_generated_plumbing(at::Tensor & self, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(bitwise_right_shift_, Tensor)(self, other);
+    return at::_ops::bitwise_right_shift__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16397,7 +16397,7 @@ at::Tensor bitwise_right_shift_Tensor_Scalar_generated_plumbing(const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(bitwise_right_shift, Tensor_Scalar)(self, other);
+    return at::_ops::bitwise_right_shift_Tensor_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16412,7 +16412,7 @@ at::Tensor & bitwise_right_shift__Tensor_Scalar_generated_plumbing(at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(bitwise_right_shift_, Tensor_Scalar)(self, other);
+    return at::_ops::bitwise_right_shift__Tensor_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16427,7 +16427,7 @@ at::Tensor bitwise_right_shift_Scalar_Tensor_generated_plumbing(const at::Scalar
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(bitwise_right_shift, Scalar_Tensor)(self, other);
+    return at::_ops::bitwise_right_shift_Scalar_Tensor::call(self, other);
   }
   Tensor other_value;
   optional<int64_t> other_bdim;
@@ -16442,7 +16442,7 @@ at::Tensor & tril__generated_plumbing(at::Tensor & self, int64_t diagonal) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(tril_)(self, diagonal);
+    return at::_ops::tril_::call(self, diagonal);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16457,7 +16457,7 @@ at::Tensor & triu__generated_plumbing(at::Tensor & self, int64_t diagonal) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(triu_)(self, diagonal);
+    return at::_ops::triu_::call(self, diagonal);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16472,7 +16472,7 @@ at::Tensor & digamma__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(digamma_)(self);
+    return at::_ops::digamma_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16487,7 +16487,7 @@ at::Tensor & lerp__Scalar_generated_plumbing(at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(end, cur_level)) {
-    return ATEN_FN2(lerp_, Scalar)(self, end, weight);
+    return at::_ops::lerp__Scalar::call(self, end, weight);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16505,7 +16505,7 @@ at::Tensor & lerp__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(end, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN2(lerp_, Tensor)(self, end, weight);
+    return at::_ops::lerp__Tensor::call(self, end, weight);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16526,7 +16526,7 @@ at::Tensor & addbmm__generated_plumbing(at::Tensor & self, const at::Tensor & ba
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(batch1, cur_level) && !isBatchedAtLevel(batch2, cur_level)) {
-    return ATEN_FN(addbmm_)(self, batch1, batch2, beta, alpha);
+    return at::_ops::addbmm_::call(self, batch1, batch2, beta, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16547,7 +16547,7 @@ at::Tensor addbmm_generated_plumbing(const at::Tensor & self, const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(batch1, cur_level) && !isBatchedAtLevel(batch2, cur_level)) {
-    return ATEN_FN(addbmm)(self, batch1, batch2, beta, alpha);
+    return at::_ops::addbmm::call(self, batch1, batch2, beta, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16568,7 +16568,7 @@ at::Tensor & random__from_generated_plumbing(at::Tensor & self, int64_t from, c1
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(random_, from)(self, from, to, generator);
+    return at::_ops::random__from::call(self, from, to, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16583,7 +16583,7 @@ at::Tensor & random__to_generated_plumbing(at::Tensor & self, int64_t to, c10::o
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(random_, to)(self, to, generator);
+    return at::_ops::random__to::call(self, to, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16598,7 +16598,7 @@ at::Tensor & random__generated_plumbing(at::Tensor & self, c10::optional<at::Gen
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(random_)(self, generator);
+    return at::_ops::random_::call(self, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16613,7 +16613,7 @@ at::Tensor & uniform__generated_plumbing(at::Tensor & self, double from, double 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(uniform_)(self, from, to, generator);
+    return at::_ops::uniform_::call(self, from, to, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16628,7 +16628,7 @@ at::Tensor & cauchy__generated_plumbing(at::Tensor & self, double median, double
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(cauchy_)(self, median, sigma, generator);
+    return at::_ops::cauchy_::call(self, median, sigma, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16643,7 +16643,7 @@ at::Tensor & log_normal__generated_plumbing(at::Tensor & self, double mean, doub
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(log_normal_)(self, mean, std, generator);
+    return at::_ops::log_normal_::call(self, mean, std, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16658,7 +16658,7 @@ at::Tensor & exponential__generated_plumbing(at::Tensor & self, double lambd, c1
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(exponential_)(self, lambd, generator);
+    return at::_ops::exponential_::call(self, lambd, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16673,7 +16673,7 @@ at::Tensor & geometric__generated_plumbing(at::Tensor & self, double p, c10::opt
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(geometric_)(self, p, generator);
+    return at::_ops::geometric_::call(self, p, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16688,7 +16688,7 @@ at::Tensor diag_generated_plumbing(const at::Tensor & self, int64_t diagonal) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(diag)(self, diagonal);
+    return at::_ops::diag::call(self, diagonal);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16703,7 +16703,7 @@ at::Tensor diag_backward_generated_plumbing(const at::Tensor & grad, at::IntArra
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level)) {
-    return ATEN_FN(diag_backward)(grad, input_sizes, diagonal);
+    return at::_ops::diag_backward::call(grad, input_sizes, diagonal);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -16718,7 +16718,7 @@ at::Tensor cross_generated_plumbing(const at::Tensor & self, const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(cross)(self, other, dim);
+    return at::_ops::cross::call(self, other, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16736,7 +16736,7 @@ at::Tensor triu_generated_plumbing(const at::Tensor & self, int64_t diagonal) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(triu)(self, diagonal);
+    return at::_ops::triu::call(self, diagonal);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16751,7 +16751,7 @@ at::Tensor tril_generated_plumbing(const at::Tensor & self, int64_t diagonal) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(tril)(self, diagonal);
+    return at::_ops::tril::call(self, diagonal);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16766,7 +16766,7 @@ at::Tensor trace_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(trace)(self);
+    return at::_ops::trace::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16781,7 +16781,7 @@ at::Tensor trace_backward_generated_plumbing(const at::Tensor & grad, at::IntArr
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level)) {
-    return ATEN_FN(trace_backward)(grad, sizes);
+    return at::_ops::trace_backward::call(grad, sizes);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -16796,7 +16796,7 @@ at::Tensor ne_Scalar_generated_plumbing(const at::Tensor & self, const at::Scala
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(ne, Scalar)(self, other);
+    return at::_ops::ne_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16811,7 +16811,7 @@ at::Tensor ne_Tensor_generated_plumbing(const at::Tensor & self, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(ne, Tensor)(self, other);
+    return at::_ops::ne_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16829,7 +16829,7 @@ at::Tensor & ne__Scalar_generated_plumbing(at::Tensor & self, const at::Scalar &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(ne_, Scalar)(self, other);
+    return at::_ops::ne__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16844,7 +16844,7 @@ at::Tensor & ne__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(ne_, Tensor)(self, other);
+    return at::_ops::ne__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16862,7 +16862,7 @@ at::Tensor not_equal_Scalar_generated_plumbing(const at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(not_equal, Scalar)(self, other);
+    return at::_ops::not_equal_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16877,7 +16877,7 @@ at::Tensor not_equal_Tensor_generated_plumbing(const at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(not_equal, Tensor)(self, other);
+    return at::_ops::not_equal_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16895,7 +16895,7 @@ at::Tensor & not_equal__Scalar_generated_plumbing(at::Tensor & self, const at::S
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(not_equal_, Scalar)(self, other);
+    return at::_ops::not_equal__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16910,7 +16910,7 @@ at::Tensor & not_equal__Tensor_generated_plumbing(at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(not_equal_, Tensor)(self, other);
+    return at::_ops::not_equal__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16928,7 +16928,7 @@ at::Tensor eq_Scalar_generated_plumbing(const at::Tensor & self, const at::Scala
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(eq, Scalar)(self, other);
+    return at::_ops::eq_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16943,7 +16943,7 @@ at::Tensor eq_Tensor_generated_plumbing(const at::Tensor & self, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(eq, Tensor)(self, other);
+    return at::_ops::eq_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16961,7 +16961,7 @@ at::Tensor ge_Scalar_generated_plumbing(const at::Tensor & self, const at::Scala
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(ge, Scalar)(self, other);
+    return at::_ops::ge_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16976,7 +16976,7 @@ at::Tensor ge_Tensor_generated_plumbing(const at::Tensor & self, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(ge, Tensor)(self, other);
+    return at::_ops::ge_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -16994,7 +16994,7 @@ at::Tensor & ge__Scalar_generated_plumbing(at::Tensor & self, const at::Scalar &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(ge_, Scalar)(self, other);
+    return at::_ops::ge__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17009,7 +17009,7 @@ at::Tensor & ge__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(ge_, Tensor)(self, other);
+    return at::_ops::ge__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17027,7 +17027,7 @@ at::Tensor greater_equal_Scalar_generated_plumbing(const at::Tensor & self, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(greater_equal, Scalar)(self, other);
+    return at::_ops::greater_equal_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17042,7 +17042,7 @@ at::Tensor greater_equal_Tensor_generated_plumbing(const at::Tensor & self, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(greater_equal, Tensor)(self, other);
+    return at::_ops::greater_equal_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17060,7 +17060,7 @@ at::Tensor & greater_equal__Scalar_generated_plumbing(at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(greater_equal_, Scalar)(self, other);
+    return at::_ops::greater_equal__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17075,7 +17075,7 @@ at::Tensor & greater_equal__Tensor_generated_plumbing(at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(greater_equal_, Tensor)(self, other);
+    return at::_ops::greater_equal__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17093,7 +17093,7 @@ at::Tensor le_Scalar_generated_plumbing(const at::Tensor & self, const at::Scala
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(le, Scalar)(self, other);
+    return at::_ops::le_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17108,7 +17108,7 @@ at::Tensor le_Tensor_generated_plumbing(const at::Tensor & self, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(le, Tensor)(self, other);
+    return at::_ops::le_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17126,7 +17126,7 @@ at::Tensor & le__Scalar_generated_plumbing(at::Tensor & self, const at::Scalar &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(le_, Scalar)(self, other);
+    return at::_ops::le__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17141,7 +17141,7 @@ at::Tensor & le__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(le_, Tensor)(self, other);
+    return at::_ops::le__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17159,7 +17159,7 @@ at::Tensor less_equal_Scalar_generated_plumbing(const at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(less_equal, Scalar)(self, other);
+    return at::_ops::less_equal_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17174,7 +17174,7 @@ at::Tensor less_equal_Tensor_generated_plumbing(const at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(less_equal, Tensor)(self, other);
+    return at::_ops::less_equal_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17192,7 +17192,7 @@ at::Tensor & less_equal__Scalar_generated_plumbing(at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(less_equal_, Scalar)(self, other);
+    return at::_ops::less_equal__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17207,7 +17207,7 @@ at::Tensor & less_equal__Tensor_generated_plumbing(at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(less_equal_, Tensor)(self, other);
+    return at::_ops::less_equal__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17225,7 +17225,7 @@ at::Tensor gt_Scalar_generated_plumbing(const at::Tensor & self, const at::Scala
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(gt, Scalar)(self, other);
+    return at::_ops::gt_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17240,7 +17240,7 @@ at::Tensor gt_Tensor_generated_plumbing(const at::Tensor & self, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(gt, Tensor)(self, other);
+    return at::_ops::gt_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17258,7 +17258,7 @@ at::Tensor & gt__Scalar_generated_plumbing(at::Tensor & self, const at::Scalar &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(gt_, Scalar)(self, other);
+    return at::_ops::gt__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17273,7 +17273,7 @@ at::Tensor & gt__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(gt_, Tensor)(self, other);
+    return at::_ops::gt__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17291,7 +17291,7 @@ at::Tensor greater_Scalar_generated_plumbing(const at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(greater, Scalar)(self, other);
+    return at::_ops::greater_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17306,7 +17306,7 @@ at::Tensor greater_Tensor_generated_plumbing(const at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(greater, Tensor)(self, other);
+    return at::_ops::greater_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17324,7 +17324,7 @@ at::Tensor & greater__Scalar_generated_plumbing(at::Tensor & self, const at::Sca
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(greater_, Scalar)(self, other);
+    return at::_ops::greater__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17339,7 +17339,7 @@ at::Tensor & greater__Tensor_generated_plumbing(at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(greater_, Tensor)(self, other);
+    return at::_ops::greater__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17357,7 +17357,7 @@ at::Tensor lt_Scalar_generated_plumbing(const at::Tensor & self, const at::Scala
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(lt, Scalar)(self, other);
+    return at::_ops::lt_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17372,7 +17372,7 @@ at::Tensor lt_Tensor_generated_plumbing(const at::Tensor & self, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(lt, Tensor)(self, other);
+    return at::_ops::lt_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17390,7 +17390,7 @@ at::Tensor & lt__Scalar_generated_plumbing(at::Tensor & self, const at::Scalar &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(lt_, Scalar)(self, other);
+    return at::_ops::lt__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17405,7 +17405,7 @@ at::Tensor & lt__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(lt_, Tensor)(self, other);
+    return at::_ops::lt__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17423,7 +17423,7 @@ at::Tensor less_Scalar_generated_plumbing(const at::Tensor & self, const at::Sca
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(less, Scalar)(self, other);
+    return at::_ops::less_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17438,7 +17438,7 @@ at::Tensor less_Tensor_generated_plumbing(const at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(less, Tensor)(self, other);
+    return at::_ops::less_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17456,7 +17456,7 @@ at::Tensor & less__Scalar_generated_plumbing(at::Tensor & self, const at::Scalar
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(less_, Scalar)(self, other);
+    return at::_ops::less__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17471,7 +17471,7 @@ at::Tensor & less__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(less_, Tensor)(self, other);
+    return at::_ops::less__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17489,7 +17489,7 @@ at::Tensor take_generated_plumbing(const at::Tensor & self, const at::Tensor & i
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN(take)(self, index);
+    return at::_ops::take::call(self, index);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17507,7 +17507,7 @@ at::Tensor take_along_dim_generated_plumbing(const at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(take_along_dim)(self, indices, dim);
+    return at::_ops::take_along_dim::call(self, indices, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17525,7 +17525,7 @@ at::Tensor index_select_generated_plumbing(const at::Tensor & self, int64_t dim,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN(index_select)(self, dim, index);
+    return at::_ops::index_select::call(self, dim, index);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17543,7 +17543,7 @@ at::Tensor index_select_dimname_generated_plumbing(const at::Tensor & self, at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN2(index_select, dimname)(self, dim, index);
+    return at::_ops::index_select_dimname::call(self, dim, index);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17561,7 +17561,7 @@ at::Tensor index_select_backward_generated_plumbing(const at::Tensor & grad, at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN(index_select_backward)(grad, self_sizes, dim, index);
+    return at::_ops::index_select_backward::call(grad, self_sizes, dim, index);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -17579,7 +17579,7 @@ at::Tensor masked_select_generated_plumbing(const at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(mask, cur_level)) {
-    return ATEN_FN(masked_select)(self, mask);
+    return at::_ops::masked_select::call(self, mask);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17597,7 +17597,7 @@ at::Tensor masked_select_backward_generated_plumbing(const at::Tensor & grad, co
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(mask, cur_level)) {
-    return ATEN_FN(masked_select_backward)(grad, input, mask);
+    return at::_ops::masked_select_backward::call(grad, input, mask);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -17618,7 +17618,7 @@ at::Tensor nonzero_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(nonzero)(self);
+    return at::_ops::nonzero::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17633,7 +17633,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(nonzero_numpy)(self);
+    return at::_ops::nonzero_numpy::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17648,7 +17648,7 @@ at::Tensor argwhere_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(argwhere)(self);
+    return at::_ops::argwhere::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17663,7 +17663,7 @@ at::Tensor gather_generated_plumbing(const at::Tensor & self, int64_t dim, const
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN(gather)(self, dim, index, sparse_grad);
+    return at::_ops::gather::call(self, dim, index, sparse_grad);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17681,7 +17681,7 @@ at::Tensor gather_backward_generated_plumbing(const at::Tensor & grad, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN(gather_backward)(grad, self, dim, index, sparse_grad);
+    return at::_ops::gather_backward::call(grad, self, dim, index, sparse_grad);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -17702,7 +17702,7 @@ at::Tensor gather_dimname_generated_plumbing(const at::Tensor & self, at::Dimnam
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level)) {
-    return ATEN_FN2(gather, dimname)(self, dim, index, sparse_grad);
+    return at::_ops::gather_dimname::call(self, dim, index, sparse_grad);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17720,7 +17720,7 @@ at::Tensor _gather_sparse_backward_generated_plumbing(const at::Tensor & self, i
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(index, cur_level) && !isBatchedAtLevel(grad, cur_level)) {
-    return ATEN_FN(_gather_sparse_backward)(self, dim, index, grad);
+    return at::_ops::_gather_sparse_backward::call(self, dim, index, grad);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17741,7 +17741,7 @@ at::Tensor addcmul_generated_plumbing(const at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(tensor1, cur_level) && !isBatchedAtLevel(tensor2, cur_level)) {
-    return ATEN_FN(addcmul)(self, tensor1, tensor2, value);
+    return at::_ops::addcmul::call(self, tensor1, tensor2, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17762,7 +17762,7 @@ at::Tensor & addcmul__generated_plumbing(at::Tensor & self, const at::Tensor & t
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(tensor1, cur_level) && !isBatchedAtLevel(tensor2, cur_level)) {
-    return ATEN_FN(addcmul_)(self, tensor1, tensor2, value);
+    return at::_ops::addcmul_::call(self, tensor1, tensor2, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17783,7 +17783,7 @@ at::Tensor addcdiv_generated_plumbing(const at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(tensor1, cur_level) && !isBatchedAtLevel(tensor2, cur_level)) {
-    return ATEN_FN(addcdiv)(self, tensor1, tensor2, value);
+    return at::_ops::addcdiv::call(self, tensor1, tensor2, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17804,7 +17804,7 @@ at::Tensor & addcdiv__generated_plumbing(at::Tensor & self, const at::Tensor & t
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(tensor1, cur_level) && !isBatchedAtLevel(tensor2, cur_level)) {
-    return ATEN_FN(addcdiv_)(self, tensor1, tensor2, value);
+    return at::_ops::addcdiv_::call(self, tensor1, tensor2, value);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17825,7 +17825,7 @@ at::Tensor cross_entropy_loss_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(cross_entropy_loss)(self, target, weight, reduction, ignore_index, label_smoothing);
+    return at::_ops::cross_entropy_loss::call(self, target, weight, reduction, ignore_index, label_smoothing);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17848,7 +17848,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(A, cur_level)) {
-    return ATEN_FN(lstsq)(self, A);
+    return at::_ops::lstsq::call(self, A);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17866,7 +17866,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(A, cur_level)) {
-    return ATEN_FN(triangular_solve)(self, A, upper, transpose, unitriangular);
+    return at::_ops::triangular_solve::call(self, A, upper, transpose, unitriangular);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17884,7 +17884,7 @@ at::Tensor linalg_solve_triangular_generated_plumbing(const at::Tensor & self, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(B, cur_level)) {
-    return ATEN_FN(linalg_solve_triangular)(self, B, upper, left, unitriangular);
+    return at::_ops::linalg_solve_triangular::call(self, B, upper, left, unitriangular);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17902,7 +17902,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(symeig)(self, eigenvectors, upper);
+    return at::_ops::symeig::call(self, eigenvectors, upper);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17917,7 +17917,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_symeig_helper)(self, eigenvectors, upper);
+    return at::_ops::_symeig_helper::call(self, eigenvectors, upper);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17932,7 +17932,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(eig)(self, eigenvectors);
+    return at::_ops::eig::call(self, eigenvectors);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17947,7 +17947,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(svd)(self, some, compute_uv);
+    return at::_ops::svd::call(self, some, compute_uv);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17962,7 +17962,7 @@ at::Tensor swapaxes_generated_plumbing(const at::Tensor & self, int64_t axis0, i
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(swapaxes)(self, axis0, axis1);
+    return at::_ops::swapaxes::call(self, axis0, axis1);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17977,7 +17977,7 @@ at::Tensor swapdims_generated_plumbing(const at::Tensor & self, int64_t dim0, in
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(swapdims)(self, dim0, dim1);
+    return at::_ops::swapdims::call(self, dim0, dim1);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -17992,7 +17992,7 @@ at::Tensor cholesky_generated_plumbing(const at::Tensor & self, bool upper) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(cholesky)(self, upper);
+    return at::_ops::cholesky::call(self, upper);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18007,7 +18007,7 @@ at::Tensor cholesky_solve_generated_plumbing(const at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(input2, cur_level)) {
-    return ATEN_FN(cholesky_solve)(self, input2, upper);
+    return at::_ops::cholesky_solve::call(self, input2, upper);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18025,7 +18025,7 @@ at::Tensor _cholesky_solve_helper_generated_plumbing(const at::Tensor & self, co
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(A, cur_level)) {
-    return ATEN_FN(_cholesky_solve_helper)(self, A, upper);
+    return at::_ops::_cholesky_solve_helper::call(self, A, upper);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18043,7 +18043,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(A, cur_level)) {
-    return ATEN_FN(solve)(self, A);
+    return at::_ops::solve::call(self, A);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18061,7 +18061,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(A, cur_level)) {
-    return ATEN_FN(_solve_helper)(self, A);
+    return at::_ops::_solve_helper::call(self, A);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18079,7 +18079,7 @@ at::Tensor cholesky_inverse_generated_plumbing(const at::Tensor & self, bool upp
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(cholesky_inverse)(self, upper);
+    return at::_ops::cholesky_inverse::call(self, upper);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18094,7 +18094,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(qr)(self, some);
+    return at::_ops::qr::call(self, some);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18109,7 +18109,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(geqrf)(self);
+    return at::_ops::geqrf::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18124,7 +18124,7 @@ at::Tensor orgqr_generated_plumbing(const at::Tensor & self, const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(input2, cur_level)) {
-    return ATEN_FN(orgqr)(self, input2);
+    return at::_ops::orgqr::call(self, input2);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18142,7 +18142,7 @@ at::Tensor ormqr_generated_plumbing(const at::Tensor & self, const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(input2, cur_level) && !isBatchedAtLevel(input3, cur_level)) {
-    return ATEN_FN(ormqr)(self, input2, input3, left, transpose);
+    return at::_ops::ormqr::call(self, input2, input3, left, transpose);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18163,7 +18163,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_lu_with_info)(self, pivot, check_errors);
+    return at::_ops::_lu_with_info::call(self, pivot, check_errors);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18178,7 +18178,7 @@ at::Tensor lu_solve_generated_plumbing(const at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(LU_data, cur_level) && !isBatchedAtLevel(LU_pivots, cur_level)) {
-    return ATEN_FN(lu_solve)(self, LU_data, LU_pivots);
+    return at::_ops::lu_solve::call(self, LU_data, LU_pivots);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18199,7 +18199,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(LU_data, cur_level) && !isBatchedAtLevel(LU_pivots, cur_level)) {
-    return ATEN_FN(lu_unpack)(LU_data, LU_pivots, unpack_data, unpack_pivots);
+    return at::_ops::lu_unpack::call(LU_data, LU_pivots, unpack_data, unpack_pivots);
   }
   Tensor LU_data_value;
   optional<int64_t> LU_data_bdim;
@@ -18217,7 +18217,7 @@ at::Tensor multinomial_generated_plumbing(const at::Tensor & self, int64_t num_s
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(multinomial)(self, num_samples, replacement, generator);
+    return at::_ops::multinomial::call(self, num_samples, replacement, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18232,7 +18232,7 @@ at::Tensor & lgamma__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(lgamma_)(self);
+    return at::_ops::lgamma_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18247,7 +18247,7 @@ at::Tensor lgamma_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(lgamma)(self);
+    return at::_ops::lgamma::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18262,7 +18262,7 @@ at::Tensor digamma_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(digamma)(self);
+    return at::_ops::digamma::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18277,7 +18277,7 @@ at::Tensor polygamma_generated_plumbing(int64_t n, const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(polygamma)(n, self);
+    return at::_ops::polygamma::call(n, self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18292,7 +18292,7 @@ at::Tensor & polygamma__generated_plumbing(at::Tensor & self, int64_t n) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(polygamma_)(self, n);
+    return at::_ops::polygamma_::call(self, n);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18307,7 +18307,7 @@ at::Tensor erfinv_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(erfinv)(self);
+    return at::_ops::erfinv::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18322,7 +18322,7 @@ at::Tensor & erfinv__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(erfinv_)(self);
+    return at::_ops::erfinv_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18337,7 +18337,7 @@ at::Tensor i0_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(i0)(self);
+    return at::_ops::i0::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18352,7 +18352,7 @@ at::Tensor & i0__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(i0_)(self);
+    return at::_ops::i0_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18367,7 +18367,7 @@ at::Tensor sign_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sign)(self);
+    return at::_ops::sign::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18382,7 +18382,7 @@ at::Tensor & sign__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sign_)(self);
+    return at::_ops::sign_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18397,7 +18397,7 @@ at::Tensor signbit_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(signbit)(self);
+    return at::_ops::signbit::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18412,7 +18412,7 @@ at::Tensor dist_generated_plumbing(const at::Tensor & self, const at::Tensor & o
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(dist)(self, other, p);
+    return at::_ops::dist::call(self, other, p);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18430,7 +18430,7 @@ at::Tensor & atan2__generated_plumbing(at::Tensor & self, const at::Tensor & oth
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(atan2_)(self, other);
+    return at::_ops::atan2_::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18448,7 +18448,7 @@ at::Tensor atan2_generated_plumbing(const at::Tensor & self, const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(atan2)(self, other);
+    return at::_ops::atan2::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18466,7 +18466,7 @@ at::Tensor arctan2_generated_plumbing(const at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(arctan2)(self, other);
+    return at::_ops::arctan2::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18484,7 +18484,7 @@ at::Tensor & arctan2__generated_plumbing(at::Tensor & self, const at::Tensor & o
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(arctan2_)(self, other);
+    return at::_ops::arctan2_::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18502,7 +18502,7 @@ at::Tensor lerp_Scalar_generated_plumbing(const at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(end, cur_level)) {
-    return ATEN_FN2(lerp, Scalar)(self, end, weight);
+    return at::_ops::lerp_Scalar::call(self, end, weight);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18520,7 +18520,7 @@ at::Tensor lerp_Tensor_generated_plumbing(const at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(end, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN2(lerp, Tensor)(self, end, weight);
+    return at::_ops::lerp_Tensor::call(self, end, weight);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18541,7 +18541,7 @@ at::Tensor histc_generated_plumbing(const at::Tensor & self, int64_t bins, const
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(histc)(self, bins, min, max);
+    return at::_ops::histc::call(self, bins, min, max);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18556,7 +18556,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(bins, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN2(histogram, bins_tensor)(self, bins, weight, density);
+    return at::_ops::histogram_bins_tensor::call(self, bins, weight, density);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18579,7 +18579,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN2(histogram, bin_ct)(self, bins, range, weight, density);
+    return at::_ops::histogram_bin_ct::call(self, bins, range, weight, density);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18599,7 +18599,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(_histogramdd_bin_edges)(self, bins, range, weight, density);
+    return at::_ops::_histogramdd_bin_edges::call(self, bins, range, weight, density);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18619,7 +18619,7 @@ at::Tensor _histogramdd_from_bin_cts_generated_plumbing(const at::Tensor & self,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(_histogramdd_from_bin_cts)(self, bins, range, weight, density);
+    return at::_ops::_histogramdd_from_bin_cts::call(self, bins, range, weight, density);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18639,7 +18639,7 @@ at::Tensor _histogramdd_from_bin_tensors_generated_plumbing(const at::Tensor & s
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(bins, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(_histogramdd_from_bin_tensors)(self, bins, weight, density);
+    return at::_ops::_histogramdd_from_bin_tensors::call(self, bins, weight, density);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18659,7 +18659,7 @@ at::Tensor fmod_Scalar_generated_plumbing(const at::Tensor & self, const at::Sca
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(fmod, Scalar)(self, other);
+    return at::_ops::fmod_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18674,7 +18674,7 @@ at::Tensor & fmod__Scalar_generated_plumbing(at::Tensor & self, const at::Scalar
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(fmod_, Scalar)(self, other);
+    return at::_ops::fmod__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18689,7 +18689,7 @@ at::Tensor fmod_Tensor_generated_plumbing(const at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(fmod, Tensor)(self, other);
+    return at::_ops::fmod_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18707,7 +18707,7 @@ at::Tensor & fmod__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(fmod_, Tensor)(self, other);
+    return at::_ops::fmod__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18725,7 +18725,7 @@ at::Tensor hypot_generated_plumbing(const at::Tensor & self, const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(hypot)(self, other);
+    return at::_ops::hypot::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18743,7 +18743,7 @@ at::Tensor & hypot__generated_plumbing(at::Tensor & self, const at::Tensor & oth
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(hypot_)(self, other);
+    return at::_ops::hypot_::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18761,7 +18761,7 @@ at::Tensor igamma_generated_plumbing(const at::Tensor & self, const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(igamma)(self, other);
+    return at::_ops::igamma::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18779,7 +18779,7 @@ at::Tensor & igamma__generated_plumbing(at::Tensor & self, const at::Tensor & ot
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(igamma_)(self, other);
+    return at::_ops::igamma_::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18797,7 +18797,7 @@ at::Tensor igammac_generated_plumbing(const at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(igammac)(self, other);
+    return at::_ops::igammac::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18815,7 +18815,7 @@ at::Tensor & igammac__generated_plumbing(at::Tensor & self, const at::Tensor & o
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(igammac_)(self, other);
+    return at::_ops::igammac_::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18833,7 +18833,7 @@ at::Tensor nextafter_generated_plumbing(const at::Tensor & self, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(nextafter)(self, other);
+    return at::_ops::nextafter::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18851,7 +18851,7 @@ at::Tensor & nextafter__generated_plumbing(at::Tensor & self, const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(nextafter_)(self, other);
+    return at::_ops::nextafter_::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18869,7 +18869,7 @@ at::Tensor remainder_Scalar_generated_plumbing(const at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(remainder, Scalar)(self, other);
+    return at::_ops::remainder_Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18884,7 +18884,7 @@ at::Tensor & remainder__Scalar_generated_plumbing(at::Tensor & self, const at::S
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(remainder_, Scalar)(self, other);
+    return at::_ops::remainder__Scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18899,7 +18899,7 @@ at::Tensor remainder_Tensor_generated_plumbing(const at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(remainder, Tensor)(self, other);
+    return at::_ops::remainder_Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18917,7 +18917,7 @@ at::Tensor & remainder__Tensor_generated_plumbing(at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(remainder_, Tensor)(self, other);
+    return at::_ops::remainder__Tensor::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18935,7 +18935,7 @@ at::Tensor remainder_Scalar_Tensor_generated_plumbing(const at::Scalar & self, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(remainder, Scalar_Tensor)(self, other);
+    return at::_ops::remainder_Scalar_Tensor::call(self, other);
   }
   Tensor other_value;
   optional<int64_t> other_bdim;
@@ -18950,7 +18950,7 @@ at::Tensor min_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(min)(self);
+    return at::_ops::min::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18965,7 +18965,7 @@ at::Tensor fmin_generated_plumbing(const at::Tensor & self, const at::Tensor & o
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(fmin)(self, other);
+    return at::_ops::fmin::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18983,7 +18983,7 @@ at::Tensor max_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(max)(self);
+    return at::_ops::max::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -18998,7 +18998,7 @@ at::Tensor fmax_generated_plumbing(const at::Tensor & self, const at::Tensor & o
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(fmax)(self, other);
+    return at::_ops::fmax::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19016,7 +19016,7 @@ at::Tensor maximum_generated_plumbing(const at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(maximum)(self, other);
+    return at::_ops::maximum::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19034,7 +19034,7 @@ at::Tensor max_other_generated_plumbing(const at::Tensor & self, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(max, other)(self, other);
+    return at::_ops::max_other::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19052,7 +19052,7 @@ at::Tensor minimum_generated_plumbing(const at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(minimum)(self, other);
+    return at::_ops::minimum::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19070,7 +19070,7 @@ at::Tensor min_other_generated_plumbing(const at::Tensor & self, const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(min, other)(self, other);
+    return at::_ops::min_other::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19088,7 +19088,7 @@ at::Tensor quantile_generated_plumbing(const at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(q, cur_level)) {
-    return ATEN_FN(quantile)(self, q, dim, keepdim, interpolation);
+    return at::_ops::quantile::call(self, q, dim, keepdim, interpolation);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19106,7 +19106,7 @@ at::Tensor quantile_scalar_generated_plumbing(const at::Tensor & self, double q,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(quantile, scalar)(self, q, dim, keepdim, interpolation);
+    return at::_ops::quantile_scalar::call(self, q, dim, keepdim, interpolation);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19121,7 +19121,7 @@ at::Tensor nanquantile_generated_plumbing(const at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(q, cur_level)) {
-    return ATEN_FN(nanquantile)(self, q, dim, keepdim, interpolation);
+    return at::_ops::nanquantile::call(self, q, dim, keepdim, interpolation);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19139,7 +19139,7 @@ at::Tensor nanquantile_scalar_generated_plumbing(const at::Tensor & self, double
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(nanquantile, scalar)(self, q, dim, keepdim, interpolation);
+    return at::_ops::nanquantile_scalar::call(self, q, dim, keepdim, interpolation);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19154,7 +19154,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(sort)(self, dim, descending);
+    return at::_ops::sort::call(self, dim, descending);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19169,7 +19169,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(sort, stable)(self, stable, dim, descending);
+    return at::_ops::sort_stable::call(self, stable, dim, descending);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19184,7 +19184,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(sort, dimname)(self, dim, descending);
+    return at::_ops::sort_dimname::call(self, dim, descending);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19199,7 +19199,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(sort, dimname_stable)(self, stable, dim, descending);
+    return at::_ops::sort_dimname_stable::call(self, stable, dim, descending);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19214,7 +19214,7 @@ at::Tensor msort_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(msort)(self);
+    return at::_ops::msort::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19229,7 +19229,7 @@ at::Tensor argsort_generated_plumbing(const at::Tensor & self, int64_t dim, bool
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(argsort)(self, dim, descending);
+    return at::_ops::argsort::call(self, dim, descending);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19244,7 +19244,7 @@ at::Tensor argsort_dimname_generated_plumbing(const at::Tensor & self, at::Dimna
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(argsort, dimname)(self, dim, descending);
+    return at::_ops::argsort_dimname::call(self, dim, descending);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19259,7 +19259,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(topk)(self, k, dim, largest, sorted);
+    return at::_ops::topk::call(self, k, dim, largest, sorted);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19274,7 +19274,7 @@ at::Tensor all_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(all)(self);
+    return at::_ops::all::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19289,7 +19289,7 @@ at::Tensor any_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(any)(self);
+    return at::_ops::any::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19304,7 +19304,7 @@ at::Tensor renorm_generated_plumbing(const at::Tensor & self, const at::Scalar &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(renorm)(self, p, dim, maxnorm);
+    return at::_ops::renorm::call(self, p, dim, maxnorm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19319,7 +19319,7 @@ at::Tensor & renorm__generated_plumbing(at::Tensor & self, const at::Scalar & p,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(renorm_)(self, p, dim, maxnorm);
+    return at::_ops::renorm_::call(self, p, dim, maxnorm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19334,7 +19334,7 @@ at::Tensor unfold_generated_plumbing(const at::Tensor & self, int64_t dimension,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(unfold)(self, dimension, size, step);
+    return at::_ops::unfold::call(self, dimension, size, step);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19349,7 +19349,7 @@ at::Tensor unfold_backward_generated_plumbing(const at::Tensor & grad_in, at::In
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_in, cur_level)) {
-    return ATEN_FN(unfold_backward)(grad_in, input_sizes, dim, size, step);
+    return at::_ops::unfold_backward::call(grad_in, input_sizes, dim, size, step);
   }
   Tensor grad_in_value;
   optional<int64_t> grad_in_bdim;
@@ -19364,7 +19364,7 @@ at::Tensor pow_Tensor_Tensor_generated_plumbing(const at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(exponent, cur_level)) {
-    return ATEN_FN2(pow, Tensor_Tensor)(self, exponent);
+    return at::_ops::pow_Tensor_Tensor::call(self, exponent);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19382,7 +19382,7 @@ at::Tensor pow_Scalar_generated_plumbing(const at::Scalar & self, const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(exponent, cur_level)) {
-    return ATEN_FN2(pow, Scalar)(self, exponent);
+    return at::_ops::pow_Scalar::call(self, exponent);
   }
   Tensor exponent_value;
   optional<int64_t> exponent_bdim;
@@ -19397,7 +19397,7 @@ at::Tensor pow_Tensor_Scalar_generated_plumbing(const at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(pow, Tensor_Scalar)(self, exponent);
+    return at::_ops::pow_Tensor_Scalar::call(self, exponent);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19412,7 +19412,7 @@ at::Tensor & pow__Scalar_generated_plumbing(at::Tensor & self, const at::Scalar 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(pow_, Scalar)(self, exponent);
+    return at::_ops::pow__Scalar::call(self, exponent);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19427,7 +19427,7 @@ at::Tensor & pow__Tensor_generated_plumbing(at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(exponent, cur_level)) {
-    return ATEN_FN2(pow_, Tensor)(self, exponent);
+    return at::_ops::pow__Tensor::call(self, exponent);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19445,7 +19445,7 @@ at::Tensor float_power_Tensor_Tensor_generated_plumbing(const at::Tensor & self,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(exponent, cur_level)) {
-    return ATEN_FN2(float_power, Tensor_Tensor)(self, exponent);
+    return at::_ops::float_power_Tensor_Tensor::call(self, exponent);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19463,7 +19463,7 @@ at::Tensor float_power_Scalar_generated_plumbing(const at::Scalar & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(exponent, cur_level)) {
-    return ATEN_FN2(float_power, Scalar)(self, exponent);
+    return at::_ops::float_power_Scalar::call(self, exponent);
   }
   Tensor exponent_value;
   optional<int64_t> exponent_bdim;
@@ -19478,7 +19478,7 @@ at::Tensor float_power_Tensor_Scalar_generated_plumbing(const at::Tensor & self,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(float_power, Tensor_Scalar)(self, exponent);
+    return at::_ops::float_power_Tensor_Scalar::call(self, exponent);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19493,7 +19493,7 @@ at::Tensor & float_power__Scalar_generated_plumbing(at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(float_power_, Scalar)(self, exponent);
+    return at::_ops::float_power__Scalar::call(self, exponent);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19508,7 +19508,7 @@ at::Tensor & float_power__Tensor_generated_plumbing(at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(exponent, cur_level)) {
-    return ATEN_FN2(float_power_, Tensor)(self, exponent);
+    return at::_ops::float_power__Tensor::call(self, exponent);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19526,7 +19526,7 @@ at::Tensor & normal__generated_plumbing(at::Tensor & self, double mean, double s
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(normal_)(self, mean, std, generator);
+    return at::_ops::normal_::call(self, mean, std, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19541,7 +19541,7 @@ at::Tensor normal_Tensor_float_generated_plumbing(const at::Tensor & mean, doubl
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(mean, cur_level)) {
-    return ATEN_FN2(normal, Tensor_float)(mean, std, generator);
+    return at::_ops::normal_Tensor_float::call(mean, std, generator);
   }
   Tensor mean_value;
   optional<int64_t> mean_bdim;
@@ -19556,7 +19556,7 @@ at::Tensor normal_float_Tensor_generated_plumbing(double mean, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(std, cur_level)) {
-    return ATEN_FN2(normal, float_Tensor)(mean, std, generator);
+    return at::_ops::normal_float_Tensor::call(mean, std, generator);
   }
   Tensor std_value;
   optional<int64_t> std_bdim;
@@ -19571,7 +19571,7 @@ at::Tensor normal_Tensor_Tensor_generated_plumbing(const at::Tensor & mean, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(mean, cur_level) && !isBatchedAtLevel(std, cur_level)) {
-    return ATEN_FN2(normal, Tensor_Tensor)(mean, std, generator);
+    return at::_ops::normal_Tensor_Tensor::call(mean, std, generator);
   }
   Tensor mean_value;
   optional<int64_t> mean_bdim;
@@ -19589,7 +19589,7 @@ at::Tensor alias_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(alias)(self);
+    return at::_ops::alias::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -19598,34 +19598,13 @@ at::Tensor alias_generated_plumbing(const at::Tensor & self) {
   return makeBatched(std::get<0>(results), std::get<1>(results), cur_level);
 }
 template <typename batch_rule_t, batch_rule_t batch_rule>
-at::Tensor & _amp_update_scale__generated_plumbing(at::Tensor & self, at::Tensor & growth_tracker, const at::Tensor & found_inf, double scale_growth_factor, double scale_backoff_factor, int64_t growth_interval) {
-  c10::impl::ExcludeDispatchKeyGuard guard(kBatchedKey);
-  auto maybe_layer = maybeCurrentDynamicLayer();
-  TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
-  int64_t cur_level = maybe_layer->layerId();
-  if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(growth_tracker, cur_level) && !isBatchedAtLevel(found_inf, cur_level)) {
-    return ATEN_FN(_amp_update_scale_)(self, growth_tracker, found_inf, scale_growth_factor, scale_backoff_factor, growth_interval);
-  }
-  Tensor self_value;
-  optional<int64_t> self_bdim;
-  std::tie(self_value, self_bdim) = unwrapTensorAtLevel(self, cur_level);
-  Tensor growth_tracker_value;
-  optional<int64_t> growth_tracker_bdim;
-  std::tie(growth_tracker_value, growth_tracker_bdim) = unwrapTensorAtLevel(growth_tracker, cur_level);
-  Tensor found_inf_value;
-  optional<int64_t> found_inf_bdim;
-  std::tie(found_inf_value, found_inf_bdim) = unwrapTensorAtLevel(found_inf, cur_level);
-  batch_rule(self_value, self_bdim, growth_tracker_value, growth_tracker_bdim, found_inf_value, found_inf_bdim, scale_growth_factor, scale_backoff_factor, growth_interval);
-  return self;
-}
-template <typename batch_rule_t, batch_rule_t batch_rule>
 at::Tensor _cat_generated_plumbing(at::TensorList tensors, int64_t dim) {
   c10::impl::ExcludeDispatchKeyGuard guard(kBatchedKey);
   auto maybe_layer = maybeCurrentDynamicLayer();
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_cat)(tensors, dim);
+    return at::_ops::_cat::call(tensors, dim);
   }
 
   auto results = batch_rule(tensors, dim);
@@ -19638,7 +19617,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(_foreach_add, Scalar)(tensors, scalar);
+    return at::_ops::_foreach_add_Scalar::call(tensors, scalar);
   }
 
   auto results = batch_rule(tensors, scalar);
@@ -19651,7 +19630,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(_foreach_sub, Scalar)(tensors, scalar);
+    return at::_ops::_foreach_sub_Scalar::call(tensors, scalar);
   }
 
   auto results = batch_rule(tensors, scalar);
@@ -19664,7 +19643,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(_foreach_mul, Scalar)(tensors, scalar);
+    return at::_ops::_foreach_mul_Scalar::call(tensors, scalar);
   }
 
   auto results = batch_rule(tensors, scalar);
@@ -19677,7 +19656,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(_foreach_div, Scalar)(tensors, scalar);
+    return at::_ops::_foreach_div_Scalar::call(tensors, scalar);
   }
 
   auto results = batch_rule(tensors, scalar);
@@ -19690,7 +19669,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors1, cur_level) && !isBatchedAtLevel(tensors2, cur_level)) {
-    return ATEN_FN2(_foreach_add, List)(tensors1, tensors2, alpha);
+    return at::_ops::_foreach_add_List::call(tensors1, tensors2, alpha);
   }
 
   auto results = batch_rule(tensors1, tensors2, alpha);
@@ -19703,7 +19682,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors1, cur_level) && !isBatchedAtLevel(tensors2, cur_level)) {
-    return ATEN_FN2(_foreach_sub, List)(tensors1, tensors2, alpha);
+    return at::_ops::_foreach_sub_List::call(tensors1, tensors2, alpha);
   }
 
   auto results = batch_rule(tensors1, tensors2, alpha);
@@ -19716,7 +19695,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors1, cur_level) && !isBatchedAtLevel(tensors2, cur_level)) {
-    return ATEN_FN2(_foreach_mul, List)(tensors1, tensors2);
+    return at::_ops::_foreach_mul_List::call(tensors1, tensors2);
   }
 
   auto results = batch_rule(tensors1, tensors2);
@@ -19729,7 +19708,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors1, cur_level) && !isBatchedAtLevel(tensors2, cur_level)) {
-    return ATEN_FN2(_foreach_div, List)(tensors1, tensors2);
+    return at::_ops::_foreach_div_List::call(tensors1, tensors2);
   }
 
   auto results = batch_rule(tensors1, tensors2);
@@ -19742,7 +19721,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(_foreach_add, ScalarList)(tensors, scalars);
+    return at::_ops::_foreach_add_ScalarList::call(tensors, scalars);
   }
 
   auto results = batch_rule(tensors, scalars);
@@ -19755,7 +19734,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(_foreach_sub, ScalarList)(tensors, scalars);
+    return at::_ops::_foreach_sub_ScalarList::call(tensors, scalars);
   }
 
   auto results = batch_rule(tensors, scalars);
@@ -19768,7 +19747,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(_foreach_div, ScalarList)(tensors, scalars);
+    return at::_ops::_foreach_div_ScalarList::call(tensors, scalars);
   }
 
   auto results = batch_rule(tensors, scalars);
@@ -19781,7 +19760,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(_foreach_mul, ScalarList)(tensors, scalars);
+    return at::_ops::_foreach_mul_ScalarList::call(tensors, scalars);
   }
 
   auto results = batch_rule(tensors, scalars);
@@ -19794,7 +19773,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_exp)(tensors);
+    return at::_ops::_foreach_exp::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19807,7 +19786,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_sqrt)(tensors);
+    return at::_ops::_foreach_sqrt::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19820,7 +19799,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_abs)(tensors);
+    return at::_ops::_foreach_abs::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19833,7 +19812,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_acos)(tensors);
+    return at::_ops::_foreach_acos::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19846,7 +19825,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_asin)(tensors);
+    return at::_ops::_foreach_asin::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19859,7 +19838,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_atan)(tensors);
+    return at::_ops::_foreach_atan::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19872,7 +19851,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_ceil)(tensors);
+    return at::_ops::_foreach_ceil::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19885,7 +19864,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_cos)(tensors);
+    return at::_ops::_foreach_cos::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19898,7 +19877,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_cosh)(tensors);
+    return at::_ops::_foreach_cosh::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19911,7 +19890,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_erf)(tensors);
+    return at::_ops::_foreach_erf::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19924,7 +19903,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_erfc)(tensors);
+    return at::_ops::_foreach_erfc::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19937,7 +19916,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_expm1)(tensors);
+    return at::_ops::_foreach_expm1::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19950,7 +19929,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_floor)(tensors);
+    return at::_ops::_foreach_floor::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19963,7 +19942,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_log)(tensors);
+    return at::_ops::_foreach_log::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19976,7 +19955,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_log10)(tensors);
+    return at::_ops::_foreach_log10::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -19989,7 +19968,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_log1p)(tensors);
+    return at::_ops::_foreach_log1p::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -20002,7 +19981,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_log2)(tensors);
+    return at::_ops::_foreach_log2::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -20015,7 +19994,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_neg)(tensors);
+    return at::_ops::_foreach_neg::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -20028,7 +20007,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_tan)(tensors);
+    return at::_ops::_foreach_tan::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -20041,7 +20020,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_tanh)(tensors);
+    return at::_ops::_foreach_tanh::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -20054,7 +20033,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_sin)(tensors);
+    return at::_ops::_foreach_sin::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -20067,7 +20046,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_sinh)(tensors);
+    return at::_ops::_foreach_sinh::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -20080,7 +20059,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_round)(tensors);
+    return at::_ops::_foreach_round::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -20093,7 +20072,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_lgamma)(tensors);
+    return at::_ops::_foreach_lgamma::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -20106,7 +20085,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_frac)(tensors);
+    return at::_ops::_foreach_frac::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -20119,7 +20098,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_reciprocal)(tensors);
+    return at::_ops::_foreach_reciprocal::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -20132,7 +20111,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_sigmoid)(tensors);
+    return at::_ops::_foreach_sigmoid::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -20145,7 +20124,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(_foreach_trunc)(tensors);
+    return at::_ops::_foreach_trunc::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -20158,7 +20137,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(tensor1, cur_level) && !isBatchedAtLevel(tensor2, cur_level)) {
-    return ATEN_FN2(_foreach_addcdiv, Scalar)(input, tensor1, tensor2, value);
+    return at::_ops::_foreach_addcdiv_Scalar::call(input, tensor1, tensor2, value);
   }
 
   auto results = batch_rule(input, tensor1, tensor2, value);
@@ -20171,7 +20150,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(tensor1, cur_level) && !isBatchedAtLevel(tensor2, cur_level)) {
-    return ATEN_FN2(_foreach_addcmul, Scalar)(input, tensor1, tensor2, value);
+    return at::_ops::_foreach_addcmul_Scalar::call(input, tensor1, tensor2, value);
   }
 
   auto results = batch_rule(input, tensor1, tensor2, value);
@@ -20184,7 +20163,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(tensor1, cur_level) && !isBatchedAtLevel(tensor2, cur_level)) {
-    return ATEN_FN2(_foreach_addcdiv, ScalarList)(input, tensor1, tensor2, scalars);
+    return at::_ops::_foreach_addcdiv_ScalarList::call(input, tensor1, tensor2, scalars);
   }
 
   auto results = batch_rule(input, tensor1, tensor2, scalars);
@@ -20197,7 +20176,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(tensor1, cur_level) && !isBatchedAtLevel(tensor2, cur_level)) {
-    return ATEN_FN2(_foreach_addcmul, ScalarList)(input, tensor1, tensor2, scalars);
+    return at::_ops::_foreach_addcmul_ScalarList::call(input, tensor1, tensor2, scalars);
   }
 
   auto results = batch_rule(input, tensor1, tensor2, scalars);
@@ -20210,7 +20189,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors1, cur_level) && !isBatchedAtLevel(tensors2, cur_level)) {
-    return ATEN_FN2(_foreach_maximum, List)(tensors1, tensors2);
+    return at::_ops::_foreach_maximum_List::call(tensors1, tensors2);
   }
 
   auto results = batch_rule(tensors1, tensors2);
@@ -20223,7 +20202,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors1, cur_level) && !isBatchedAtLevel(tensors2, cur_level)) {
-    return ATEN_FN2(_foreach_minimum, List)(tensors1, tensors2);
+    return at::_ops::_foreach_minimum_List::call(tensors1, tensors2);
   }
 
   auto results = batch_rule(tensors1, tensors2);
@@ -20236,7 +20215,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN2(_foreach_norm, Scalar)(tensors, ord);
+    return at::_ops::_foreach_norm_Scalar::call(tensors, ord);
   }
 
   auto results = batch_rule(tensors, ord);
@@ -20249,7 +20228,7 @@ at::Tensor bucketize_Tensor_generated_plumbing(const at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(boundaries, cur_level)) {
-    return ATEN_FN2(bucketize, Tensor)(self, boundaries, out_int32, right);
+    return at::_ops::bucketize_Tensor::call(self, boundaries, out_int32, right);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20267,7 +20246,7 @@ at::Tensor bucketize_Scalar_generated_plumbing(const at::Scalar & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(boundaries, cur_level)) {
-    return ATEN_FN2(bucketize, Scalar)(self, boundaries, out_int32, right);
+    return at::_ops::bucketize_Scalar::call(self, boundaries, out_int32, right);
   }
   Tensor boundaries_value;
   optional<int64_t> boundaries_bdim;
@@ -20282,7 +20261,7 @@ at::Tensor searchsorted_Tensor_generated_plumbing(const at::Tensor & sorted_sequ
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(sorted_sequence, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(sorter, cur_level)) {
-    return ATEN_FN2(searchsorted, Tensor)(sorted_sequence, self, out_int32, right, side, sorter);
+    return at::_ops::searchsorted_Tensor::call(sorted_sequence, self, out_int32, right, side, sorter);
   }
   Tensor sorted_sequence_value;
   optional<int64_t> sorted_sequence_bdim;
@@ -20305,7 +20284,7 @@ at::Tensor _torch_cuda_cu_linker_symbol_op_generated_plumbing(const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_torch_cuda_cu_linker_symbol_op)(self);
+    return at::_ops::_torch_cuda_cu_linker_symbol_op::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20320,7 +20299,7 @@ at::Tensor searchsorted_Scalar_generated_plumbing(const at::Tensor & sorted_sequ
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(sorted_sequence, cur_level) && !isBatchedAtLevel(sorter, cur_level)) {
-    return ATEN_FN2(searchsorted, Scalar)(sorted_sequence, self, out_int32, right, side, sorter);
+    return at::_ops::searchsorted_Scalar::call(sorted_sequence, self, out_int32, right, side, sorter);
   }
   Tensor sorted_sequence_value;
   optional<int64_t> sorted_sequence_bdim;
@@ -20340,7 +20319,7 @@ at::Tensor _convert_indices_from_coo_to_csr_generated_plumbing(const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_convert_indices_from_coo_to_csr)(self, size, out_int32);
+    return at::_ops::_convert_indices_from_coo_to_csr::call(self, size, out_int32);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20355,7 +20334,7 @@ at::Tensor _convert_indices_from_csr_to_coo_generated_plumbing(const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(crow_indices, cur_level) && !isBatchedAtLevel(col_indices, cur_level)) {
-    return ATEN_FN(_convert_indices_from_csr_to_coo)(crow_indices, col_indices, out_int32, transpose);
+    return at::_ops::_convert_indices_from_csr_to_coo::call(crow_indices, col_indices, out_int32, transpose);
   }
   Tensor crow_indices_value;
   optional<int64_t> crow_indices_bdim;
@@ -20373,7 +20352,7 @@ at::Tensor mse_loss_generated_plumbing(const at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(mse_loss)(self, target, reduction);
+    return at::_ops::mse_loss::call(self, target, reduction);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20391,7 +20370,7 @@ at::Tensor mse_loss_backward_generated_plumbing(const at::Tensor & grad_output, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(mse_loss_backward)(grad_output, self, target, reduction);
+    return at::_ops::mse_loss_backward::call(grad_output, self, target, reduction);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -20412,7 +20391,7 @@ at::Tensor l1_loss_generated_plumbing(const at::Tensor & self, const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(l1_loss)(self, target, reduction);
+    return at::_ops::l1_loss::call(self, target, reduction);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20430,7 +20409,7 @@ at::Tensor l1_loss_backward_generated_plumbing(const at::Tensor & grad_output, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(l1_loss_backward)(grad_output, self, target, reduction);
+    return at::_ops::l1_loss_backward::call(grad_output, self, target, reduction);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -20451,7 +20430,7 @@ at::Tensor multi_margin_loss_generated_plumbing(const at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(multi_margin_loss)(self, target, p, margin, weight, reduction);
+    return at::_ops::multi_margin_loss::call(self, target, p, margin, weight, reduction);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20474,7 +20453,7 @@ at::Tensor multi_margin_loss_backward_generated_plumbing(const at::Tensor & grad
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(multi_margin_loss_backward)(grad_output, self, target, p, margin, weight, reduction);
+    return at::_ops::multi_margin_loss_backward::call(grad_output, self, target, p, margin, weight, reduction);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -20500,7 +20479,7 @@ at::Tensor multilabel_margin_loss_generated_plumbing(const at::Tensor & self, co
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(multilabel_margin_loss)(self, target, reduction);
+    return at::_ops::multilabel_margin_loss::call(self, target, reduction);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20518,7 +20497,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(multilabel_margin_loss_forward)(self, target, reduction);
+    return at::_ops::multilabel_margin_loss_forward::call(self, target, reduction);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20536,7 +20515,7 @@ at::Tensor multilabel_margin_loss_backward_generated_plumbing(const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(is_target, cur_level)) {
-    return ATEN_FN(multilabel_margin_loss_backward)(grad_output, self, target, reduction, is_target);
+    return at::_ops::multilabel_margin_loss_backward::call(grad_output, self, target, reduction, is_target);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -20560,7 +20539,7 @@ at::Tensor nll_loss_nd_generated_plumbing(const at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(nll_loss_nd)(self, target, weight, reduction, ignore_index);
+    return at::_ops::nll_loss_nd::call(self, target, weight, reduction, ignore_index);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20583,7 +20562,7 @@ at::Tensor nll_loss_generated_plumbing(const at::Tensor & self, const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(nll_loss)(self, target, weight, reduction, ignore_index);
+    return at::_ops::nll_loss::call(self, target, weight, reduction, ignore_index);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20606,7 +20585,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(nll_loss_forward)(self, target, weight, reduction, ignore_index);
+    return at::_ops::nll_loss_forward::call(self, target, weight, reduction, ignore_index);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20629,7 +20608,7 @@ at::Tensor nll_loss_backward_generated_plumbing(const at::Tensor & grad_output, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(total_weight, cur_level)) {
-    return ATEN_FN(nll_loss_backward)(grad_output, self, target, weight, reduction, ignore_index, total_weight);
+    return at::_ops::nll_loss_backward::call(grad_output, self, target, weight, reduction, ignore_index, total_weight);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -20658,7 +20637,7 @@ at::Tensor nll_loss2d_generated_plumbing(const at::Tensor & self, const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(nll_loss2d)(self, target, weight, reduction, ignore_index);
+    return at::_ops::nll_loss2d::call(self, target, weight, reduction, ignore_index);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20681,7 +20660,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN(nll_loss2d_forward)(self, target, weight, reduction, ignore_index);
+    return at::_ops::nll_loss2d_forward::call(self, target, weight, reduction, ignore_index);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20704,7 +20683,7 @@ at::Tensor nll_loss2d_backward_generated_plumbing(const at::Tensor & grad_output
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(total_weight, cur_level)) {
-    return ATEN_FN(nll_loss2d_backward)(grad_output, self, target, weight, reduction, ignore_index, total_weight);
+    return at::_ops::nll_loss2d_backward::call(grad_output, self, target, weight, reduction, ignore_index, total_weight);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -20733,7 +20712,7 @@ at::Tensor smooth_l1_loss_generated_plumbing(const at::Tensor & self, const at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(smooth_l1_loss)(self, target, reduction, beta);
+    return at::_ops::smooth_l1_loss::call(self, target, reduction, beta);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20751,7 +20730,7 @@ at::Tensor smooth_l1_loss_backward_generated_plumbing(const at::Tensor & grad_ou
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(smooth_l1_loss_backward)(grad_output, self, target, reduction, beta);
+    return at::_ops::smooth_l1_loss_backward::call(grad_output, self, target, reduction, beta);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -20772,7 +20751,7 @@ at::Tensor huber_loss_generated_plumbing(const at::Tensor & self, const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(huber_loss)(self, target, reduction, delta);
+    return at::_ops::huber_loss::call(self, target, reduction, delta);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20790,7 +20769,7 @@ at::Tensor huber_loss_backward_generated_plumbing(const at::Tensor & grad_output
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(huber_loss_backward)(grad_output, self, target, reduction, delta);
+    return at::_ops::huber_loss_backward::call(grad_output, self, target, reduction, delta);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -20811,7 +20790,7 @@ at::Tensor soft_margin_loss_generated_plumbing(const at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(soft_margin_loss)(self, target, reduction);
+    return at::_ops::soft_margin_loss::call(self, target, reduction);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20829,7 +20808,7 @@ at::Tensor soft_margin_loss_backward_generated_plumbing(const at::Tensor & grad_
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(target, cur_level)) {
-    return ATEN_FN(soft_margin_loss_backward)(grad_output, self, target, reduction);
+    return at::_ops::soft_margin_loss_backward::call(grad_output, self, target, reduction);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -20850,7 +20829,7 @@ at::Tensor elu_generated_plumbing(const at::Tensor & self, const at::Scalar & al
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(elu)(self, alpha, scale, input_scale);
+    return at::_ops::elu::call(self, alpha, scale, input_scale);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20865,7 +20844,7 @@ at::Tensor elu_backward_generated_plumbing(const at::Tensor & grad_output, const
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self_or_result, cur_level)) {
-    return ATEN_FN(elu_backward)(grad_output, alpha, scale, input_scale, is_result, self_or_result);
+    return at::_ops::elu_backward::call(grad_output, alpha, scale, input_scale, is_result, self_or_result);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -20883,7 +20862,7 @@ at::Tensor & elu__generated_plumbing(at::Tensor & self, const at::Scalar & alpha
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(elu_)(self, alpha, scale, input_scale);
+    return at::_ops::elu_::call(self, alpha, scale, input_scale);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20898,7 +20877,7 @@ at::Tensor glu_generated_plumbing(const at::Tensor & self, int64_t dim) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(glu)(self, dim);
+    return at::_ops::glu::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20913,7 +20892,7 @@ at::Tensor glu_backward_generated_plumbing(const at::Tensor & grad_output, const
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(glu_backward)(grad_output, self, dim);
+    return at::_ops::glu_backward::call(grad_output, self, dim);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -20931,7 +20910,7 @@ at::Tensor hardsigmoid_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(hardsigmoid)(self);
+    return at::_ops::hardsigmoid::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20946,7 +20925,7 @@ at::Tensor & hardsigmoid__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(hardsigmoid_)(self);
+    return at::_ops::hardsigmoid_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20961,7 +20940,7 @@ at::Tensor hardsigmoid_backward_generated_plumbing(const at::Tensor & grad_outpu
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(hardsigmoid_backward)(grad_output, self);
+    return at::_ops::hardsigmoid_backward::call(grad_output, self);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -20979,7 +20958,7 @@ at::Tensor hardtanh_generated_plumbing(const at::Tensor & self, const at::Scalar
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(hardtanh)(self, min_val, max_val);
+    return at::_ops::hardtanh::call(self, min_val, max_val);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -20994,7 +20973,7 @@ at::Tensor hardtanh_backward_generated_plumbing(const at::Tensor & grad_output, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(hardtanh_backward)(grad_output, self, min_val, max_val);
+    return at::_ops::hardtanh_backward::call(grad_output, self, min_val, max_val);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21012,7 +20991,7 @@ at::Tensor & hardtanh__generated_plumbing(at::Tensor & self, const at::Scalar & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(hardtanh_)(self, min_val, max_val);
+    return at::_ops::hardtanh_::call(self, min_val, max_val);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21027,7 +21006,7 @@ at::Tensor hardswish_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(hardswish)(self);
+    return at::_ops::hardswish::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21042,7 +21021,7 @@ at::Tensor & hardswish__generated_plumbing(at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(hardswish_)(self);
+    return at::_ops::hardswish_::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21057,7 +21036,7 @@ at::Tensor hardswish_backward_generated_plumbing(const at::Tensor & grad_output,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(hardswish_backward)(grad_output, self);
+    return at::_ops::hardswish_backward::call(grad_output, self);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21075,7 +21054,7 @@ at::Tensor leaky_relu_generated_plumbing(const at::Tensor & self, const at::Scal
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(leaky_relu)(self, negative_slope);
+    return at::_ops::leaky_relu::call(self, negative_slope);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21090,7 +21069,7 @@ at::Tensor leaky_relu_backward_generated_plumbing(const at::Tensor & grad_output
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(leaky_relu_backward)(grad_output, self, negative_slope, self_is_result);
+    return at::_ops::leaky_relu_backward::call(grad_output, self, negative_slope, self_is_result);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21108,7 +21087,7 @@ at::Tensor & leaky_relu__generated_plumbing(at::Tensor & self, const at::Scalar 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(leaky_relu_)(self, negative_slope);
+    return at::_ops::leaky_relu_::call(self, negative_slope);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21123,7 +21102,7 @@ at::Tensor log_sigmoid_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(log_sigmoid)(self);
+    return at::_ops::log_sigmoid::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21138,7 +21117,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(log_sigmoid_forward)(self);
+    return at::_ops::log_sigmoid_forward::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21153,7 +21132,7 @@ at::Tensor log_sigmoid_backward_generated_plumbing(const at::Tensor & grad_outpu
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(buffer, cur_level)) {
-    return ATEN_FN(log_sigmoid_backward)(grad_output, self, buffer);
+    return at::_ops::log_sigmoid_backward::call(grad_output, self, buffer);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21174,7 +21153,7 @@ at::Tensor rrelu_with_noise_generated_plumbing(const at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(noise, cur_level)) {
-    return ATEN_FN(rrelu_with_noise)(self, noise, lower, upper, training, generator);
+    return at::_ops::rrelu_with_noise::call(self, noise, lower, upper, training, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21192,7 +21171,7 @@ at::Tensor rrelu_with_noise_backward_generated_plumbing(const at::Tensor & grad_
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(noise, cur_level)) {
-    return ATEN_FN(rrelu_with_noise_backward)(grad_output, self, noise, lower, upper, training, self_is_result);
+    return at::_ops::rrelu_with_noise_backward::call(grad_output, self, noise, lower, upper, training, self_is_result);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21213,7 +21192,7 @@ at::Tensor & rrelu_with_noise__generated_plumbing(at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(noise, cur_level)) {
-    return ATEN_FN(rrelu_with_noise_)(self, noise, lower, upper, training, generator);
+    return at::_ops::rrelu_with_noise_::call(self, noise, lower, upper, training, generator);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21231,7 +21210,7 @@ at::Tensor softplus_generated_plumbing(const at::Tensor & self, const at::Scalar
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(softplus)(self, beta, threshold);
+    return at::_ops::softplus::call(self, beta, threshold);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21246,7 +21225,7 @@ at::Tensor softplus_backward_generated_plumbing(const at::Tensor & grad_output, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(softplus_backward)(grad_output, self, beta, threshold);
+    return at::_ops::softplus_backward::call(grad_output, self, beta, threshold);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21264,7 +21243,7 @@ at::Tensor softshrink_generated_plumbing(const at::Tensor & self, const at::Scal
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(softshrink)(self, lambd);
+    return at::_ops::softshrink::call(self, lambd);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21279,7 +21258,7 @@ at::Tensor softshrink_backward_generated_plumbing(const at::Tensor & grad_output
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(softshrink_backward)(grad_output, self, lambd);
+    return at::_ops::softshrink_backward::call(grad_output, self, lambd);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21297,7 +21276,7 @@ at::Tensor adaptive_avg_pool2d_generated_plumbing(const at::Tensor & self, at::I
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(adaptive_avg_pool2d)(self, output_size);
+    return at::_ops::adaptive_avg_pool2d::call(self, output_size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21312,7 +21291,7 @@ at::Tensor mkldnn_adaptive_avg_pool2d_generated_plumbing(const at::Tensor & self
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mkldnn_adaptive_avg_pool2d)(self, output_size);
+    return at::_ops::mkldnn_adaptive_avg_pool2d::call(self, output_size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21327,7 +21306,7 @@ at::Tensor mkldnn_adaptive_avg_pool2d_backward_generated_plumbing(const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(mkldnn_adaptive_avg_pool2d_backward)(grad_output, self);
+    return at::_ops::mkldnn_adaptive_avg_pool2d_backward::call(grad_output, self);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21345,7 +21324,7 @@ at::Tensor _adaptive_avg_pool2d_generated_plumbing(const at::Tensor & self, at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_adaptive_avg_pool2d)(self, output_size);
+    return at::_ops::_adaptive_avg_pool2d::call(self, output_size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21360,7 +21339,7 @@ at::Tensor _adaptive_avg_pool2d_backward_generated_plumbing(const at::Tensor & g
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_adaptive_avg_pool2d_backward)(grad_output, self);
+    return at::_ops::_adaptive_avg_pool2d_backward::call(grad_output, self);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21378,7 +21357,7 @@ at::Tensor adaptive_avg_pool3d_generated_plumbing(const at::Tensor & self, at::I
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(adaptive_avg_pool3d)(self, output_size);
+    return at::_ops::adaptive_avg_pool3d::call(self, output_size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21393,7 +21372,7 @@ at::Tensor _adaptive_avg_pool3d_generated_plumbing(const at::Tensor & self, at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_adaptive_avg_pool3d)(self, output_size);
+    return at::_ops::_adaptive_avg_pool3d::call(self, output_size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21408,7 +21387,7 @@ at::Tensor _adaptive_avg_pool3d_backward_generated_plumbing(const at::Tensor & g
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_adaptive_avg_pool3d_backward)(grad_output, self);
+    return at::_ops::_adaptive_avg_pool3d_backward::call(grad_output, self);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21426,7 +21405,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(adaptive_max_pool2d)(self, output_size);
+    return at::_ops::adaptive_max_pool2d::call(self, output_size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21441,7 +21420,7 @@ at::Tensor adaptive_max_pool2d_backward_generated_plumbing(const at::Tensor & gr
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(adaptive_max_pool2d_backward)(grad_output, self, indices);
+    return at::_ops::adaptive_max_pool2d_backward::call(grad_output, self, indices);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21462,7 +21441,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(adaptive_max_pool3d)(self, output_size);
+    return at::_ops::adaptive_max_pool3d::call(self, output_size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21477,7 +21456,7 @@ at::Tensor adaptive_max_pool3d_backward_generated_plumbing(const at::Tensor & gr
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(adaptive_max_pool3d_backward)(grad_output, self, indices);
+    return at::_ops::adaptive_max_pool3d_backward::call(grad_output, self, indices);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21498,7 +21477,7 @@ at::Tensor avg_pool2d_generated_plumbing(const at::Tensor & self, at::IntArrayRe
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(avg_pool2d)(self, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override);
+    return at::_ops::avg_pool2d::call(self, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21513,7 +21492,7 @@ at::Tensor avg_pool2d_backward_generated_plumbing(const at::Tensor & grad_output
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(avg_pool2d_backward)(grad_output, self, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override);
+    return at::_ops::avg_pool2d_backward::call(grad_output, self, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21531,7 +21510,7 @@ at::Tensor avg_pool3d_generated_plumbing(const at::Tensor & self, at::IntArrayRe
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(avg_pool3d)(self, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override);
+    return at::_ops::avg_pool3d::call(self, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21546,7 +21525,7 @@ at::Tensor avg_pool3d_backward_generated_plumbing(const at::Tensor & grad_output
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(avg_pool3d_backward)(grad_output, self, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override);
+    return at::_ops::avg_pool3d_backward::call(grad_output, self, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21564,7 +21543,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(random_samples, cur_level)) {
-    return ATEN_FN(fractional_max_pool2d)(self, kernel_size, output_size, random_samples);
+    return at::_ops::fractional_max_pool2d::call(self, kernel_size, output_size, random_samples);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21582,7 +21561,7 @@ at::Tensor fractional_max_pool2d_backward_generated_plumbing(const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(fractional_max_pool2d_backward)(grad_output, self, kernel_size, output_size, indices);
+    return at::_ops::fractional_max_pool2d_backward::call(grad_output, self, kernel_size, output_size, indices);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21603,7 +21582,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(random_samples, cur_level)) {
-    return ATEN_FN(fractional_max_pool3d)(self, kernel_size, output_size, random_samples);
+    return at::_ops::fractional_max_pool3d::call(self, kernel_size, output_size, random_samples);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21621,7 +21600,7 @@ at::Tensor fractional_max_pool3d_backward_generated_plumbing(const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(fractional_max_pool3d_backward)(grad_output, self, kernel_size, output_size, indices);
+    return at::_ops::fractional_max_pool3d_backward::call(grad_output, self, kernel_size, output_size, indices);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21642,7 +21621,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(max_pool2d_with_indices)(self, kernel_size, stride, padding, dilation, ceil_mode);
+    return at::_ops::max_pool2d_with_indices::call(self, kernel_size, stride, padding, dilation, ceil_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21657,7 +21636,7 @@ at::Tensor max_pool2d_with_indices_backward_generated_plumbing(const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(max_pool2d_with_indices_backward)(grad_output, self, kernel_size, stride, padding, dilation, ceil_mode, indices);
+    return at::_ops::max_pool2d_with_indices_backward::call(grad_output, self, kernel_size, stride, padding, dilation, ceil_mode, indices);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21678,7 +21657,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(max_pool3d_with_indices)(self, kernel_size, stride, padding, dilation, ceil_mode);
+    return at::_ops::max_pool3d_with_indices::call(self, kernel_size, stride, padding, dilation, ceil_mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21693,7 +21672,7 @@ at::Tensor max_pool3d_with_indices_backward_generated_plumbing(const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(max_pool3d_with_indices_backward)(grad_output, self, kernel_size, stride, padding, dilation, ceil_mode, indices);
+    return at::_ops::max_pool3d_with_indices_backward::call(grad_output, self, kernel_size, stride, padding, dilation, ceil_mode, indices);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21714,7 +21693,7 @@ at::Tensor max_unpool2d_generated_plumbing(const at::Tensor & self, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(max_unpool2d)(self, indices, output_size);
+    return at::_ops::max_unpool2d::call(self, indices, output_size);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21732,7 +21711,7 @@ at::Tensor max_unpool2d_backward_generated_plumbing(const at::Tensor & grad_outp
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(max_unpool2d_backward)(grad_output, self, indices, output_size);
+    return at::_ops::max_unpool2d_backward::call(grad_output, self, indices, output_size);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21753,7 +21732,7 @@ at::Tensor max_unpool3d_generated_plumbing(const at::Tensor & self, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(max_unpool3d)(self, indices, output_size, stride, padding);
+    return at::_ops::max_unpool3d::call(self, indices, output_size, stride, padding);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21771,7 +21750,7 @@ at::Tensor max_unpool3d_backward_generated_plumbing(const at::Tensor & grad_outp
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(max_unpool3d_backward)(grad_output, self, indices, output_size, stride, padding);
+    return at::_ops::max_unpool3d_backward::call(grad_output, self, indices, output_size, stride, padding);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21792,7 +21771,7 @@ at::Tensor reflection_pad1d_generated_plumbing(const at::Tensor & self, at::IntA
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(reflection_pad1d)(self, padding);
+    return at::_ops::reflection_pad1d::call(self, padding);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21807,7 +21786,7 @@ at::Tensor reflection_pad1d_backward_generated_plumbing(const at::Tensor & grad_
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(reflection_pad1d_backward)(grad_output, self, padding);
+    return at::_ops::reflection_pad1d_backward::call(grad_output, self, padding);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21825,7 +21804,7 @@ at::Tensor reflection_pad2d_generated_plumbing(const at::Tensor & self, at::IntA
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(reflection_pad2d)(self, padding);
+    return at::_ops::reflection_pad2d::call(self, padding);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21840,7 +21819,7 @@ at::Tensor reflection_pad2d_backward_generated_plumbing(const at::Tensor & grad_
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(reflection_pad2d_backward)(grad_output, self, padding);
+    return at::_ops::reflection_pad2d_backward::call(grad_output, self, padding);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21858,7 +21837,7 @@ at::Tensor reflection_pad3d_generated_plumbing(const at::Tensor & self, at::IntA
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(reflection_pad3d)(self, padding);
+    return at::_ops::reflection_pad3d::call(self, padding);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21873,7 +21852,7 @@ at::Tensor reflection_pad3d_backward_generated_plumbing(const at::Tensor & grad_
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(reflection_pad3d_backward)(grad_output, self, padding);
+    return at::_ops::reflection_pad3d_backward::call(grad_output, self, padding);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21891,7 +21870,7 @@ at::Tensor replication_pad1d_generated_plumbing(const at::Tensor & self, at::Int
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(replication_pad1d)(self, padding);
+    return at::_ops::replication_pad1d::call(self, padding);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21906,7 +21885,7 @@ at::Tensor replication_pad1d_backward_generated_plumbing(const at::Tensor & grad
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(replication_pad1d_backward)(grad_output, self, padding);
+    return at::_ops::replication_pad1d_backward::call(grad_output, self, padding);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21924,7 +21903,7 @@ at::Tensor replication_pad2d_generated_plumbing(const at::Tensor & self, at::Int
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(replication_pad2d)(self, padding);
+    return at::_ops::replication_pad2d::call(self, padding);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21939,7 +21918,7 @@ at::Tensor replication_pad2d_backward_generated_plumbing(const at::Tensor & grad
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(replication_pad2d_backward)(grad_output, self, padding);
+    return at::_ops::replication_pad2d_backward::call(grad_output, self, padding);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21957,7 +21936,7 @@ at::Tensor replication_pad3d_generated_plumbing(const at::Tensor & self, at::Int
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(replication_pad3d)(self, padding);
+    return at::_ops::replication_pad3d::call(self, padding);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -21972,7 +21951,7 @@ at::Tensor replication_pad3d_backward_generated_plumbing(const at::Tensor & grad
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(replication_pad3d_backward)(grad_output, self, padding);
+    return at::_ops::replication_pad3d_backward::call(grad_output, self, padding);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -21990,7 +21969,7 @@ at::Tensor upsample_linear1d_vec_generated_plumbing(const at::Tensor & input, c1
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN2(upsample_linear1d, vec)(input, output_size, align_corners, scale_factors);
+    return at::_ops::upsample_linear1d_vec::call(input, output_size, align_corners, scale_factors);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -22005,7 +21984,7 @@ at::Tensor upsample_linear1d_backward_vec_generated_plumbing(const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN2(upsample_linear1d_backward, vec)(grad_output, output_size, input_size, align_corners, scale_factors);
+    return at::_ops::upsample_linear1d_backward_vec::call(grad_output, output_size, input_size, align_corners, scale_factors);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22020,7 +21999,7 @@ at::Tensor upsample_bilinear2d_vec_generated_plumbing(const at::Tensor & input, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN2(upsample_bilinear2d, vec)(input, output_size, align_corners, scale_factors);
+    return at::_ops::upsample_bilinear2d_vec::call(input, output_size, align_corners, scale_factors);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -22035,7 +22014,7 @@ at::Tensor upsample_bilinear2d_backward_vec_generated_plumbing(const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN2(upsample_bilinear2d_backward, vec)(grad_output, output_size, input_size, align_corners, scale_factors);
+    return at::_ops::upsample_bilinear2d_backward_vec::call(grad_output, output_size, input_size, align_corners, scale_factors);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22050,7 +22029,7 @@ at::Tensor _upsample_bilinear2d_aa_vec_generated_plumbing(const at::Tensor & inp
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN2(_upsample_bilinear2d_aa, vec)(input, output_size, align_corners, scale_factors);
+    return at::_ops::_upsample_bilinear2d_aa_vec::call(input, output_size, align_corners, scale_factors);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -22065,7 +22044,7 @@ at::Tensor _upsample_bilinear2d_aa_backward_vec_generated_plumbing(const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN2(_upsample_bilinear2d_aa_backward, vec)(grad_output, output_size, input_size, align_corners, scale_factors);
+    return at::_ops::_upsample_bilinear2d_aa_backward_vec::call(grad_output, output_size, input_size, align_corners, scale_factors);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22080,7 +22059,7 @@ at::Tensor upsample_trilinear3d_vec_generated_plumbing(const at::Tensor & input,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN2(upsample_trilinear3d, vec)(input, output_size, align_corners, scale_factors);
+    return at::_ops::upsample_trilinear3d_vec::call(input, output_size, align_corners, scale_factors);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -22095,7 +22074,7 @@ at::Tensor upsample_trilinear3d_backward_vec_generated_plumbing(const at::Tensor
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN2(upsample_trilinear3d_backward, vec)(grad_output, output_size, input_size, align_corners, scale_factors);
+    return at::_ops::upsample_trilinear3d_backward_vec::call(grad_output, output_size, input_size, align_corners, scale_factors);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22110,7 +22089,7 @@ at::Tensor upsample_bicubic2d_vec_generated_plumbing(const at::Tensor & input, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN2(upsample_bicubic2d, vec)(input, output_size, align_corners, scale_factors);
+    return at::_ops::upsample_bicubic2d_vec::call(input, output_size, align_corners, scale_factors);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -22125,7 +22104,7 @@ at::Tensor upsample_bicubic2d_backward_vec_generated_plumbing(const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN2(upsample_bicubic2d_backward, vec)(grad_output, output_size, input_size, align_corners, scale_factors);
+    return at::_ops::upsample_bicubic2d_backward_vec::call(grad_output, output_size, input_size, align_corners, scale_factors);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22140,7 +22119,7 @@ at::Tensor _upsample_bicubic2d_aa_vec_generated_plumbing(const at::Tensor & inpu
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN2(_upsample_bicubic2d_aa, vec)(input, output_size, align_corners, scale_factors);
+    return at::_ops::_upsample_bicubic2d_aa_vec::call(input, output_size, align_corners, scale_factors);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -22155,7 +22134,7 @@ at::Tensor _upsample_bicubic2d_aa_backward_vec_generated_plumbing(const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN2(_upsample_bicubic2d_aa_backward, vec)(grad_output, output_size, input_size, align_corners, scale_factors);
+    return at::_ops::_upsample_bicubic2d_aa_backward_vec::call(grad_output, output_size, input_size, align_corners, scale_factors);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22170,7 +22149,7 @@ at::Tensor upsample_nearest1d_vec_generated_plumbing(const at::Tensor & input, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN2(upsample_nearest1d, vec)(input, output_size, scale_factors);
+    return at::_ops::upsample_nearest1d_vec::call(input, output_size, scale_factors);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -22185,7 +22164,7 @@ at::Tensor _upsample_nearest_exact1d_vec_generated_plumbing(const at::Tensor & i
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN2(_upsample_nearest_exact1d, vec)(input, output_size, scale_factors);
+    return at::_ops::_upsample_nearest_exact1d_vec::call(input, output_size, scale_factors);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -22200,7 +22179,7 @@ at::Tensor upsample_nearest1d_backward_vec_generated_plumbing(const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN2(upsample_nearest1d_backward, vec)(grad_output, output_size, input_size, scale_factors);
+    return at::_ops::upsample_nearest1d_backward_vec::call(grad_output, output_size, input_size, scale_factors);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22215,7 +22194,7 @@ at::Tensor _upsample_nearest_exact1d_backward_vec_generated_plumbing(const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN2(_upsample_nearest_exact1d_backward, vec)(grad_output, output_size, input_size, scale_factors);
+    return at::_ops::_upsample_nearest_exact1d_backward_vec::call(grad_output, output_size, input_size, scale_factors);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22230,7 +22209,7 @@ at::Tensor upsample_nearest2d_vec_generated_plumbing(const at::Tensor & input, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN2(upsample_nearest2d, vec)(input, output_size, scale_factors);
+    return at::_ops::upsample_nearest2d_vec::call(input, output_size, scale_factors);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -22245,7 +22224,7 @@ at::Tensor _upsample_nearest_exact2d_vec_generated_plumbing(const at::Tensor & i
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN2(_upsample_nearest_exact2d, vec)(input, output_size, scale_factors);
+    return at::_ops::_upsample_nearest_exact2d_vec::call(input, output_size, scale_factors);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -22260,7 +22239,7 @@ at::Tensor upsample_nearest2d_backward_vec_generated_plumbing(const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN2(upsample_nearest2d_backward, vec)(grad_output, output_size, input_size, scale_factors);
+    return at::_ops::upsample_nearest2d_backward_vec::call(grad_output, output_size, input_size, scale_factors);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22275,7 +22254,7 @@ at::Tensor _upsample_nearest_exact2d_backward_vec_generated_plumbing(const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN2(_upsample_nearest_exact2d_backward, vec)(grad_output, output_size, input_size, scale_factors);
+    return at::_ops::_upsample_nearest_exact2d_backward_vec::call(grad_output, output_size, input_size, scale_factors);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22290,7 +22269,7 @@ at::Tensor upsample_nearest3d_vec_generated_plumbing(const at::Tensor & input, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN2(upsample_nearest3d, vec)(input, output_size, scale_factors);
+    return at::_ops::upsample_nearest3d_vec::call(input, output_size, scale_factors);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -22305,7 +22284,7 @@ at::Tensor _upsample_nearest_exact3d_vec_generated_plumbing(const at::Tensor & i
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level)) {
-    return ATEN_FN2(_upsample_nearest_exact3d, vec)(input, output_size, scale_factors);
+    return at::_ops::_upsample_nearest_exact3d_vec::call(input, output_size, scale_factors);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -22320,7 +22299,7 @@ at::Tensor upsample_nearest3d_backward_vec_generated_plumbing(const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN2(upsample_nearest3d_backward, vec)(grad_output, output_size, input_size, scale_factors);
+    return at::_ops::upsample_nearest3d_backward_vec::call(grad_output, output_size, input_size, scale_factors);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22335,7 +22314,7 @@ at::Tensor _upsample_nearest_exact3d_backward_vec_generated_plumbing(const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN2(_upsample_nearest_exact3d_backward, vec)(grad_output, output_size, input_size, scale_factors);
+    return at::_ops::_upsample_nearest_exact3d_backward_vec::call(grad_output, output_size, input_size, scale_factors);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22350,7 +22329,7 @@ at::Tensor upsample_linear1d_generated_plumbing(const at::Tensor & self, at::Int
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(upsample_linear1d)(self, output_size, align_corners, scales);
+    return at::_ops::upsample_linear1d::call(self, output_size, align_corners, scales);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22365,7 +22344,7 @@ at::Tensor upsample_linear1d_backward_generated_plumbing(const at::Tensor & grad
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(upsample_linear1d_backward)(grad_output, output_size, input_size, align_corners, scales);
+    return at::_ops::upsample_linear1d_backward::call(grad_output, output_size, input_size, align_corners, scales);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22380,7 +22359,7 @@ at::Tensor upsample_bilinear2d_generated_plumbing(const at::Tensor & self, at::I
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(upsample_bilinear2d)(self, output_size, align_corners, scales_h, scales_w);
+    return at::_ops::upsample_bilinear2d::call(self, output_size, align_corners, scales_h, scales_w);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22395,7 +22374,7 @@ at::Tensor upsample_bilinear2d_backward_generated_plumbing(const at::Tensor & gr
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(upsample_bilinear2d_backward)(grad_output, output_size, input_size, align_corners, scales_h, scales_w);
+    return at::_ops::upsample_bilinear2d_backward::call(grad_output, output_size, input_size, align_corners, scales_h, scales_w);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22410,7 +22389,7 @@ at::Tensor _upsample_bilinear2d_aa_generated_plumbing(const at::Tensor & self, a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_upsample_bilinear2d_aa)(self, output_size, align_corners, scales_h, scales_w);
+    return at::_ops::_upsample_bilinear2d_aa::call(self, output_size, align_corners, scales_h, scales_w);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22425,7 +22404,7 @@ at::Tensor _upsample_bilinear2d_aa_backward_generated_plumbing(const at::Tensor 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(_upsample_bilinear2d_aa_backward)(grad_output, output_size, input_size, align_corners, scales_h, scales_w);
+    return at::_ops::_upsample_bilinear2d_aa_backward::call(grad_output, output_size, input_size, align_corners, scales_h, scales_w);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22440,7 +22419,7 @@ at::Tensor upsample_bicubic2d_generated_plumbing(const at::Tensor & self, at::In
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(upsample_bicubic2d)(self, output_size, align_corners, scales_h, scales_w);
+    return at::_ops::upsample_bicubic2d::call(self, output_size, align_corners, scales_h, scales_w);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22455,7 +22434,7 @@ at::Tensor upsample_bicubic2d_backward_generated_plumbing(const at::Tensor & gra
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(upsample_bicubic2d_backward)(grad_output, output_size, input_size, align_corners, scales_h, scales_w);
+    return at::_ops::upsample_bicubic2d_backward::call(grad_output, output_size, input_size, align_corners, scales_h, scales_w);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22470,7 +22449,7 @@ at::Tensor _upsample_bicubic2d_aa_generated_plumbing(const at::Tensor & self, at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_upsample_bicubic2d_aa)(self, output_size, align_corners, scales_h, scales_w);
+    return at::_ops::_upsample_bicubic2d_aa::call(self, output_size, align_corners, scales_h, scales_w);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22485,7 +22464,7 @@ at::Tensor _upsample_bicubic2d_aa_backward_generated_plumbing(const at::Tensor &
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(_upsample_bicubic2d_aa_backward)(grad_output, output_size, input_size, align_corners, scales_h, scales_w);
+    return at::_ops::_upsample_bicubic2d_aa_backward::call(grad_output, output_size, input_size, align_corners, scales_h, scales_w);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22500,7 +22479,7 @@ at::Tensor upsample_trilinear3d_generated_plumbing(const at::Tensor & self, at::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(upsample_trilinear3d)(self, output_size, align_corners, scales_d, scales_h, scales_w);
+    return at::_ops::upsample_trilinear3d::call(self, output_size, align_corners, scales_d, scales_h, scales_w);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22515,7 +22494,7 @@ at::Tensor upsample_trilinear3d_backward_generated_plumbing(const at::Tensor & g
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(upsample_trilinear3d_backward)(grad_output, output_size, input_size, align_corners, scales_d, scales_h, scales_w);
+    return at::_ops::upsample_trilinear3d_backward::call(grad_output, output_size, input_size, align_corners, scales_d, scales_h, scales_w);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22530,7 +22509,7 @@ at::Tensor upsample_nearest1d_generated_plumbing(const at::Tensor & self, at::In
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(upsample_nearest1d)(self, output_size, scales);
+    return at::_ops::upsample_nearest1d::call(self, output_size, scales);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22545,7 +22524,7 @@ at::Tensor _upsample_nearest_exact1d_generated_plumbing(const at::Tensor & self,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_upsample_nearest_exact1d)(self, output_size, scales);
+    return at::_ops::_upsample_nearest_exact1d::call(self, output_size, scales);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22560,7 +22539,7 @@ at::Tensor upsample_nearest1d_backward_generated_plumbing(const at::Tensor & gra
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(upsample_nearest1d_backward)(grad_output, output_size, input_size, scales);
+    return at::_ops::upsample_nearest1d_backward::call(grad_output, output_size, input_size, scales);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22575,7 +22554,7 @@ at::Tensor _upsample_nearest_exact1d_backward_generated_plumbing(const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(_upsample_nearest_exact1d_backward)(grad_output, output_size, input_size, scales);
+    return at::_ops::_upsample_nearest_exact1d_backward::call(grad_output, output_size, input_size, scales);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22590,7 +22569,7 @@ at::Tensor upsample_nearest2d_generated_plumbing(const at::Tensor & self, at::In
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(upsample_nearest2d)(self, output_size, scales_h, scales_w);
+    return at::_ops::upsample_nearest2d::call(self, output_size, scales_h, scales_w);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22605,7 +22584,7 @@ at::Tensor _upsample_nearest_exact2d_generated_plumbing(const at::Tensor & self,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_upsample_nearest_exact2d)(self, output_size, scales_h, scales_w);
+    return at::_ops::_upsample_nearest_exact2d::call(self, output_size, scales_h, scales_w);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22620,7 +22599,7 @@ at::Tensor upsample_nearest2d_backward_generated_plumbing(const at::Tensor & gra
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(upsample_nearest2d_backward)(grad_output, output_size, input_size, scales_h, scales_w);
+    return at::_ops::upsample_nearest2d_backward::call(grad_output, output_size, input_size, scales_h, scales_w);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22635,7 +22614,7 @@ at::Tensor _upsample_nearest_exact2d_backward_generated_plumbing(const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(_upsample_nearest_exact2d_backward)(grad_output, output_size, input_size, scales_h, scales_w);
+    return at::_ops::_upsample_nearest_exact2d_backward::call(grad_output, output_size, input_size, scales_h, scales_w);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22650,7 +22629,7 @@ at::Tensor upsample_nearest3d_generated_plumbing(const at::Tensor & self, at::In
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(upsample_nearest3d)(self, output_size, scales_d, scales_h, scales_w);
+    return at::_ops::upsample_nearest3d::call(self, output_size, scales_d, scales_h, scales_w);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22665,7 +22644,7 @@ at::Tensor _upsample_nearest_exact3d_generated_plumbing(const at::Tensor & self,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_upsample_nearest_exact3d)(self, output_size, scales_d, scales_h, scales_w);
+    return at::_ops::_upsample_nearest_exact3d::call(self, output_size, scales_d, scales_h, scales_w);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22680,7 +22659,7 @@ at::Tensor upsample_nearest3d_backward_generated_plumbing(const at::Tensor & gra
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(upsample_nearest3d_backward)(grad_output, output_size, input_size, scales_d, scales_h, scales_w);
+    return at::_ops::upsample_nearest3d_backward::call(grad_output, output_size, input_size, scales_d, scales_h, scales_w);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22695,7 +22674,7 @@ at::Tensor _upsample_nearest_exact3d_backward_generated_plumbing(const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(_upsample_nearest_exact3d_backward)(grad_output, output_size, input_size, scales_d, scales_h, scales_w);
+    return at::_ops::_upsample_nearest_exact3d_backward::call(grad_output, output_size, input_size, scales_d, scales_h, scales_w);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22710,7 +22689,7 @@ at::Tensor sigmoid_backward_generated_plumbing(const at::Tensor & grad_output, c
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(output, cur_level)) {
-    return ATEN_FN(sigmoid_backward)(grad_output, output);
+    return at::_ops::sigmoid_backward::call(grad_output, output);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22728,7 +22707,7 @@ at::Tensor logit_backward_generated_plumbing(const at::Tensor & grad_output, con
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(logit_backward)(grad_output, self, eps);
+    return at::_ops::logit_backward::call(grad_output, self, eps);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22746,7 +22725,7 @@ at::Tensor tanh_backward_generated_plumbing(const at::Tensor & grad_output, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(output, cur_level)) {
-    return ATEN_FN(tanh_backward)(grad_output, output);
+    return at::_ops::tanh_backward::call(grad_output, output);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22764,7 +22743,7 @@ at::Tensor slow_conv_transpose2d_generated_plumbing(const at::Tensor & self, con
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(slow_conv_transpose2d)(self, weight, kernel_size, bias, stride, padding, output_padding, dilation);
+    return at::_ops::slow_conv_transpose2d::call(self, weight, kernel_size, bias, stride, padding, output_padding, dilation);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22787,7 +22766,7 @@ at::Tensor slow_conv_transpose3d_generated_plumbing(const at::Tensor & self, con
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(slow_conv_transpose3d)(self, weight, kernel_size, bias, stride, padding, output_padding, dilation);
+    return at::_ops::slow_conv_transpose3d::call(self, weight, kernel_size, bias, stride, padding, output_padding, dilation);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22810,7 +22789,7 @@ at::Tensor thnn_conv2d_generated_plumbing(const at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(thnn_conv2d)(self, weight, kernel_size, bias, stride, padding);
+    return at::_ops::thnn_conv2d::call(self, weight, kernel_size, bias, stride, padding);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22833,7 +22812,7 @@ at::Tensor _slow_conv2d_forward_generated_plumbing(const at::Tensor & self, cons
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(_slow_conv2d_forward)(self, weight, kernel_size, bias, stride, padding);
+    return at::_ops::_slow_conv2d_forward::call(self, weight, kernel_size, bias, stride, padding);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22856,7 +22835,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level)) {
-    return ATEN_FN2(_slow_conv2d_backward, output_mask)(grad_output, self, weight, kernel_size, stride, padding, output_mask);
+    return at::_ops::_slow_conv2d_backward_output_mask::call(grad_output, self, weight, kernel_size, stride, padding, output_mask);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -22877,7 +22856,7 @@ at::Tensor _conv_depthwise2d_generated_plumbing(const at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(_conv_depthwise2d)(self, weight, kernel_size, bias, stride, padding, dilation);
+    return at::_ops::_conv_depthwise2d::call(self, weight, kernel_size, bias, stride, padding, dilation);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22900,7 +22879,7 @@ at::Tensor conv_depthwise3d_generated_plumbing(const at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(conv_depthwise3d)(self, weight, kernel_size, bias, stride, padding, dilation);
+    return at::_ops::conv_depthwise3d::call(self, weight, kernel_size, bias, stride, padding, dilation);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22923,7 +22902,7 @@ at::Tensor slow_conv3d_generated_plumbing(const at::Tensor & self, const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(slow_conv3d)(self, weight, kernel_size, bias, stride, padding);
+    return at::_ops::slow_conv3d::call(self, weight, kernel_size, bias, stride, padding);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22946,7 +22925,7 @@ at::Tensor slow_conv3d_forward_generated_plumbing(const at::Tensor & self, const
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(slow_conv3d_forward)(self, weight, kernel_size, bias, stride, padding);
+    return at::_ops::slow_conv3d_forward::call(self, weight, kernel_size, bias, stride, padding);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22969,7 +22948,7 @@ at::Tensor slow_conv_dilated2d_generated_plumbing(const at::Tensor & self, const
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(slow_conv_dilated2d)(self, weight, kernel_size, bias, stride, padding, dilation);
+    return at::_ops::slow_conv_dilated2d::call(self, weight, kernel_size, bias, stride, padding, dilation);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -22992,7 +22971,7 @@ at::Tensor slow_conv_dilated3d_generated_plumbing(const at::Tensor & self, const
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(weight, cur_level) && !isBatchedAtLevel(bias, cur_level)) {
-    return ATEN_FN(slow_conv_dilated3d)(self, weight, kernel_size, bias, stride, padding, dilation);
+    return at::_ops::slow_conv_dilated3d::call(self, weight, kernel_size, bias, stride, padding, dilation);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23015,7 +22994,7 @@ at::Tensor col2im_generated_plumbing(const at::Tensor & self, at::IntArrayRef ou
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(col2im)(self, output_size, kernel_size, dilation, padding, stride);
+    return at::_ops::col2im::call(self, output_size, kernel_size, dilation, padding, stride);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23030,7 +23009,7 @@ at::Tensor col2im_backward_generated_plumbing(const at::Tensor & grad_output, at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(col2im_backward)(grad_output, kernel_size, dilation, padding, stride);
+    return at::_ops::col2im_backward::call(grad_output, kernel_size, dilation, padding, stride);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -23045,7 +23024,7 @@ at::Tensor column_stack_generated_plumbing(at::TensorList tensors) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(column_stack)(tensors);
+    return at::_ops::column_stack::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -23058,7 +23037,7 @@ at::Tensor im2col_generated_plumbing(const at::Tensor & self, at::IntArrayRef ke
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(im2col)(self, kernel_size, dilation, padding, stride);
+    return at::_ops::im2col::call(self, kernel_size, dilation, padding, stride);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23073,7 +23052,7 @@ at::Tensor im2col_backward_generated_plumbing(const at::Tensor & grad_output, at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad_output, cur_level)) {
-    return ATEN_FN(im2col_backward)(grad_output, input_size, kernel_size, dilation, padding, stride);
+    return at::_ops::im2col_backward::call(grad_output, input_size, kernel_size, dilation, padding, stride);
   }
   Tensor grad_output_value;
   optional<int64_t> grad_output_bdim;
@@ -23088,7 +23067,7 @@ at::Tensor isfinite_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(isfinite)(self);
+    return at::_ops::isfinite::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23103,7 +23082,7 @@ at::Tensor isinf_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(isinf)(self);
+    return at::_ops::isinf::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23118,7 +23097,7 @@ at::Tensor isposinf_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(isposinf)(self);
+    return at::_ops::isposinf::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23133,7 +23112,7 @@ at::Tensor isneginf_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(isneginf)(self);
+    return at::_ops::isneginf::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23148,7 +23127,7 @@ at::Tensor _add_batch_dim_generated_plumbing(const at::Tensor & self, int64_t ba
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_add_batch_dim)(self, batch_dim, level);
+    return at::_ops::_add_batch_dim::call(self, batch_dim, level);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23163,7 +23142,7 @@ at::Tensor _remove_batch_dim_generated_plumbing(const at::Tensor & self, int64_t
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_remove_batch_dim)(self, level, batch_size, out_dim);
+    return at::_ops::_remove_batch_dim::call(self, level, batch_size, out_dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23178,7 +23157,7 @@ at::Tensor special_entr_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_entr)(self);
+    return at::_ops::special_entr::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23193,7 +23172,7 @@ at::Tensor special_ndtri_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_ndtri)(self);
+    return at::_ops::special_ndtri::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23208,7 +23187,7 @@ at::Tensor special_expm1_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_expm1)(self);
+    return at::_ops::special_expm1::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23223,7 +23202,7 @@ at::Tensor special_exp2_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_exp2)(self);
+    return at::_ops::special_exp2::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23238,7 +23217,7 @@ at::Tensor special_psi_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_psi)(self);
+    return at::_ops::special_psi::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23253,7 +23232,7 @@ at::Tensor special_digamma_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_digamma)(self);
+    return at::_ops::special_digamma::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23268,7 +23247,7 @@ at::Tensor special_gammaln_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_gammaln)(self);
+    return at::_ops::special_gammaln::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23283,7 +23262,7 @@ at::Tensor special_erf_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_erf)(self);
+    return at::_ops::special_erf::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23298,7 +23277,7 @@ at::Tensor special_erfc_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_erfc)(self);
+    return at::_ops::special_erfc::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23313,7 +23292,7 @@ at::Tensor special_erfcx_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_erfcx)(self);
+    return at::_ops::special_erfcx::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23328,7 +23307,7 @@ at::Tensor special_erfinv_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_erfinv)(self);
+    return at::_ops::special_erfinv::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23343,7 +23322,7 @@ at::Tensor special_ndtr_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_ndtr)(self);
+    return at::_ops::special_ndtr::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23358,7 +23337,7 @@ at::Tensor special_xlog1py_generated_plumbing(const at::Tensor & self, const at:
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(special_xlog1py)(self, other);
+    return at::_ops::special_xlog1py::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23376,7 +23355,7 @@ at::Tensor special_xlog1py_self_scalar_generated_plumbing(const at::Scalar & sel
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(special_xlog1py, self_scalar)(self, other);
+    return at::_ops::special_xlog1py_self_scalar::call(self, other);
   }
   Tensor other_value;
   optional<int64_t> other_bdim;
@@ -23391,7 +23370,7 @@ at::Tensor special_xlog1py_other_scalar_generated_plumbing(const at::Tensor & se
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(special_xlog1py, other_scalar)(self, other);
+    return at::_ops::special_xlog1py_other_scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23406,7 +23385,7 @@ at::Tensor special_xlogy_generated_plumbing(const at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(special_xlogy)(self, other);
+    return at::_ops::special_xlogy::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23424,7 +23403,7 @@ at::Tensor special_xlogy_self_scalar_generated_plumbing(const at::Scalar & self,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(special_xlogy, self_scalar)(self, other);
+    return at::_ops::special_xlogy_self_scalar::call(self, other);
   }
   Tensor other_value;
   optional<int64_t> other_bdim;
@@ -23439,7 +23418,7 @@ at::Tensor special_xlogy_other_scalar_generated_plumbing(const at::Tensor & self
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(special_xlogy, other_scalar)(self, other);
+    return at::_ops::special_xlogy_other_scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23454,7 +23433,7 @@ at::Tensor special_zeta_generated_plumbing(const at::Tensor & self, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(special_zeta)(self, other);
+    return at::_ops::special_zeta::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23472,7 +23451,7 @@ at::Tensor special_zeta_self_scalar_generated_plumbing(const at::Scalar & self, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN2(special_zeta, self_scalar)(self, other);
+    return at::_ops::special_zeta_self_scalar::call(self, other);
   }
   Tensor other_value;
   optional<int64_t> other_bdim;
@@ -23487,7 +23466,7 @@ at::Tensor special_zeta_other_scalar_generated_plumbing(const at::Tensor & self,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(special_zeta, other_scalar)(self, other);
+    return at::_ops::special_zeta_other_scalar::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23502,7 +23481,7 @@ at::Tensor special_i0_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_i0)(self);
+    return at::_ops::special_i0::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23517,7 +23496,7 @@ at::Tensor special_i0e_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_i0e)(self);
+    return at::_ops::special_i0e::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23532,7 +23511,7 @@ at::Tensor special_i1_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_i1)(self);
+    return at::_ops::special_i1::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23547,7 +23526,7 @@ at::Tensor special_i1e_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_i1e)(self);
+    return at::_ops::special_i1e::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23562,7 +23541,7 @@ at::Tensor special_logit_generated_plumbing(const at::Tensor & self, c10::option
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_logit)(self, eps);
+    return at::_ops::special_logit::call(self, eps);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23577,7 +23556,7 @@ at::Tensor special_polygamma_generated_plumbing(int64_t n, const at::Tensor & se
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_polygamma)(n, self);
+    return at::_ops::special_polygamma::call(n, self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23592,7 +23571,7 @@ at::Tensor special_logsumexp_generated_plumbing(const at::Tensor & self, at::Int
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_logsumexp)(self, dim, keepdim);
+    return at::_ops::special_logsumexp::call(self, dim, keepdim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23607,7 +23586,7 @@ at::Tensor special_expit_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_expit)(self);
+    return at::_ops::special_expit::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23622,7 +23601,7 @@ at::Tensor special_sinc_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_sinc)(self);
+    return at::_ops::special_sinc::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23637,7 +23616,7 @@ at::Tensor special_round_generated_plumbing(const at::Tensor & self, int64_t dec
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_round)(self, decimals);
+    return at::_ops::special_round::call(self, decimals);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23652,7 +23631,7 @@ at::Tensor special_log1p_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_log1p)(self);
+    return at::_ops::special_log1p::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23667,7 +23646,7 @@ at::Tensor special_log_softmax_generated_plumbing(const at::Tensor & self, int64
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_log_softmax)(self, dim, dtype);
+    return at::_ops::special_log_softmax::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23682,7 +23661,7 @@ at::Tensor special_gammainc_generated_plumbing(const at::Tensor & self, const at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(special_gammainc)(self, other);
+    return at::_ops::special_gammainc::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23700,7 +23679,7 @@ at::Tensor special_gammaincc_generated_plumbing(const at::Tensor & self, const a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(special_gammaincc)(self, other);
+    return at::_ops::special_gammaincc::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23718,7 +23697,7 @@ at::Tensor special_multigammaln_generated_plumbing(const at::Tensor & self, int6
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_multigammaln)(self, p);
+    return at::_ops::special_multigammaln::call(self, p);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23733,7 +23712,7 @@ at::Tensor special_softmax_generated_plumbing(const at::Tensor & self, int64_t d
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(special_softmax)(self, dim, dtype);
+    return at::_ops::special_softmax::call(self, dim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23748,7 +23727,7 @@ at::Tensor fft_fft_generated_plumbing(const at::Tensor & self, c10::optional<int
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_fft)(self, n, dim, norm);
+    return at::_ops::fft_fft::call(self, n, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23763,7 +23742,7 @@ at::Tensor fft_ifft_generated_plumbing(const at::Tensor & self, c10::optional<in
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_ifft)(self, n, dim, norm);
+    return at::_ops::fft_ifft::call(self, n, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23778,7 +23757,7 @@ at::Tensor fft_rfft_generated_plumbing(const at::Tensor & self, c10::optional<in
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_rfft)(self, n, dim, norm);
+    return at::_ops::fft_rfft::call(self, n, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23793,7 +23772,7 @@ at::Tensor fft_irfft_generated_plumbing(const at::Tensor & self, c10::optional<i
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_irfft)(self, n, dim, norm);
+    return at::_ops::fft_irfft::call(self, n, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23808,7 +23787,7 @@ at::Tensor fft_hfft_generated_plumbing(const at::Tensor & self, c10::optional<in
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_hfft)(self, n, dim, norm);
+    return at::_ops::fft_hfft::call(self, n, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23823,7 +23802,7 @@ at::Tensor fft_ihfft_generated_plumbing(const at::Tensor & self, c10::optional<i
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_ihfft)(self, n, dim, norm);
+    return at::_ops::fft_ihfft::call(self, n, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23838,7 +23817,7 @@ at::Tensor fft_fft2_generated_plumbing(const at::Tensor & self, c10::optional<at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_fft2)(self, s, dim, norm);
+    return at::_ops::fft_fft2::call(self, s, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23853,7 +23832,7 @@ at::Tensor fft_ifft2_generated_plumbing(const at::Tensor & self, c10::optional<a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_ifft2)(self, s, dim, norm);
+    return at::_ops::fft_ifft2::call(self, s, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23868,7 +23847,7 @@ at::Tensor fft_rfft2_generated_plumbing(const at::Tensor & self, c10::optional<a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_rfft2)(self, s, dim, norm);
+    return at::_ops::fft_rfft2::call(self, s, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23883,7 +23862,7 @@ at::Tensor fft_irfft2_generated_plumbing(const at::Tensor & self, c10::optional<
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_irfft2)(self, s, dim, norm);
+    return at::_ops::fft_irfft2::call(self, s, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23898,7 +23877,7 @@ at::Tensor fft_hfft2_generated_plumbing(const at::Tensor & self, c10::optional<a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_hfft2)(self, s, dim, norm);
+    return at::_ops::fft_hfft2::call(self, s, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23913,7 +23892,7 @@ at::Tensor fft_ihfft2_generated_plumbing(const at::Tensor & self, c10::optional<
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_ihfft2)(self, s, dim, norm);
+    return at::_ops::fft_ihfft2::call(self, s, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23928,7 +23907,7 @@ at::Tensor fft_fftn_generated_plumbing(const at::Tensor & self, c10::optional<at
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_fftn)(self, s, dim, norm);
+    return at::_ops::fft_fftn::call(self, s, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23943,7 +23922,7 @@ at::Tensor fft_ifftn_generated_plumbing(const at::Tensor & self, c10::optional<a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_ifftn)(self, s, dim, norm);
+    return at::_ops::fft_ifftn::call(self, s, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23958,7 +23937,7 @@ at::Tensor fft_rfftn_generated_plumbing(const at::Tensor & self, c10::optional<a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_rfftn)(self, s, dim, norm);
+    return at::_ops::fft_rfftn::call(self, s, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23973,7 +23952,7 @@ at::Tensor fft_irfftn_generated_plumbing(const at::Tensor & self, c10::optional<
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_irfftn)(self, s, dim, norm);
+    return at::_ops::fft_irfftn::call(self, s, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -23988,7 +23967,7 @@ at::Tensor fft_hfftn_generated_plumbing(const at::Tensor & self, c10::optional<a
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_hfftn)(self, s, dim, norm);
+    return at::_ops::fft_hfftn::call(self, s, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24003,7 +23982,7 @@ at::Tensor fft_ihfftn_generated_plumbing(const at::Tensor & self, c10::optional<
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_ihfftn)(self, s, dim, norm);
+    return at::_ops::fft_ihfftn::call(self, s, dim, norm);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24018,7 +23997,7 @@ at::Tensor fft_fftshift_generated_plumbing(const at::Tensor & self, c10::optiona
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_fftshift)(self, dim);
+    return at::_ops::fft_fftshift::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24033,7 +24012,7 @@ at::Tensor fft_ifftshift_generated_plumbing(const at::Tensor & self, c10::option
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(fft_ifftshift)(self, dim);
+    return at::_ops::fft_ifftshift::call(self, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24048,7 +24027,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_cholesky_ex)(self, upper, check_errors);
+    return at::_ops::linalg_cholesky_ex::call(self, upper, check_errors);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24063,7 +24042,7 @@ at::Tensor linalg_cholesky_generated_plumbing(const at::Tensor & self, bool uppe
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_cholesky)(self, upper);
+    return at::_ops::linalg_cholesky::call(self, upper);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24078,7 +24057,7 @@ at::Tensor linalg_cross_generated_plumbing(const at::Tensor & self, const at::Te
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(linalg_cross)(self, other, dim);
+    return at::_ops::linalg_cross::call(self, other, dim);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24096,7 +24075,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(A, cur_level)) {
-    return ATEN_FN(linalg_lu_factor)(A, pivot);
+    return at::_ops::linalg_lu_factor::call(A, pivot);
   }
   Tensor A_value;
   optional<int64_t> A_bdim;
@@ -24111,7 +24090,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(A, cur_level)) {
-    return ATEN_FN(linalg_lu_factor_ex)(A, pivot, check_errors);
+    return at::_ops::linalg_lu_factor_ex::call(A, pivot, check_errors);
   }
   Tensor A_value;
   optional<int64_t> A_bdim;
@@ -24126,7 +24105,7 @@ at::Tensor linalg_det_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_det)(self);
+    return at::_ops::linalg_det::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24141,7 +24120,7 @@ at::Tensor det_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(det)(self);
+    return at::_ops::det::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24156,7 +24135,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_det_lu_based_helper)(self);
+    return at::_ops::_det_lu_based_helper::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24171,7 +24150,7 @@ at::Tensor _det_lu_based_helper_backward_helper_generated_plumbing(const at::Ten
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(det_grad, cur_level) && !isBatchedAtLevel(det, cur_level) && !isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(lu, cur_level) && !isBatchedAtLevel(pivs, cur_level)) {
-    return ATEN_FN(_det_lu_based_helper_backward_helper)(det_grad, det, self, lu, pivs);
+    return at::_ops::_det_lu_based_helper_backward_helper::call(det_grad, det, self, lu, pivs);
   }
   Tensor det_grad_value;
   optional<int64_t> det_grad_bdim;
@@ -24198,7 +24177,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(b, cur_level)) {
-    return ATEN_FN(linalg_lstsq)(self, b, rcond, driver);
+    return at::_ops::linalg_lstsq::call(self, b, rcond, driver);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24216,7 +24195,7 @@ at::Tensor linalg_matmul_generated_plumbing(const at::Tensor & self, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(linalg_matmul)(self, other);
+    return at::_ops::linalg_matmul::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24234,7 +24213,7 @@ at::Tensor linalg_matrix_exp_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_matrix_exp)(self);
+    return at::_ops::linalg_matrix_exp::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24249,7 +24228,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_slogdet)(self);
+    return at::_ops::linalg_slogdet::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24264,7 +24243,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_eig)(self);
+    return at::_ops::linalg_eig::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24279,7 +24258,7 @@ at::Tensor linalg_eigvals_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_eigvals)(self);
+    return at::_ops::linalg_eigvals::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24294,7 +24273,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_eigh)(self, UPLO);
+    return at::_ops::linalg_eigh::call(self, UPLO);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24309,7 +24288,7 @@ at::Tensor linalg_eigvalsh_generated_plumbing(const at::Tensor & self, c10::stri
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_eigvalsh)(self, UPLO);
+    return at::_ops::linalg_eigvalsh::call(self, UPLO);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24324,7 +24303,7 @@ at::Tensor linalg_householder_product_generated_plumbing(const at::Tensor & inpu
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(tau, cur_level)) {
-    return ATEN_FN(linalg_householder_product)(input, tau);
+    return at::_ops::linalg_householder_product::call(input, tau);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -24336,34 +24315,13 @@ at::Tensor linalg_householder_product_generated_plumbing(const at::Tensor & inpu
   return makeBatched(std::get<0>(results), std::get<1>(results), cur_level);
 }
 template <typename batch_rule_t, batch_rule_t batch_rule>
-at::Tensor & _linalg_inv_out_helper__generated_plumbing(at::Tensor & self, at::Tensor & infos_lu, at::Tensor & infos_getri) {
-  c10::impl::ExcludeDispatchKeyGuard guard(kBatchedKey);
-  auto maybe_layer = maybeCurrentDynamicLayer();
-  TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
-  int64_t cur_level = maybe_layer->layerId();
-  if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(infos_lu, cur_level) && !isBatchedAtLevel(infos_getri, cur_level)) {
-    return ATEN_FN(_linalg_inv_out_helper_)(self, infos_lu, infos_getri);
-  }
-  Tensor self_value;
-  optional<int64_t> self_bdim;
-  std::tie(self_value, self_bdim) = unwrapTensorAtLevel(self, cur_level);
-  Tensor infos_lu_value;
-  optional<int64_t> infos_lu_bdim;
-  std::tie(infos_lu_value, infos_lu_bdim) = unwrapTensorAtLevel(infos_lu, cur_level);
-  Tensor infos_getri_value;
-  optional<int64_t> infos_getri_bdim;
-  std::tie(infos_getri_value, infos_getri_bdim) = unwrapTensorAtLevel(infos_getri, cur_level);
-  batch_rule(self_value, self_bdim, infos_lu_value, infos_lu_bdim, infos_getri_value, infos_getri_bdim);
-  return self;
-}
-template <typename batch_rule_t, batch_rule_t batch_rule>
 ::std::tuple<at::Tensor,at::Tensor> linalg_inv_ex_generated_plumbing(const at::Tensor & self, bool check_errors) {
   c10::impl::ExcludeDispatchKeyGuard guard(kBatchedKey);
   auto maybe_layer = maybeCurrentDynamicLayer();
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_inv_ex)(self, check_errors);
+    return at::_ops::linalg_inv_ex::call(self, check_errors);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24378,7 +24336,7 @@ at::Tensor linalg_inv_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_inv)(self);
+    return at::_ops::linalg_inv::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24393,7 +24351,7 @@ at::Tensor inner_generated_plumbing(const at::Tensor & self, const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(inner)(self, other);
+    return at::_ops::inner::call(self, other);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24411,7 +24369,7 @@ at::Tensor outer_generated_plumbing(const at::Tensor & self, const at::Tensor & 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(vec2, cur_level)) {
-    return ATEN_FN(outer)(self, vec2);
+    return at::_ops::outer::call(self, vec2);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24429,7 +24387,7 @@ at::Tensor ger_generated_plumbing(const at::Tensor & self, const at::Tensor & ve
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(vec2, cur_level)) {
-    return ATEN_FN(ger)(self, vec2);
+    return at::_ops::ger::call(self, vec2);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24447,7 +24405,7 @@ at::Tensor linalg_norm_generated_plumbing(const at::Tensor & self, const c10::op
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_norm)(self, ord, dim, keepdim, dtype);
+    return at::_ops::linalg_norm::call(self, ord, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24462,7 +24420,7 @@ at::Tensor linalg_norm_ord_str_generated_plumbing(const at::Tensor & self, c10::
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(linalg_norm, ord_str)(self, ord, dim, keepdim, dtype);
+    return at::_ops::linalg_norm_ord_str::call(self, ord, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24477,7 +24435,7 @@ at::Tensor linalg_vector_norm_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_vector_norm)(self, ord, dim, keepdim, dtype);
+    return at::_ops::linalg_vector_norm::call(self, ord, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24492,7 +24450,7 @@ at::Tensor linalg_matrix_norm_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_matrix_norm)(self, ord, dim, keepdim, dtype);
+    return at::_ops::linalg_matrix_norm::call(self, ord, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24507,7 +24465,7 @@ at::Tensor linalg_matrix_norm_str_ord_generated_plumbing(const at::Tensor & self
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(linalg_matrix_norm, str_ord)(self, ord, dim, keepdim, dtype);
+    return at::_ops::linalg_matrix_norm_str_ord::call(self, ord, dim, keepdim, dtype);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24522,7 +24480,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(A, cur_level)) {
-    return ATEN_FN(_linalg_svd)(A, full_matrices, compute_uv);
+    return at::_ops::_linalg_svd::call(A, full_matrices, compute_uv);
   }
   Tensor A_value;
   optional<int64_t> A_bdim;
@@ -24537,7 +24495,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(A, cur_level)) {
-    return ATEN_FN(linalg_svd)(A, full_matrices);
+    return at::_ops::linalg_svd::call(A, full_matrices);
   }
   Tensor A_value;
   optional<int64_t> A_bdim;
@@ -24552,7 +24510,7 @@ at::Tensor linalg_svdvals_generated_plumbing(const at::Tensor & A) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(A, cur_level)) {
-    return ATEN_FN(linalg_svdvals)(A);
+    return at::_ops::linalg_svdvals::call(A);
   }
   Tensor A_value;
   optional<int64_t> A_bdim;
@@ -24567,7 +24525,7 @@ at::Tensor linalg_cond_generated_plumbing(const at::Tensor & self, const c10::op
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_cond)(self, p);
+    return at::_ops::linalg_cond::call(self, p);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24582,7 +24540,7 @@ at::Tensor linalg_cond_p_str_generated_plumbing(const at::Tensor & self, c10::st
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(linalg_cond, p_str)(self, p);
+    return at::_ops::linalg_cond_p_str::call(self, p);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24597,7 +24555,7 @@ at::Tensor linalg_pinv_atol_rtol_tensor_generated_plumbing(const at::Tensor & se
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(atol, cur_level) && !isBatchedAtLevel(rtol, cur_level)) {
-    return ATEN_FN2(linalg_pinv, atol_rtol_tensor)(self, atol, rtol, hermitian);
+    return at::_ops::linalg_pinv_atol_rtol_tensor::call(self, atol, rtol, hermitian);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24622,7 +24580,7 @@ at::Tensor linalg_pinv_atol_rtol_float_generated_plumbing(const at::Tensor & sel
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(linalg_pinv, atol_rtol_float)(self, atol, rtol, hermitian);
+    return at::_ops::linalg_pinv_atol_rtol_float::call(self, atol, rtol, hermitian);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24637,7 +24595,7 @@ at::Tensor linalg_pinv_generated_plumbing(const at::Tensor & self, double rcond,
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_pinv)(self, rcond, hermitian);
+    return at::_ops::linalg_pinv::call(self, rcond, hermitian);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24652,7 +24610,7 @@ at::Tensor linalg_pinv_rcond_tensor_generated_plumbing(const at::Tensor & self, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(rcond, cur_level)) {
-    return ATEN_FN2(linalg_pinv, rcond_tensor)(self, rcond, hermitian);
+    return at::_ops::linalg_pinv_rcond_tensor::call(self, rcond, hermitian);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24670,7 +24628,7 @@ at::Tensor linalg_solve_generated_plumbing(const at::Tensor & input, const at::T
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(linalg_solve)(input, other);
+    return at::_ops::linalg_solve::call(input, other);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -24688,7 +24646,7 @@ at::Tensor linalg_tensorinv_generated_plumbing(const at::Tensor & self, int64_t 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_tensorinv)(self, ind);
+    return at::_ops::linalg_tensorinv::call(self, ind);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24703,7 +24661,7 @@ at::Tensor linalg_tensorsolve_generated_plumbing(const at::Tensor & self, const 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(linalg_tensorsolve)(self, other, dims);
+    return at::_ops::linalg_tensorsolve::call(self, other, dims);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24721,7 +24679,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_qr)(self, mode);
+    return at::_ops::linalg_qr::call(self, mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24736,7 +24694,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_linalg_qr_helper)(self, mode);
+    return at::_ops::_linalg_qr_helper::call(self, mode);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24751,7 +24709,7 @@ at::Tensor linalg_matrix_power_generated_plumbing(const at::Tensor & self, int64
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_matrix_power)(self, n);
+    return at::_ops::linalg_matrix_power::call(self, n);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24766,7 +24724,7 @@ at::Tensor linalg_matrix_rank_atol_rtol_tensor_generated_plumbing(const at::Tens
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(atol, cur_level) && !isBatchedAtLevel(rtol, cur_level)) {
-    return ATEN_FN2(linalg_matrix_rank, atol_rtol_tensor)(input, atol, rtol, hermitian);
+    return at::_ops::linalg_matrix_rank_atol_rtol_tensor::call(input, atol, rtol, hermitian);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -24791,7 +24749,7 @@ at::Tensor linalg_matrix_rank_atol_rtol_float_generated_plumbing(const at::Tenso
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN2(linalg_matrix_rank, atol_rtol_float)(self, atol, rtol, hermitian);
+    return at::_ops::linalg_matrix_rank_atol_rtol_float::call(self, atol, rtol, hermitian);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24806,7 +24764,7 @@ at::Tensor linalg_matrix_rank_generated_plumbing(const at::Tensor & self, double
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(linalg_matrix_rank)(self, tol, hermitian);
+    return at::_ops::linalg_matrix_rank::call(self, tol, hermitian);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24821,7 +24779,7 @@ at::Tensor linalg_matrix_rank_tol_tensor_generated_plumbing(const at::Tensor & i
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(input, cur_level) && !isBatchedAtLevel(tol, cur_level)) {
-    return ATEN_FN2(linalg_matrix_rank, tol_tensor)(input, tol, hermitian);
+    return at::_ops::linalg_matrix_rank_tol_tensor::call(input, tol, hermitian);
   }
   Tensor input_value;
   optional<int64_t> input_bdim;
@@ -24839,7 +24797,7 @@ at::Tensor linalg_multi_dot_generated_plumbing(at::TensorList tensors) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(linalg_multi_dot)(tensors);
+    return at::_ops::linalg_multi_dot::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -24852,7 +24810,7 @@ at::Tensor _test_serialization_subcmul_generated_plumbing(const at::Tensor & sel
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level) && !isBatchedAtLevel(other, cur_level)) {
-    return ATEN_FN(_test_serialization_subcmul)(self, other, alpha);
+    return at::_ops::_test_serialization_subcmul::call(self, other, alpha);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24870,7 +24828,7 @@ at::Tensor _test_optional_intlist_generated_plumbing(const at::Tensor & values, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN(_test_optional_intlist)(values, addends);
+    return at::_ops::_test_optional_intlist::call(values, addends);
   }
   Tensor values_value;
   optional<int64_t> values_bdim;
@@ -24885,7 +24843,7 @@ at::Tensor _test_optional_filled_intlist_generated_plumbing(const at::Tensor & v
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN(_test_optional_filled_intlist)(values, addends);
+    return at::_ops::_test_optional_filled_intlist::call(values, addends);
   }
   Tensor values_value;
   optional<int64_t> values_bdim;
@@ -24900,7 +24858,7 @@ at::Tensor _test_optional_floatlist_generated_plumbing(const at::Tensor & values
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(values, cur_level)) {
-    return ATEN_FN(_test_optional_floatlist)(values, addends);
+    return at::_ops::_test_optional_floatlist::call(values, addends);
   }
   Tensor values_value;
   optional<int64_t> values_bdim;
@@ -24915,7 +24873,7 @@ at::Tensor _test_string_default_generated_plumbing(const at::Tensor & dummy, c10
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(dummy, cur_level)) {
-    return ATEN_FN(_test_string_default)(dummy, a, b);
+    return at::_ops::_test_string_default::call(dummy, a, b);
   }
   Tensor dummy_value;
   optional<int64_t> dummy_bdim;
@@ -24930,7 +24888,7 @@ at::Tensor _test_ambiguous_defaults_a_generated_plumbing(const at::Tensor & dumm
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(dummy, cur_level)) {
-    return ATEN_FN2(_test_ambiguous_defaults, a)(dummy, a, b);
+    return at::_ops::_test_ambiguous_defaults_a::call(dummy, a, b);
   }
   Tensor dummy_value;
   optional<int64_t> dummy_bdim;
@@ -24945,7 +24903,7 @@ at::Tensor _test_ambiguous_defaults_b_generated_plumbing(const at::Tensor & dumm
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(dummy, cur_level)) {
-    return ATEN_FN2(_test_ambiguous_defaults, b)(dummy, a, b);
+    return at::_ops::_test_ambiguous_defaults_b::call(dummy, a, b);
   }
   Tensor dummy_value;
   optional<int64_t> dummy_bdim;
@@ -24960,7 +24918,7 @@ at::Tensor _test_warn_in_autograd_generated_plumbing(const at::Tensor & self) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(self, cur_level)) {
-    return ATEN_FN(_test_warn_in_autograd)(self);
+    return at::_ops::_test_warn_in_autograd::call(self);
   }
   Tensor self_value;
   optional<int64_t> self_bdim;
@@ -24975,7 +24933,7 @@ at::Tensor segment_reduce_generated_plumbing(const at::Tensor & data, c10::strin
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(data, cur_level) && !isBatchedAtLevel(lengths, cur_level) && !isBatchedAtLevel(indices, cur_level)) {
-    return ATEN_FN(segment_reduce)(data, reduce, lengths, indices, axis, unsafe, initial);
+    return at::_ops::segment_reduce::call(data, reduce, lengths, indices, axis, unsafe, initial);
   }
   Tensor data_value;
   optional<int64_t> data_bdim;
@@ -25000,7 +24958,7 @@ at::Tensor _segment_reduce_backward_generated_plumbing(const at::Tensor & grad, 
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(grad, cur_level) && !isBatchedAtLevel(output, cur_level) && !isBatchedAtLevel(data, cur_level) && !isBatchedAtLevel(lengths, cur_level)) {
-    return ATEN_FN(_segment_reduce_backward)(grad, output, data, reduce, lengths, axis);
+    return at::_ops::_segment_reduce_backward::call(grad, output, data, reduce, lengths, axis);
   }
   Tensor grad_value;
   optional<int64_t> grad_bdim;
@@ -25026,7 +24984,7 @@ at::Tensor pad_sequence_generated_plumbing(at::TensorList sequences, bool batch_
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(sequences, cur_level)) {
-    return ATEN_FN(pad_sequence)(sequences, batch_first, padding_value);
+    return at::_ops::pad_sequence::call(sequences, batch_first, padding_value);
   }
 
   auto results = batch_rule(sequences, batch_first, padding_value);
@@ -25039,7 +24997,7 @@ at::Tensor flatten_dense_tensors_generated_plumbing(at::TensorList tensors) {
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(flatten_dense_tensors)(tensors);
+    return at::_ops::flatten_dense_tensors::call(tensors);
   }
 
   auto results = batch_rule(tensors);
@@ -25052,7 +25010,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(flat, cur_level) && !isBatchedAtLevel(tensors, cur_level)) {
-    return ATEN_FN(unflatten_dense_tensors)(flat, tensors);
+    return at::_ops::unflatten_dense_tensors::call(flat, tensors);
   }
   Tensor flat_value;
   optional<int64_t> flat_bdim;
@@ -25067,7 +25025,7 @@ at::Tensor _nested_tensor_generated_plumbing(at::TensorList list, c10::optional<
   TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
   int64_t cur_level = maybe_layer->layerId();
   if (!isBatchedAtLevel(list, cur_level)) {
-    return ATEN_FN(_nested_tensor)(list, dtype, layout, device, pin_memory);
+    return at::_ops::_nested_tensor::call(list, dtype, layout, device, pin_memory);
   }
 
   auto results = batch_rule(list, dtype, layout, device, pin_memory);

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -185,7 +185,7 @@ def main() -> None:
         '-s',
         '--source-path',
         help='path to source directory for ATen',
-        default='/scratch/rzou/pt/workbench/aten/src/ATen')
+        default='/scratch/rzou/pt/debug-cpu/aten/src/ATen')
     parser.add_argument(
         '-o',
         '--output-dependencies',


### PR DESCRIPTION
Here's how the output looks:
- https://github.com/pytorch/functorch/blob/main/functorch/csrc/VmapGeneratedPlumbing.h
- (yes, we check in the codegen as a short-term solution because we
didn't have time to add it as a step to setup.py)

short-term / long-term plans
- we've copy-pasted tools/codegen from pytorch/pytorch into functorch
- In the long term, pytorch/pytorch will package its codegen somehow
(https://github.com/pytorch/pytorch/issues/73212)

Questions for reviewer:
- Are we using PyTorch's codegen abstractions the right way?