### PR TITLE
[WIP] Handle grads which are not dependent on the tangent inputs

### DIFF
--- a/functorch/_src/partitioners.py
+++ b/functorch/_src/partitioners.py
@@ -270,6 +270,14 @@ def min_cut_rematerialization_partition(joint_module: fx.GraphModule, _joint_inp
 
     saved_values = [name_to_node[node] for node in cut_nodes]
 
+    # Save the gradients which are not dependendent on the tangents. This can
+    # happen when the primary output is not dependent on the inputs. For such
+    # cases, we just compute the gradient in the forward pass.
+    _, bwd_outputs = _extract_fwd_bwd_outputs(joint_module)
+    for bwd_output in bwd_outputs:
+        if bwd_output not in tangent_closure and bwd_output is not None:
+            saved_values.append(name_to_node[bwd_output.name])
+
     return _extract_fwd_bwd_modules(joint_module, saved_values)
 
 


### PR DESCRIPTION
Repro test case.


~~~
import torch
from torch.nn import *
import functorch
from functorch.compile import memory_efficient_fusion

class FxModule(torch.nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, einsum, unsqueeze_3):
        exp = einsum.exp()
        gather = torch.gather(exp, 3, unsqueeze_3);  expand = unsqueeze_3 = None
        return gather

inp0 = torch.randn([1, 3, 2, 10], device='cuda', requires_grad=True)
inp1 = torch.ones([1, 3, 2, 1], dtype=torch.int64, device='cuda')
inps = [inp0, inp1]

cloned_inps = [x.clone().detach() for x in inps]
cloned_inps[0].requires_grad_(True)
cloned_inps[0].grad = None

mod = FxModule().to(device="cuda")
ref = mod(*inps)
ref.sum().backward()

aot_mod = memory_efficient_fusion(mod)
res = aot_mod(*cloned_inps)
res.sum().backward()

assert torch.allclose(ref, res)
print(inps[0].grad)
print(cloned_inps[0].grad)
assert torch.allclose(inps[0].grad, cloned_inps[0].grad)

print("Success")
~~~

The joint graph after tracing above module is 

~~~

def forward(self, primals, tangents):
    primals_1, primals_2, tangents_1, = fx_pytree.tree_flatten_spec([primals, tangents], self._in_spec)
    exp = torch.ops.aten.exp(primals_1);  primals_1 = None
    gather = torch.ops.aten.gather(exp, 3, primals_2)
    _tensor_constant0 = self._tensor_constant0
    scatter_add_ = torch.ops.aten.scatter_add_(_tensor_constant0, 3, primals_2, tangents_1);  _tensor_constant0 = primals_2 = tangents_1 = None
    _tensor_constant0_1 = self._tensor_constant0
    mul = torch.ops.aten.mul(_tensor_constant0_1, exp);  _tensor_constant0_1 = exp = None
    return pytree.tree_unflatten([gather, mul, None], self._out_spec)
~~~

Here, 2nd output `mul`, which is gradient of primals_1 is not dependent on tangents_1. 

Looking closely, backward operations of gather seem suspicious.



