### PR TITLE
Don't unnecessarily wrap the elem in PythonTensor

### DIFF
--- a/functorch/compile/__init__.py
+++ b/functorch/compile/__init__.py
@@ -1,5 +1,5 @@
 from .._src.operator_authoring import pointwise_operator
-from .._src.python_key import pythonkey_decompose, pythonkey_meta
+from .._src.python_key import pythonkey_decompose
 from .._src.decompositions import register_decomposition, decomposition_table
 from .._src.fx_minifier import minifier, check_nvfuser_subprocess
 from .._src.aot_autograd import (

--- a/test/test_pythonkey.py
+++ b/test/test_pythonkey.py
@@ -192,7 +192,6 @@ make_fx_failures = {
     xfail('allclose'),
     xfail('nn.functional.dropout'),
     xfail('linalg.eigvals'),
-    xfail('nn.functional.ctc_loss'),
     xfail('nn.functional.fractional_max_pool3d', device_type='cpu'),
     xfail('randn_like'),  # randomness
     xfail('rand_like'),  # randomness
@@ -355,11 +354,8 @@ class TestEagerFusionOpInfo(TestCase):
     # entries in here need don't work and need to be fixed.
     # Each one of these is a bug (or needs to be investigated)
     @skipOps('TestEagerFusionOpInfo', 'test_aot_autograd_exhaustive', {
-        xfail('__rmatmul__'),
         xfail('linalg.cholesky'),
-        xfail('matmul'),
         skip('msort'),
-        xfail('nn.functional.linear'),
         xfail('nn.functional.dropout'),
         xfail('polar'),
         xfail('special.zeta', 'grad'),


### PR DESCRIPTION
Instead of saying that a PythonTensor has a regular (e.g., CPU) tensor
and an FX proxy, a PythonTensor *is a* regular CPU tensor, that also
carries an FX proxy (that updates as we go along).

Partially addresses https://github.com/pytorch/functorch/issues/465 and
it also fixed some expected failures in the test suite.