### PR TITLE
inplace random batching rules

### DIFF
--- a/functorch/csrc/BatchRulesRandomness.cpp
+++ b/functorch/csrc/BatchRulesRandomness.cpp
@@ -353,7 +353,12 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchVmapMode, m) {
   RANDOM_INPLACE_BATCH_RULE2(random_, from);
   RANDOM_INPLACE_BATCH_RULE2(random_, to);
 
+  RANDOM_INPLACE_BATCH_RULE(cauchy_);
+  RANDOM_INPLACE_BATCH_RULE(exponential_);
+  RANDOM_INPLACE_BATCH_RULE(geometric_);
+  RANDOM_INPLACE_BATCH_RULE(log_normal_);
   RANDOM_INPLACE_BATCH_RULE(normal_);
+  RANDOM_INPLACE_BATCH_RULE(uniform_);
 
   RANDINT_BATCH_RULE(randint);
   RANDINT_BATCH_RULE2(randint, generator);

--- a/functorch/csrc/VmapModeRegistrations.cpp
+++ b/functorch/csrc/VmapModeRegistrations.cpp
@@ -38,10 +38,6 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchVmapMode, m) {
   UNSUPPORTED_RANDOM2(bernoulli, out);
   UNSUPPORTED_RANDOM2(bernoulli, p);
 
-  UNSUPPORTED_RANDOM(cauchy_);
-  UNSUPPORTED_RANDOM(exponential_);
-  UNSUPPORTED_RANDOM(geometric_);
-  UNSUPPORTED_RANDOM(log_normal_);
   UNSUPPORTED_RANDOM(multinomial);
   UNSUPPORTED_RANDOM2(multinomial, out);
 
@@ -49,8 +45,6 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchVmapMode, m) {
 
   UNSUPPORTED_RANDOM(randint_like);
   UNSUPPORTED_RANDOM2(randint_like, low_dtype);
-
-  UNSUPPORTED_RANDOM(uniform_);
 }
 
 

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -2654,20 +2654,6 @@ class TestVmapOperators(Namespace.TestVmapBase):
             # (lambda t: torch.randn_like(captured) , (torch.rand(B0),)),
             (lambda t: torch.randint_like(captured, 2), (torch.rand(B0),)),
             (lambda t: torch.randint_like(captured, 0, 2), (torch.rand(B0),)),
-
-            # in-place on BatchedTensor
-            (lambda t: t.cauchy_(), (torch.randn(B0, 1),)),
-            (lambda t: t.exponential_(), (torch.randn(B0, 1),)),
-            (lambda t: t.geometric_(0.5), (torch.randn(B0, 1),)),
-            (lambda t: t.log_normal_(), (torch.randn(B0, 1),)),
-            (lambda t: t.uniform_(), (torch.randn(B0, 1),)),
-
-            # in-place on captured tensor
-            (lambda t: captured.cauchy_(), (torch.randn(B0),)),
-            (lambda t: captured.exponential_(), (torch.randn(B0),)),
-            (lambda t: captured.geometric_(0.5), (torch.randn(B0),)),
-            (lambda t: captured.log_normal_(), (torch.randn(B0),)),
-            (lambda t: captured.uniform_(), (torch.randn(B0),)),
         ]
         for op, args in random_ops:
             with self.assertRaisesRegex(RuntimeError,
@@ -3514,6 +3500,11 @@ class TestVmapOperatorsOpInfo(TestCase):
             lambda _, shape: torch.randint(100, shape, **kwargs),
             lambda _, shape: torch.randint(5, 100, shape, **kwargs),
             lambda t, _: t.random_(**only_gen_kwarg),
+            lambda t, _: t.cauchy_(**only_gen_kwarg),
+            lambda t, _: t.exponential_(**only_gen_kwarg),
+            lambda t, _: t.geometric_(0.5, **only_gen_kwarg),
+            lambda t, _: t.log_normal_(**only_gen_kwarg),
+            lambda t, _: t.uniform_(**only_gen_kwarg),
             lambda _, shape: torch.normal(0., 1., shape, **kwargs),
             lambda t, _: t.normal_(**only_gen_kwarg),
             lambda t, _: t.bernoulli_(torch.tensor([0.3, 0.4, 0.5, 0.6]), **only_gen_kwarg),
@@ -3620,6 +3611,11 @@ class TestVmapOperatorsOpInfo(TestCase):
             lambda t, _: t.normal_(**kwargs),
             lambda t, _: t.bernoulli_(torch.tensor([0.3, 0.4, 0.5, 0.6]), **kwargs),
             lambda t, _: t.bernoulli_(**kwargs),
+            lambda t, _: t.cauchy_(**kwargs),
+            lambda t, _: t.exponential_(**kwargs),
+            lambda t, _: t.geometric_(0.5, **kwargs),
+            lambda t, _: t.log_normal_(**kwargs),
+            lambda t, _: t.uniform_(**kwargs),
         ]
 
         B0 = 4


### PR DESCRIPTION
Adds batching rules for cauchy_, exponential_, geometric_, log_normal_, and uniform_

Since they all use the same inplace random logic and they're each so small, I just put them all together