### PR TITLE
Docs website modification

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,9 +11,13 @@ It aims to provide composable vmap and grad transforms that work with PyTorch mo
 and PyTorch autograd with good eager-mode performance.
 
 .. note::
-   This library is currently under heavy development - if you have suggestions on the API or
-   use-cases you'd like to be covered, please open an github issue or reach out.
-   We'd love to hear about how you're using the library.
+   This library is currently in [beta](https://pytorch.org/blog/pytorch-feature-classification-changes/#beta).
+   What this means is that the features generally work (unless otherwise documented)
+   and we (the PyTorch team) are committed to bringing this library forward. However, the APIs
+   may change under user feedback and we don't have full coverage over PyTorch operations.
+
+   If you have suggestions on the API or use-cases you'd like to be covered, please
+   open an github issue or reach out. We'd love to hear about how you're using the library.
 
 Why composable function transforms?
 -----------------------------------
@@ -37,9 +41,16 @@ For a whirlwind tour of how to use the transforms, please check out `this sectio
 
 .. toctree::
    :maxdepth: 2
-   :caption: Content
+   :caption: Getting Started
 
    install
+   notebooks/whirlwind_tour.ipynb
+   ux_limitations
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference and Notes
+
    functorch
 
 .. toctree::

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,15 +1,19 @@
 Install functorch
 =================
 
-There are two ways to install functorch:
+pip
+---
 
-#. `functorch main  <https://github.com/pytorch/functorch#installing-functorch-main>`_
-#. `functorch preview with PyTorch 1.10 <https://github.com/pytorch/functorch#installing-functorch-preview-with-pytorch-110>`_
+(Coming soon)
 
-We recommend installing the functorch main development branch for the latest and
-greatest. This requires an installation of the latest PyTorch nightly.
+Colab
+-----
 
-If you're looking for an older version of functorch that works with a stable
-version of PyTorch (1.10), please install the functorch preview.
+(Coming soon)
 
-Check out `the instructions at our GitHub <https://github.com/pytorch/functorch/blob/main/README.md#install>`_.
+Building from source
+--------------------
+
+See our `README <https://github.com/pytorch/functorch#installing-functorch-main>`_
+for instructions on how to build the functorch main development branch for the
+latest and greatest. This requires an installation of the latest PyTorch nightly.

--- a/docs/source/ux_limitations.rst
+++ b/docs/source/ux_limitations.rst
@@ -1,0 +1,181 @@
+.. currentmodule:: functorch
+
+UX Limitations
+==============
+
+functorch, like `JAX <https://github.com/google/jax>`_, has restrictions around
+what can be transformed. In general, JAX’s limitations are that transforms
+only work with pure functions: that is, functions where the output is completely
+determined by the input and that do not involve side effects (like mutation).
+
+We have a similar guarantee: our transforms work well with pure functions.
+However, we do support certain in-place operations. On one hand, writing code
+compatible with functorch transforms may involve changing how you write PyTorch
+code, on the other hand, you may find that our transforms let you express things
+that were previously difficult to express in PyTorch.
+
+General limitations
+-------------------
+
+All functorch transforms share a limitation in that a function should not
+assign to global variables. Instead, all outputs to a function must be returned
+from the function. This restriction comes from how functorch is implemented:
+each transform wraps Tensor inputs in special functorch Tensor subclasses
+that facilitate the transform.
+
+So, instead of the following:
+
+::
+
+  import torch
+  from functorch import grad
+
+  # Don't do this
+  intermediate = None
+
+  def f(x):
+    global intermediate
+    intermediate = x.sin()
+    z = intermediate.sin()
+    return z
+
+  x = torch.randn([])
+  grad_x = grad(f)(x)
+
+Please rewrite ``f`` to return ``intermediate``:
+
+::
+
+  def f(x):
+    intermediate = x.sin()
+    z = intermediate.sin()
+    return z, intermediate
+
+  grad_x, intermediate = grad(f, has_aux=True)(x)
+
+vmap limitations
+----------------
+
+.. note::
+  :func:`vmap` is our most restrictive transform.
+  The grad-related transforms (:func:`grad`, :func:`vjp`, :func:`jvp`) do not
+  have these limitations. :func:`jacfwd` (and :func:`hessian`, which is
+  implemented with :func:`jacfwd`) is a composition of :func:`vmap` and
+  :func:`jvp` so it also has these limitations.
+
+``vmap(func)`` is a transform that returns a function that maps ``func`` over
+some new dimension of each input Tensor. The mental model for vmap is that it is
+like running a for-loop: for pure functions (i.e. in the absence of side
+effects), ``vmap(f)(x)`` is equivalent to:
+
+::
+
+  torch.stack([f(x_i) for x_i in x.unbind(0)])
+
+Mutation: Arbitrary mutation of Python data structures
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In the presence of side effects, :func:`vmap` no longer acts like it is running
+a for-loop. For example, the following function:
+
+::
+
+  def f(x, list):
+    list.pop()
+    print("hello!")
+    return x.sum(0)
+
+  x = torch.randn(3, 1)
+  lst = [0, 1, 2, 3]
+
+  result = vmap(f, in_dims=(0, None))(x, lst)
+
+will print "hello!" once and pop only one element from ``lst``.
+
+
+:func:`vmap` executes `f` a single time, so all side effects only happen once.
+
+This is a consequence of how vmap is implemented. functorch has a special,
+internal BatchedTensor class. ``vmap(f)(*inputs)`` takes all Tensor inputs,
+turns them into BatchedTensors, and calls ``f(*batched_tensor_inputs)``.
+BatchedTensor overrides the PyTorch API to produce batched (i.e. vectorized)
+behavior for each PyTorch operator.
+
+
+Mutation: in-place PyTorch Operations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:func:`vmap` will raise an error if it encounters an unsupported PyTorch
+in-place operation and it will succeed otherwise. Unsupported operations
+are those that would cause a Tensor with more memory to be written to a
+Tensor with less memory. Here's an example of how this can occur:
+
+::
+
+  def f(x, y):
+    x.add_(y)
+  return x
+
+  x = torch.randn(1)
+  y = torch.randn(3)
+
+  # Raises an error
+  vmap(f, in_dims=(None, 0))(x, y)
+
+``x`` is a Tensor with one element, ``y`` is a Tensor with three elements.
+``x + y`` has three elements (due to broadcasting), but attempting to write
+three elements back into ``x``, which only has one element, raises an error
+due to there not being enough memory to hold three elements.
+
+There is no problem if there is sufficient memory for the in-place operations
+to occur:
+
+::
+
+  def f(x, y):
+    x.add_(y)
+    return x
+
+  x = torch.randn(3)
+  y = torch.randn(3)
+  expected = x + y
+
+  # Raises an error
+  vmap(f, in_dims=(0, 0))(x, y)
+  assert torch.allclose(x, expected)
+
+Data-dependent Python control flow
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+We don't yet support ``vmap`` over data-dependent control flow. Data-dependent
+control flow is when the condition of an if-statement, while-loop, or
+for-loop is a Tensor that is being ``vmap``'ed over. For example, the
+following will raise an error message:
+
+::
+
+  def relu(x):
+    if x > 0:
+      return x
+    return 0
+
+  x = torch.randn(3)
+  vmap(relu)(x)
+
+However, any control flow that is not dependent on the values in ``vmap``'ed
+tensors will work:
+
+::
+
+  def custom_dot(x):
+    if x.dim() == 1:
+      return torch.dot(x, x)
+    return (x * x).sum()
+
+  x = torch.randn(3)
+  vmap(custom_dot)(x)
+
+JAX supports transforming over
+`data-dependent control flow <https://jax.readthedocs.io/en/latest/jax.lax.html#control-flow-operators>`_
+using special control flow operators (e.g. ``jax.lax.cond``, ``jax.lax.while_loop``).
+We're investigating adding equivalents of those to functorch
+(open an issue on `GitHub <https://github.com/pytorch/functorch>`_ to voice your support!).

--- a/notebooks/whirlwind_tour.ipynb
+++ b/notebooks/whirlwind_tour.ipynb
@@ -1,0 +1,323 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "903e2f76",
+   "metadata": {},
+   "source": [
+    "# Whirlwind Tour\n",
+    "\n",
+    "functorch is [JAX](https://github.com/google/jax)-like composable function transforms for PyTorch. In this whirlwind tour, we'll introduce all the functorch transforms.\n",
+    "\n",
+    "\n",
+    "## Why composable function transforms?\n",
+    "There are a number of use cases that are tricky to do in PyTorch today:\n",
+    "- computing per-sample-gradients (or other per-sample quantities)\n",
+    "- running ensembles of models on a single machine\n",
+    "- efficiently batching together tasks in the inner-loop of MAML\n",
+    "- efficiently computing Jacobians and Hessians\n",
+    "- efficiently computing batched Jacobians and Hessians\n",
+    "\n",
+    "Composing `vmap`, `grad`, `vjp`, and `jvp` transforms allows us to express the above without designing a separate subsystem for each. This idea of composable function transforms comes from the [JAX framework](https://github.com/google/jax).\n",
+    "\n",
+    "## What are the transforms?\n",
+    "\n",
+    "Right now, we support the following transforms:\n",
+    "\n",
+    "- `grad`, `vjp`, `jvp`,\n",
+    "- `jacrev`, `jacfwd`, `hessian`\n",
+    "- `vmap`\n",
+    "\n",
+    "Furthermore, we have some utilities for working with PyTorch modules.\n",
+    "- `make_functional(model)`\n",
+    "- `make_functional_with_buffers(model)`\n",
+    "\n",
+    "### vmap\n",
+    "\n",
+    "Note: vmap imposes restrictions on the code that it can be used on. For more details, please read its docstring.\n",
+    "\n",
+    "`vmap(func)(*inputs)` is a transform that adds a dimension to all Tensor operations in `func`. `vmap(func)` returns a new function that maps `func` over some dimension (default: 0) of each Tensor in inputs.\n",
+    "\n",
+    "vmap is useful for hiding batch dimensions: one can write a function func that runs on examples and then lift it to a function that can take batches of examples with `vmap(func)`, leading to a simpler modeling experience:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f920b923",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from functorch import vmap\n",
+    "batch_size, feature_size = 3, 5\n",
+    "weights = torch.randn(feature_size, requires_grad=True)\n",
+    "\n",
+    "def model(feature_vec):\n",
+    "    # Very simple linear model with activation\n",
+    "    assert feature_vec.dim() == 1\n",
+    "    return feature_vec.dot(weights).relu()\n",
+    "\n",
+    "examples = torch.randn(batch_size, feature_size)\n",
+    "result = vmap(model)(examples)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef3b2d85",
+   "metadata": {},
+   "source": [
+    "### grad\n",
+    "\n",
+    "`grad(func)(*inputs)` assumes `func` returns a single-element Tensor. By default, it computes the gradients of the output of `func` w.r.t. to `inputs[0]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6ebac649",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from functorch import grad\n",
+    "x = torch.randn([])\n",
+    "cos_x = grad(lambda x: torch.sin(x))(x)\n",
+    "assert torch.allclose(cos_x, x.cos())\n",
+    "\n",
+    "# Second-order gradients\n",
+    "neg_sin_x = grad(grad(lambda x: torch.sin(x)))(x)\n",
+    "assert torch.allclose(neg_sin_x, -x.sin())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5161e6d2",
+   "metadata": {},
+   "source": [
+    "When composed with vmap, grad can be used to compute per-sample-gradients:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ffb2fcb1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from functorch import vmap\n",
+    "batch_size, feature_size = 3, 5\n",
+    "\n",
+    "def model(weights,feature_vec):\n",
+    "    # Very simple linear model with activation\n",
+    "    assert feature_vec.dim() == 1\n",
+    "    return feature_vec.dot(weights).relu()\n",
+    "\n",
+    "def compute_loss(weights, example, target):\n",
+    "    y = model(weights, example)\n",
+    "    return ((y - target) ** 2).mean()  # MSELoss\n",
+    "\n",
+    "weights = torch.randn(feature_size, requires_grad=True)\n",
+    "examples = torch.randn(batch_size, feature_size)\n",
+    "targets = torch.randn(batch_size)\n",
+    "inputs = (weights,examples, targets)\n",
+    "grad_weight_per_example = vmap(grad(compute_loss), in_dims=(None, 0, 0))(*inputs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11d711af",
+   "metadata": {},
+   "source": [
+    "### vjp\n",
+    "\n",
+    "The `vjp` transform applies `func` to `inputs` and returns a new function that computes vjps given some `cotangents` Tensors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ad48f9d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from functorch import vjp\n",
+    "\n",
+    "inputs = torch.randn(3)\n",
+    "func = torch.sin\n",
+    "cotangents = (torch.randn(3),)\n",
+    "\n",
+    "outputs, vjp_fn = vjp(func, inputs); vjps = vjp_fn(*cotangents)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0221270",
+   "metadata": {},
+   "source": [
+    "### jvp\n",
+    "\n",
+    "The `jvp` transforms computes Jacobian-vector-products and is also known as \"forward-mode AD\". It is not a higher-order function unlike most other transforms, but it returns the outputs of `func(inputs)` as well as the jvps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f3772f43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from functorch import jvp\n",
+    "x = torch.randn(5)\n",
+    "y = torch.randn(5)\n",
+    "f = lambda x, y: (x * y)\n",
+    "_, output = jvp(f, (x, y), (torch.ones(5), torch.ones(5)))\n",
+    "assert torch.allclose(output, x + y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b00953b",
+   "metadata": {},
+   "source": [
+    "### jacrev, jacfwd, and hessian\n",
+    "\n",
+    "The `jacrev` transform returns a new function that takes in `x` and returns the Jacobian of the function\n",
+    "with respect to `x` using reverse-mode AD."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "20f53be2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from functorch import jacrev\n",
+    "x = torch.randn(5)\n",
+    "jacobian = jacrev(torch.sin)(x)\n",
+    "expected = torch.diag(torch.cos(x))\n",
+    "assert torch.allclose(jacobian, expected)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9007c88",
+   "metadata": {},
+   "source": [
+    "Use `jacrev` to compute the jacobian. This can be composed with `vmap` to produce batched jacobians:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "97d6c382",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = torch.randn(64, 5)\n",
+    "jacobian = vmap(jacrev(torch.sin))(x)\n",
+    "assert jacobian.shape == (64, 5, 5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cda642ec",
+   "metadata": {},
+   "source": [
+    "`jacfwd` is a drop-in replacement for `jacrev` that computes Jacobians using forward-mode AD:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a8c1dedb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from functorch import jacfwd\n",
+    "x = torch.randn(5)\n",
+    "jacobian = jacfwd(torch.sin)(x)\n",
+    "expected = torch.diag(torch.cos(x))\n",
+    "assert torch.allclose(jacobian, expected)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39f85b50",
+   "metadata": {},
+   "source": [
+    "Composing `jacrev` with itself or `jacfwd` can produce hessians:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "1e511139",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def f(x):\n",
+    "  return x.sin().sum()\n",
+    "\n",
+    "x = torch.randn(5)\n",
+    "hessian0 = jacrev(jacrev(f))(x)\n",
+    "hessian1 = jacfwd(jacrev(f))(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18efdc65",
+   "metadata": {},
+   "source": [
+    "The `hessian` is a convenience function that combines `jacfwd` and `jacrev`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "fd1765df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from functorch import hessian\n",
+    "\n",
+    "def f(x):\n",
+    "  return x.sin().sum()\n",
+    "\n",
+    "x = torch.randn(5)\n",
+    "hess = hessian(f)(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b597d7ad",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Check out our other tutorials (in the left bar) for more detailed explanations of how to apply functorch transforms for various use cases. `functorch` is very much a work in progress and we'd love to hear how you're using it -- we encourage you to start a conversation at our [issues tracker](https://github.com/pytorch/functorch) to discuss your use case."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I modified the docs website:
- It has a new install page which we'll fill out l ater
- It has a new "whirlwind tour" section which is just our README
copy-pasted
- It has a "UX Limitations" section describing arbitrary python
mutation, in-place operations, and control flow.

Please let me know if you think anything else should be here.

Future work:
- I might put up a table of what operators we have support for and
which ones we don't, autogenerated via OpInfo