### PR TITLE
Setting tensor_meta attr for inplace ops

### DIFF
--- a/functorch/_src/python_key.py
+++ b/functorch/_src/python_key.py
@@ -87,6 +87,7 @@ class PythonTensor(torch.Tensor):
         # Kind of a hacky way to test if an op is in-place or not
         if func.__name__[-1] == "_" and func.__name__[0] != "_":
             args[0].proxy = proxy_out
+            proxy_out.node.meta['tensor_meta'] = _extract_tensor_metadata(args[0])
 
         with no_dispatch():
             real_out = func(*args, **kwargs)

--- a/test/test_pythonkey.py
+++ b/test/test_pythonkey.py
@@ -475,6 +475,33 @@ class TestPartitioning(TestCase):
         assert torch.allclose(ref_b.grad, res_b.grad, atol=1e-3, rtol=1e-3)
 
 
+    def test_meta_tensor_inplace_op(self):
+        # Following module results in inplace ops while tracing. The test checks
+        # that the meta tensor information is stored for inplace ops.
+        class MockModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(3072, 768, requires_grad=True))
+                self.bias = torch.nn.Parameter(torch.randn(3072, requires_grad=True))
+
+            def forward(self, add_4):
+                linear_4 = torch.nn.functional.linear(add_4, self.weight, bias = self.bias)
+                gelu = torch.nn.functional.gelu(linear_4, approximate = False);  linear_4 = None
+                return gelu
+
+        def check_meta_tensor(fx_g, _):
+            for node in fx_g.graph.nodes:
+                if node.op != 'output':
+                    assert 'tensor_meta' in node.meta
+            return fx_g
+
+        inp0 = torch.randn(16, 128, 768, requires_grad=True)
+        inputs = [inp0, ]
+        mod = MockModule().to(device="cpu")
+        aot_mod = aot_module(mod, fw_compiler=check_meta_tensor)
+        aot_mod(*inputs)
+
+
 only_for = ("cpu")
 instantiate_device_type_tests(
     TestPythonKey,

--- a/test/test_pythonkey.py
+++ b/test/test_pythonkey.py
@@ -485,7 +485,7 @@ class TestPartitioning(TestCase):
 
             def forward(self, add_4):
                 linear_4 = torch.nn.functional.linear(add_4, self.weight, bias=self.bias)
-                gelu = torch.nn.functional.gelu(linear_4, approximate=False)
+                gelu = torch.nn.functional.gelu(linear_4)
                 return gelu
 
         def check_meta_tensor(fx_g, _):

--- a/test/test_pythonkey.py
+++ b/test/test_pythonkey.py
@@ -474,7 +474,6 @@ class TestPartitioning(TestCase):
         assert torch.allclose(ref_a.grad, res_a.grad, atol=1e-3, rtol=1e-3)
         assert torch.allclose(ref_b.grad, res_b.grad, atol=1e-3, rtol=1e-3)
 
-
     def test_meta_tensor_inplace_op(self):
         # Following module results in inplace ops while tracing. The test checks
         # that the meta tensor information is stored for inplace ops.
@@ -485,8 +484,8 @@ class TestPartitioning(TestCase):
                 self.bias = torch.nn.Parameter(torch.randn(3072, requires_grad=True))
 
             def forward(self, add_4):
-                linear_4 = torch.nn.functional.linear(add_4, self.weight, bias = self.bias)
-                gelu = torch.nn.functional.gelu(linear_4, approximate = False);  linear_4 = None
+                linear_4 = torch.nn.functional.linear(add_4, self.weight, bias=self.bias)
+                gelu = torch.nn.functional.gelu(linear_4, approximate=False)
                 return gelu
 
         def check_meta_tensor(fx_g, _):


### PR DESCRIPTION
The following test snippet fails accuracy testing. There is a broader issue here first (not handled by this PR) - mutation. The joint graph had an inplace op. And partitioner decided to recompute the inplace op, leading to incorrect gradients.

The second issue is that, in the test below, we are using default partitioner. Default partitioner is not supposed to recompute any operations in the backward pass. So, this PR specifically handles the second issue. We were not recording the meta tensor knowledge for inplace ops, causing redundant recomputation.

Note that the first issue still exists and is very likely to happen (recomputation of inplace ops) in the specialized partitioners  like min-cut rematerialization partitioner. 


~~~~
import functorch
import torch

from functorch.compile import memory_efficient_fusion, print_compile, aot_module, decomposition_table
import importlib
import torchdynamo
import copy
import itertools
from torchdynamo.optimizations import backends

class Bar(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.weight = torch.nn.Parameter(torch.randn(3072, 768, device='cuda', requires_grad=True))
        self.bias = torch.nn.Parameter(torch.randn(3072, device='cuda', requires_grad=True))

    def forward(self, add_4):
        linear_4 = torch.nn.functional.linear(add_4, self.weight, bias = self.bias)

        # HACKING - Change gelu to relu
        gelu = torch.nn.functional.gelu(linear_4, approximate = False);  linear_4 = None
        # gelu = torch.nn.functional.relu(linear_4);  linear_4 = None

        return gelu
        


def reduce_out(out):
    if isinstance(out, torch.Tensor):
        return torch.sigmoid(out).sum()
    elif isinstance(out, (tuple, list)):
        return sum([reduce_out(x) for x in out])
    raise NotImplementedError("Don't know how to reduce", type(out))


def checkpoint_params(gm):
    rng_state = torch.clone(torch.random.get_rng_state())
    saved_state = []
    for param in itertools.chain(gm.parameters(), gm.buffers()):
        saved_state.append((param, param._version, torch.clone(param)))

    def restore():
        with torch.no_grad():
            torch.random.set_rng_state(rng_state)
            for param, version, original_value in saved_state:
                if param._version != version:
                    param.copy_(original_value)

    return restore


def clone_me(x):
    if x is None:
        return None
    return x.detach().clone().requires_grad_(x.requires_grad)

def collect_results(model, prediction, loss, example_inputs):
    results = []
    results.append(prediction)
    results.append(loss)
    for param in model.parameters():
        results.append(clone_me(param.grad))
    for example in example_inputs:
        if isinstance(example, list):
            for inp in example:
                results.append(clone_me(inp.grad))
        else:
            results.append(clone_me(example.grad))
    return results

counter = 0
def same(a, b):
    """Check correctness to see if a and b match"""
    global counter 
    counter += 1
    if isinstance(a, (list, tuple, torch.nn.ParameterList)):
        if not isinstance(b, (list, tuple)):
            return False
        return all(same(ai, bi) for ai, bi in zip(a, b))
    elif isinstance(a, torch.Tensor):
        assert isinstance(b, torch.Tensor)
        if not  torch.allclose(a, b, atol=1e-3, rtol=1e-3):
            print("Failed", counter)
            print(a.flatten()[1], b.flatten()[1])
            print(a.size())
        return torch.allclose(a, b, atol=1e-3, rtol=1e-3)
    elif isinstance(a, (int, float, type(None), bool, torch.device)):
        return a == b
    else:
        raise RuntimeError(f"unsupported type: {type(a).__name__}")


def clone_inputs(inputs):
    clones = [x.detach().clone().requires_grad_(True) for x in inputs]
    for c in clones:
        c.grad = None
    return clones


def get_results(mod, inputs):
    global counter
    counter = 0
    cloned_inputs = clone_inputs(inputs)
    mod.zero_grad(True)
    ref = mod(*cloned_inputs)
    l = reduce_out(ref)
    l.backward()
    ref_results = collect_results(mod, ref, l, cloned_inputs) 
    return ref_results
 
def test_module():
    # inp0 = torch.load(module_id + "_tensor0.pt").to(device="cpu").requires_grad_(True)
    # inputs = [inp0,]

    inp0 = torch.randn(16, 128, 768, requires_grad=True)
    inputs = [inp0, ]

    mod = Bar().to(device="cpu")
    restore = checkpoint_params(mod)
    orig_mod_results = get_results(mod, inputs)

    restore()
    new_mod = copy.deepcopy(mod)
    copy_mod_results = get_results(new_mod, inputs)
    print("Are Orig_mod and Copy_mod same:", same(orig_mod_results, copy_mod_results))
    # assert same(orig_mod_results, copy_mod_results), "Deepcopy of a mod fails, what the hell"

    restore()
    aot_mod = aot_module(mod, fw_compiler=print_compile)
    aot_mod_results = get_results(aot_mod, inputs)

    print("Recheck Are Orig_mod and Copy_mod same:", same(orig_mod_results, copy_mod_results))
    global counter
    counter = 0
    print("Are Orig_mod and AOT_mod same:", same(orig_mod_results, aot_mod_results))
    counter = 0
    print("Are Copy_mod and AOT_mod same:", same(copy_mod_results, aot_mod_results))

test_module()

~~~~