### PR TITLE
Fix + test dropout without batch dimension

### DIFF
--- a/functorch/csrc/BatchRulesDecompositions.cpp
+++ b/functorch/csrc/BatchRulesDecompositions.cpp
@@ -93,13 +93,9 @@ void decompose_functional(const c10::OperatorHandle& op, torch::jit::Stack* stac
 #define OP_DECOMPOSE2(op, overload)  m.impl(#op"."#overload, static_cast<decltype(&ATEN_FN2(op, overload))>(native::op));
 
 TORCH_LIBRARY_IMPL(aten, FT_VMAP_MODE_KEY, m) {
-  OP_DECOMPOSE(alpha_dropout);
   OP_DECOMPOSE(alpha_dropout_);
-  OP_DECOMPOSE(dropout);
   OP_DECOMPOSE(dropout_);
-  OP_DECOMPOSE(feature_alpha_dropout);
   OP_DECOMPOSE(feature_alpha_dropout_);
-  OP_DECOMPOSE(feature_dropout);
   OP_DECOMPOSE(feature_dropout_);
 }
 

--- a/functorch/csrc/BatchRulesRandomness.cpp
+++ b/functorch/csrc/BatchRulesRandomness.cpp
@@ -165,9 +165,6 @@ std::tuple<Tensor,Tensor> native_dropout_batching_rule(const Tensor& tensor, dou
   }
 
   if ((train.has_value() && !train) || randomness == RandomnessType::Different) {
-    if (!tensor_bdim) {
-      tensor_value = tensor_value.unsqueeze(0).expand(maybe_layer->batchSize()); // ret value will be a batched tensor
-    }
     auto res = at::native_dropout(tensor_value, p, train);
     return std::make_tuple(makeBatched(std::get<0>(res), 0, cur_level), makeBatched(std::get<1>(res), 0, cur_level));
   }
@@ -180,6 +177,32 @@ std::tuple<Tensor,Tensor> native_dropout_batching_rule(const Tensor& tensor, dou
   mask.bernoulli_(p1m);
   const auto output = tensor.mul(mask).mul_(scale);
   return std::make_tuple(output, mask);
+}
+
+template <typename F, F NativeFunc>
+Tensor dropout_unsqueeze(const Tensor& input, double p, bool train) {
+  // with out of place dropout, if the input is not batched and the randomness is on different, we need to
+  // expand the input to appear like a batched input. Otherwise we just decompose it to the corresponding
+  // native op
+
+  auto maybe_layer = maybeCurrentDynamicLayer();
+  const auto cur_level = maybe_layer->layerId();
+  RandomnessType randomness = maybe_layer->randomness();
+
+  Tensor input_value;
+  optional<int64_t> input_bdim;
+  std::tie(input_value, input_bdim) = unwrapTensorAtLevel(input, cur_level);
+
+  if (!input_bdim && randomness == RandomnessType::Different) {
+    VmapDimVector shapeVec(1, maybe_layer->batchSize());
+    auto shape = input.sizes();
+    shapeVec.reserve(input_value.dim() + 1);
+    shapeVec.insert(shapeVec.end(), shape.begin(), shape.end());
+    input_value = input_value.unsqueeze(0).expand(shapeVec);
+    return NativeFunc(makeBatched(input_value, 0, cur_level), p, train);
+  } else {
+    return NativeFunc(input, p, train);
+  }
 }
 
 template <typename A, A a, typename C>
@@ -354,6 +377,9 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchVmapMode, m) {
       UnaryPointwiseRandomLeadingFloatBatchRule<decltype(&ATEN_FN2(op, overload)), &ATEN_FN2(op, overload), \
                                                 c10::guts::function_traits<decltype(ATEN_FN2(op, overload))>::parameter_types>::apply))
 
+  #define DROPOUT_UNSQUEEZE(op)\
+    m.impl(#op, SINGLE_ARG(dropout_unsqueeze<decltype(&native::op), &native::op>))
+
   RANDOM_BATCH_RULE(randn);
   RANDOM_BATCH_RULE2(randn, generator);
   RANDOM_BATCH_RULE2(randn, generator_with_names);
@@ -398,6 +424,11 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchVmapMode, m) {
   UNARY_POINTWISE_RANDOM(multinomial);
   UNARY_POINTWISE_RANDOM(poisson);
   UNARY_POINTWISE_RANDOM(bernoulli);
+
+  DROPOUT_UNSQUEEZE(dropout);
+  DROPOUT_UNSQUEEZE(feature_dropout);
+  DROPOUT_UNSQUEEZE(alpha_dropout);
+  DROPOUT_UNSQUEEZE(feature_alpha_dropout);
 
   #undef RANDOM_BATCH_RULE
   #undef RANDOM_BATCH_RULE2

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -3567,34 +3567,40 @@ class TestVmapOperatorsOpInfo(TestCase):
                 assert torch.allclose(vmap_result[i], expected)
 
     @parametrize('randomness', ['error', 'same', 'different'])
-    def test_feature_dropout(self, device, randomness):
+    @parametrize('batched_input', [True, False])
+    def test_feature_dropout(self, device, randomness, batched_input):
         # special case because functional feature dropout expects a batch dimension, so it doesn't match the
         # pattern for other randomness
 
         seed = 1234567
         supported_ops = [
-            lambda t: torch.nn.functional.dropout(torch.ones_like(t), training=True),
-            lambda t: torch.nn.functional.alpha_dropout(torch.ones_like(t), training=True),
-            lambda t: torch.nn.functional.feature_alpha_dropout(t, training=True),
-            lambda t: torch.nn.functional.dropout2d(t, training=True),
-            lambda t: torch.nn.functional.dropout3d(t.unsqueeze(-1), training=True),
+            lambda t, _: torch.nn.functional.dropout(torch.ones_like(t), training=True),
+            lambda t, _: torch.nn.functional.alpha_dropout(torch.ones_like(t), training=True),
+            lambda t, _: torch.nn.functional.feature_alpha_dropout(t, training=True),
+            lambda t, _: torch.nn.functional.dropout2d(t, training=True),
+            lambda t, _: torch.nn.functional.dropout3d(t.unsqueeze(-1), training=True),
         ]
+        B0 = 4
 
         for op in supported_ops:
-            passed = torch.ones([4, 3, 3, 3, 3])
+            always_batched = torch.randn((B0,))
+            passed = torch.ones([B0, 3, 3, 3, 3], device=device) if batched_input else torch.ones([3, 3, 3, 3])
+            in_dims = 0 if batched_input else (None, 0)
             if randomness == 'error':
                 with self.assertRaisesRegex(RuntimeError, r"called random operation while in randomness error mode"):
-                    vmap(op, randomness=randomness)(passed)
+                    vmap(op, randomness=randomness, in_dims=in_dims)(passed, always_batched)
                 return
             torch.manual_seed(seed)
-            vmap_result = vmap(op, randomness=randomness)(passed)
+            vmap_result = vmap(op, randomness=randomness, in_dims=in_dims)(passed, always_batched)
             torch.manual_seed(seed)
+            if not batched_input:
+                passed = passed.unsqueeze(0).expand(B0, 3, 3, 3, 3)  # 
             if randomness == 'different':
-                expected = op(passed.flatten(0, 1))
+                expected = op(passed.flatten(0, 1), always_batched)  # (B0, B, ...) -> (B0 * B, ...)
                 expected = expected.reshape(passed.shape[0], passed.shape[1], *expected.shape[1:])
                 assert torch.allclose(vmap_result, expected)
             else:
-                expected = op(passed[0])
+                expected = op(passed[0], always_batched)
                 for i in range(4):
                     assert torch.allclose(vmap_result[i], expected)
 


### PR DESCRIPTION
After trying to update some of the tests in `randint_like` after Richard pointed out that it was wrong for the case where an incoming tensor is unbatched, found out that dropout wasn't dealing with that case correctly. If we vmap over dropout that takes in an regular tensor using different randomness, we'll need to upgrade it to a batched tensor that's expanded to have the correct behavior