### PR TITLE
[PROTOTYPE] generated batching rules for custom dispatcher ops

### DIFF
--- a/functorch/_src/custom_function.py
+++ b/functorch/_src/custom_function.py
@@ -8,6 +8,8 @@ def custom_vjp(name, filter_fn, fwd_fn, bwd_fn):
     m.def_(f"{name}(Tensor[] args) -> Tensor[]")
     m.impl(f"{name}", "CompositeImplicitAutograd", fwd_fn)
 
+    m.gen_vmap_binding(f"{name}")
+
     m.def_(f"{name}_vjp(Tensor[] args) -> Tensor[]")
     m.impl(f"{name}_vjp", "CompositeImplicitAutograd", bwd_fn)
 


### PR DESCRIPTION
Note: this PR has a bunch of issues, but it shows one potential way of getting "automatically generated" batching rules for custom ops registered to the dispatcher through python.

Let's say you have a custom operator (`foo`) in python that you've defined a derivative formula for (`foo_vjp`), and you want to vmap over it. If I run this:
```
f = vmap(foo)
out = f(x)
```
Then the chain of calls in the dispatcher will look something like this:
```
foo
-> foo_vmap (vmap kernel for `foo`, which [somehow] does some batching stuff and redispatches)
-> foo_grad (autograd kernel for `foo`, which adds `foo_vjp` to the autograd graph and redispatches
-> foo_cpu (cpu kernel, which we've actually directly registered our python `foo` function to. call into `foo` in python)
```

Doing the above requires writing an explicit batching rule for `foo` though. One way to "get the batching rule for free" by running `foo()`, letting it decompose into whatever `aten` ops it eventually calls, and running the batching rules on each of those aten ops. There's a problem with that though. If we decompose `foo` when we run the batching rule, then theres no way to "undo" the decomposition below. Any kernels that we redispatch to will see the "base" ops, instead of the original op:
```
foo
-> foo_vmap----------------
            |                                    |
       base_a                          base_b
       -> base_a_grad            -> base_b_grad      // bad outcome: we ran autograd on base_a. wanted to run on foo!
       -> base_a_cpu             -> base_b_cpu
```

How do we get around that? We can't really "undo" the decomposition inside of the call stack... But we could just run "foo" twice: once for the forward pass where we *do* decompose into the base ops, and run the batching rule on each, and once for the backward pass where we *dont* decompose:

```
foo
-> foo_vmap
     (1) runs forward (decomposes, skips autograd)
            |                                    |
       base_a                          base_b
       -> base_a_vmap          -> base_b_vmap
       -> base_a_cpu             -> base_b_cpu
     (2) set up autograd graph (doesn't decompose, hits the autograd kernel but "skips" the call to the backend)
       ->  foo_grad
```


Known issues:
(1) I'm not sure how composable this is. I haven't thought too hard yet about what would happen if you the logic together with another functionality (e.g. `amp` or `functionalization`)
(2) It interacts poorly with `DynamicLayer` - I left a comment explaining why, but I'm not sure what the best solution is.
(3) I'm hardcoding that the custom ops accept and return a single TensorList argument (but so does the existing code 😛)
(4) I got one very basic test to pass, but there are probably other problems I just haven't run into.