### PR TITLE
[skip-ci] Fixed get_perf in jacobians_hessians

### DIFF
--- a/notebooks/jacobians_hessians.ipynb
+++ b/notebooks/jacobians_hessians.ipynb
@@ -252,9 +252,12 @@
         "  faster = second.times[0]\n",
         "  slower = first.times[0]\n",
         "  gain = (slower-faster)/slower\n",
-        "  if gain < 0: gain *=-1 \n",
+        "  faster_desc = second_descriptor\n",
+        "  if gain < 0:\n",
+        "    gain *=-1\n",
+        "    faster_desc = first_descriptor\n",        
         "  final_gain = gain*100\n",
-        "  print(f\" Performance delta: {final_gain:.4f} percent improvement with {second_descriptor} \")"
+        "  print(f\" Performance delta: {final_gain:.4f} percent improvement with {faster_desc} \")"
       ],
       "metadata": {
         "id": "II7r6jBtflUJ"


### PR DESCRIPTION
https://pytorch.org/functorch/stable/notebooks/jacobians_hessians.html#reverse-mode-jacobian-jacrev-vs-forward-mode-jacobian-jacfwd

<img width="708" alt="image" src="https://user-images.githubusercontent.com/2459423/158375920-a70541ca-e8fd-4f63-8f6a-5536e3500565.png">


`jacfwd` is faster then `jacrev` but message says the opposite.

