### PR TITLE
Make default_decompositions visible in functorch.compile namespace

### DIFF
--- a/functorch/compile/__init__.py
+++ b/functorch/compile/__init__.py
@@ -18,7 +18,8 @@ from .._src.compilers import (
     nnc_jit,
     memory_efficient_fusion,
     debug_compile,
-    print_compile
+    print_compile,
+    default_decompositions
 )
 from .._src.partitioners import (
     min_cut_rematerialization_partition,


### PR DESCRIPTION
As title