### PR TITLE
fix functionalize(): properly propagate input mutations

### DIFF
--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -1224,10 +1224,10 @@ def functionalize(func: Callable) -> Callable:
             func_args = _wrap_all_tensors_to_functional(args, func_level)
             func_kwargs = _wrap_all_tensors_to_functional(kwargs, func_level)
 
-            flattened_unwrapped_args = tree_flatten(args)
-            flattened_wrapped_args = tree_flatten(func_args)
-            flattened_unwrapped_kwargs = tree_flatten(kwargs)
-            flattened_wrapped_kwargs = tree_flatten(func_kwargs)
+            flattened_unwrapped_args, _ = tree_flatten(args)
+            flattened_wrapped_args, _ = tree_flatten(func_args)
+            flattened_unwrapped_kwargs, _ = tree_flatten(kwargs)
+            flattened_wrapped_kwargs, _ = tree_flatten(func_kwargs)
 
             func_outputs = func(*func_args, **func_kwargs)
             outputs = _unwrap_all_tensors_from_functional(func_outputs)

--- a/test/test_eager_transforms.py
+++ b/test/test_eager_transforms.py
@@ -2776,6 +2776,9 @@ class TestFunctionalize(TestCase):
         # Check that outputs are the same
         self.assertEqual(actual_outputs, expected_outputs)
 
+        # Inputs might have been mutated by f: check that they were mutated properly
+        self.assertEqual(inpt1, inpt2)
+
     def test_simple_view(self, device):
         def f(x: torch.Tensor) -> torch.Tensor:
             tmp = torch.ones(2, device=device)


### PR DESCRIPTION
fixed a bug where input mutations weren't getting propagated to the inputs correctly