### PR TITLE
fix release branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches:
-      - main
+      - release/*
 
 jobs:
 
@@ -18,9 +18,9 @@ jobs:
           architecture: x64
       - name: Checkout functorch
         uses: actions/checkout@v2
-      - name: Install PyTorch Nightly
+      - name: Install PyTorch 1.11
         run: |
-          python3 -mpip install --pre torch>=1.12.0.dev -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+          python3 -mpip install torch==1.11.0
       - name: Install functorch
         run: |
           python3 setup.py install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   push:
     branches:
-      - main
+      - release/*
   pull_request:
 
 jobs:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,5 @@ sphinxcontrib.katex
 sphinx_copybutton>=0.3.1
 IPython
 myst-nb==0.13.2
+# Fixing upper version due to https://github.com/sphinx-doc/sphinx/issues/10306
+Jinja2<3.1.0

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ if os.getenv('BUILD_VERSION'):
 elif sha != 'Unknown':
     version += '+' + sha[:7]
 
+
 def write_version_file():
     version_path = os.path.join(cwd, 'functorch', 'version.py')
     with open(version_path, 'w') as f:


### PR DESCRIPTION
Makes doc build + lint check run on release/0.1 branch

Also cleans up the problems for those jobs that currently break them (since they were small changes)