### PR TITLE
AOT Module Simplified - Low Overhead version of AOT Module

### DIFF
--- a/functorch/compile/__init__.py
+++ b/functorch/compile/__init__.py
@@ -8,6 +8,7 @@ from .._src.aot_autograd import (
     compiled_module,
     num_of_recompilations,
     clear_compile_cache,
+    aot_module_simplified,
 )
 from .._src.compilers import (
     ts_compile,


### PR DESCRIPTION
This PR adds a new API - `aot_module_simplified` which removes the overhead associated with pytree and compilation cache for TorchDynamo-like frontends generated graphs.

For completeness, I am adding few benchmarks

~~~
import functorch
import torch
from functorch.compile import aot_module_simplified, aot_module, nop
from time import perf_counter

class MockModule(torch.nn.Module):
    def __init__(self):
        super().__init__()
        # self.linears = [torch.nn.Linear(10, 10) for _ in range(10)]
        self.linears = torch.nn.Linear(10, 10)

    def forward(self, x):
        return (x, )



mod = MockModule()

x = torch.randn(4, 5)

mod(x)

aot_mod = aot_module(mod, nop)
aot_mod_simple = aot_module_simplified(mod, nop)

def bench(m):
    for _ in range(50):
        m(x)
    t0 = perf_counter()
    repeats = 1000
    for _ in range(repeats):
        m(x)
    t1 = perf_counter()
    return f"{round((t1 - t0) * (10**6)/repeats, 2)} us"

print("Old", bench(aot_mod))
print("New", bench(aot_mod_simple))
~~~

For the above benchmark code, on A100 GPUs, we get the following numbers

~~~
Old 39.65 us
New 8.84 us
~~~

The speedup is because of (1) preventing walking through the module in each forward call to extract params, (2) No pytree handling needed for params, as they are already flattened beforehand, (3) No caching

And these are the torchbench results. We observe good improvements for many models, with average of ~ 2.5% improvement.



name | aot_module speedup | aot_module_simplified speedup
-- | -- | --
BERT_pytorch | 1.1923 | 1.2257
Background_Matting | 1.0919 | 1.0975
LearningToPaint | 1.1334 | 1.1715
alexnet | 0.9838 | 0.9932
attention_is_all_you_need_pytorch | 0.9714 | 0.9807
dcgan | 0.9403 | 0.9688
drq | 0.9291 | 0.9677
hf_Bart | 0.9814 | 1.0028
hf_Bert | 0.988 | 1.0147
hf_BigBird | 0.989 | 1.002
hf_DistilBert | 0.9519 | 0.9631
hf_Longformer | 1.0169 | 1.0185
maml_omniglot | 0.8805 | 0.9271
mnasnet1_0 | 1.1979 | 1.2412
mobilenet_v2 | 1.2034 | 1.2193
mobilenet_v2_quantized_qat | 1.2857 | 1.3202
mobilenet_v3_large | 1.1849 | 1.2295
nvidia_deeprecommender | 0.9493 | 0.9511
pytorch_CycleGAN_and_pix2pix | 1.1893 | 1.1876
pytorch_struct | 1.0079 | 0.9957
pytorch_unet | 1.0424 | 1.0485
resnet18 | 1.076 | 1.116
resnet50 | 1.084 | 1.1101
resnext50_32x4d | 1.049 | 1.0797
shufflenet_v2_x1_0 | 1.1872 | 1.223
soft_actor_critic | 0.8648 | 0.9312
speech_transformer | 0.7549 | 0.8289
squeezenet1_1 | 1.025 | 1.0484
timm_efficientnet | 1.2452 | 1.2801
timm_nfnet | 1.165 | 1.1683
timm_regnet | 1.118 | 1.1486
timm_resnest | 1.055 | 1.0607
timm_vision_transformer | 1.1467 | 1.1936
timm_vovnet | 1.0599 | 1.0738
tts_angular | 0.9776 | 0.9853
vgg16 | 0.9971 | 0.9988
yolov3 | 1.1371 | 1.1469
Average speedup | 1.055 | 1.079






