### PR TITLE
functionalize(): make "additionally removing views" toggleable

### DIFF
--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -1206,14 +1206,14 @@ def _wrap_all_tensors_to_functional(tensor_pytree, level):
     return tree_map(partial(_maybe_wrap_functional_tensor, level=level), tensor_pytree)
 
 
-def _maybe_unwrap_functional_tensor(maybe_tensor):
+def _maybe_unwrap_functional_tensor(maybe_tensor, *, reapply_views: bool):
     if not isinstance(maybe_tensor, torch.Tensor):
         return maybe_tensor
-    return _unwrap_functional_tensor(maybe_tensor)
+    return _unwrap_functional_tensor(maybe_tensor, reapply_views)
 
 
-def _unwrap_all_tensors_from_functional(tensor_pytree):
-    return tree_map(_maybe_unwrap_functional_tensor, tensor_pytree)
+def _unwrap_all_tensors_from_functional(tensor_pytree, *, reapply_views: bool):
+    return tree_map(lambda t: _maybe_unwrap_functional_tensor(t, reapply_views=reapply_views), tensor_pytree)
 
 
 def functionalize(func: Callable, *, reapply_views: bool = False) -> Callable:
@@ -1230,7 +1230,7 @@ def functionalize(func: Callable, *, reapply_views: bool = False) -> Callable:
             flattened_wrapped_kwargs, _ = tree_flatten(func_kwargs)
 
             func_outputs = func(*func_args, **func_kwargs)
-            outputs = _unwrap_all_tensors_from_functional(func_outputs)
+            outputs = _unwrap_all_tensors_from_functional(func_outputs, reapply_views=reapply_views)
             flat_outputs, func_out_spec = tree_flatten(outputs)
 
             for a in flattened_wrapped_args + flattened_wrapped_kwargs:

--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -1216,7 +1216,21 @@ def _unwrap_all_tensors_from_functional(tensor_pytree, *, reapply_views: bool):
     return tree_map(lambda t: _maybe_unwrap_functional_tensor(t, reapply_views=reapply_views), tensor_pytree)
 
 
-def functionalize(func: Callable, *, reapply_views: bool = False) -> Callable:
+def functionalize(func: Callable, *, remove: str = 'mutations') -> Callable:
+    if remove == 'mutations':
+        reapply_views = True
+    elif remove == 'mutations_and_views':
+        reapply_views = False
+    else:
+        raise RuntimeError(
+            f"functionalize(f, remove='mutations'): received invalid argument for remove={remove}."
+            " Valid options are:\n"
+            "     remove='mutations': all inplace and out= operators will be removed from the program, and replaced"
+            " with their out-of-place equivalents.\n"
+            "     remove='mutations_and_views': In addition to the above, all aliasing operators {view} will be"
+            " replaced with their non-aliasing counterparts, {view}_copy.\n"
+        )
+
     @wraps(func)
     def wrapped(*args, **kwargs):
         try:

--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -1216,11 +1216,11 @@ def _unwrap_all_tensors_from_functional(tensor_pytree):
     return tree_map(_maybe_unwrap_functional_tensor, tensor_pytree)
 
 
-def functionalize(func: Callable) -> Callable:
+def functionalize(func: Callable, *, reapply_views: bool = False) -> Callable:
     @wraps(func)
     def wrapped(*args, **kwargs):
         try:
-            func_level = _func_increment_nesting()
+            func_level = _func_increment_nesting(reapply_views)
             func_args = _wrap_all_tensors_to_functional(args, func_level)
             func_kwargs = _wrap_all_tensors_to_functional(kwargs, func_level)
 

--- a/functorch/csrc/DynamicLayer.cpp
+++ b/functorch/csrc/DynamicLayer.cpp
@@ -557,7 +557,7 @@ void dynamicLayerFrontFallback(const c10::OperatorHandle& op, torch::jit::Stack*
   auto num_args = op.schema().arguments().size();
   foreachTensorInplace(*stack, stack->size() - num_args, stack->size(), maybeTransformGradWrappers);
 
-  auto layer& = dynamicLayerStack.back();
+  auto& layer = dynamicLayerStack.back();
 
   DispatchKeySet exclude = keysToExcludeWhenEnteringDynamicLayer(layer.key());
   DispatchKeySet hacky_include;

--- a/functorch/csrc/DynamicLayer.h
+++ b/functorch/csrc/DynamicLayer.h
@@ -33,7 +33,8 @@ struct FUNCTORCH_API DynamicLayer {
       optional<int64_t> batchSize = nullopt,
       optional<RandomnessType> randomness = nullopt,
       optional<bool> prev_grad_mode = nullopt,
-      optional<bool> pre_fwd_grad_mode = nullopt);
+      optional<bool> pre_fwd_grad_mode = nullopt,
+      optional<bool> functionalize_add_back_views = nullopt);
 
   DispatchKey key() const;
   int64_t layerId() const;
@@ -48,10 +49,15 @@ struct FUNCTORCH_API DynamicLayer {
   // only valid for jvp transform
   optional<bool> prevFwdGradMode() const;
 
+<<<<<<< HEAD
   void saveLocalDispatchKeySet(c10::impl::LocalDispatchKeySet keyset);
   void clearSavedLocalDispatchKeySet();
   c10::impl::LocalDispatchKeySet getSavedLocalDispatchKeySet() const;
 
+=======
+  // only valid for functionalization
+  optional<bool> functionalizeAddBackViews() const;
+>>>>>>> e7ebcf2 (make functionalize() toggleable when adding back views)
  private:
   DispatchKey key_;
   int64_t layerId_;
@@ -62,8 +68,12 @@ struct FUNCTORCH_API DynamicLayer {
   optional<RandomnessType> randomness_;
   optional<bool> prevGradMode_;
   optional<bool> prevFwdGradMode_;
+<<<<<<< HEAD
 
   optional<c10::impl::LocalDispatchKeySet> savedLocalDispatchKeySet_;
+=======
+  optional<bool> functionalizeAddBackViews_;
+>>>>>>> e7ebcf2 (make functionalize() toggleable when adding back views)
 };
 
 FUNCTORCH_API int64_t initAndPushDynamicLayer(
@@ -71,12 +81,22 @@ FUNCTORCH_API int64_t initAndPushDynamicLayer(
     optional<int64_t> batch_size = nullopt,
     optional<RandomnessType> randomness = nullopt,
     optional<bool> prev_grad_mode = nullopt,
+<<<<<<< HEAD
     optional<bool> prev_fwd_grad_mode = nullopt);
 FUNCTORCH_API DynamicLayer popDynamicLayerAndDeleteMetadata();
 FUNCTORCH_API c10::optional<DynamicLayer> maybeCurrentDynamicLayer();
 FUNCTORCH_API const std::vector<DynamicLayer>& getDynamicLayerStack();
 FUNCTORCH_API void setDynamicLayerStack(const std::vector<DynamicLayer>& stack);
 FUNCTORCH_API void setDynamicLayerFrontBackKeysIncluded(bool included);
+=======
+    optional<bool> prev_fwd_grad_mode = nullopt,
+    optional<bool> functionalize_add_back_views = nullopt);
+TORCH_API DynamicLayer popDynamicLayerAndDeleteMetadata();
+TORCH_API c10::optional<DynamicLayer> maybeCurrentDynamicLayer();
+TORCH_API const std::vector<DynamicLayer>& getDynamicLayerStack();
+TORCH_API void setDynamicLayerStack(const std::vector<DynamicLayer>& stack);
+TORCH_API void setDynamicLayerFrontBackKeysIncluded(bool included);
+>>>>>>> e7ebcf2 (make functionalize() toggleable when adding back views)
 
 // NB: Not lock safe, you should only call this from Python where the GIL will
 // prevent race conditions.

--- a/functorch/csrc/DynamicLayer.h
+++ b/functorch/csrc/DynamicLayer.h
@@ -49,15 +49,12 @@ struct FUNCTORCH_API DynamicLayer {
   // only valid for jvp transform
   optional<bool> prevFwdGradMode() const;
 
-<<<<<<< HEAD
   void saveLocalDispatchKeySet(c10::impl::LocalDispatchKeySet keyset);
   void clearSavedLocalDispatchKeySet();
   c10::impl::LocalDispatchKeySet getSavedLocalDispatchKeySet() const;
 
-=======
   // only valid for functionalization
   optional<bool> functionalizeAddBackViews() const;
->>>>>>> e7ebcf2 (make functionalize() toggleable when adding back views)
  private:
   DispatchKey key_;
   int64_t layerId_;
@@ -68,12 +65,10 @@ struct FUNCTORCH_API DynamicLayer {
   optional<RandomnessType> randomness_;
   optional<bool> prevGradMode_;
   optional<bool> prevFwdGradMode_;
-<<<<<<< HEAD
 
   optional<c10::impl::LocalDispatchKeySet> savedLocalDispatchKeySet_;
-=======
+
   optional<bool> functionalizeAddBackViews_;
->>>>>>> e7ebcf2 (make functionalize() toggleable when adding back views)
 };
 
 FUNCTORCH_API int64_t initAndPushDynamicLayer(
@@ -81,22 +76,13 @@ FUNCTORCH_API int64_t initAndPushDynamicLayer(
     optional<int64_t> batch_size = nullopt,
     optional<RandomnessType> randomness = nullopt,
     optional<bool> prev_grad_mode = nullopt,
-<<<<<<< HEAD
-    optional<bool> prev_fwd_grad_mode = nullopt);
+    optional<bool> prev_fwd_grad_mode = nullopt,
+    optional<bool> functionalize_add_back_views = nullopt);
 FUNCTORCH_API DynamicLayer popDynamicLayerAndDeleteMetadata();
 FUNCTORCH_API c10::optional<DynamicLayer> maybeCurrentDynamicLayer();
 FUNCTORCH_API const std::vector<DynamicLayer>& getDynamicLayerStack();
 FUNCTORCH_API void setDynamicLayerStack(const std::vector<DynamicLayer>& stack);
 FUNCTORCH_API void setDynamicLayerFrontBackKeysIncluded(bool included);
-=======
-    optional<bool> prev_fwd_grad_mode = nullopt,
-    optional<bool> functionalize_add_back_views = nullopt);
-TORCH_API DynamicLayer popDynamicLayerAndDeleteMetadata();
-TORCH_API c10::optional<DynamicLayer> maybeCurrentDynamicLayer();
-TORCH_API const std::vector<DynamicLayer>& getDynamicLayerStack();
-TORCH_API void setDynamicLayerStack(const std::vector<DynamicLayer>& stack);
-TORCH_API void setDynamicLayerFrontBackKeysIncluded(bool included);
->>>>>>> e7ebcf2 (make functionalize() toggleable when adding back views)
 
 // NB: Not lock safe, you should only call this from Python where the GIL will
 // prevent race conditions.

--- a/functorch/csrc/init.cpp
+++ b/functorch/csrc/init.cpp
@@ -137,19 +137,26 @@ Tensor _remove_batch_dim(const Tensor& self, int64_t level, int64_t batch_size, 
   return result;
 }
 
-Tensor _unwrap_functional_tensor(const Tensor& self) {
+Tensor _unwrap_functional_tensor(const Tensor& self, bool add_back_views) {
   // We only ever call that after popping out of a functionalize() call, in which case the current tensors
   // should always be wrapped in a FunctionalTensorWrapper.
   TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(self));
   auto functional = at::functionalization::impl::unsafeGetFunctionalWrapper(self);
-  // when regenerating the (potentially mutated) input tensors, the functionalization pass
-  // regenerates them through a series of view_copy() op calls.
-  // Functorch wants to turn those back into view ops though.
-  c10::impl::IncludeDispatchKeyGuard(c10::DispatchKey::FunctionalizeAddBackViews);
-  // Ensure that the input is up to date by committing any pending updates to the alias.
-  auto any_updates = functional->apply_updates();
-  if (any_updates) {
-    functional->regenerate_from_base();
+  if (add_back_views) {
+    // when regenerating the (potentially mutated) input tensors, the functionalization pass
+    // regenerates them through a series of view_copy() op calls.
+    // Functorch wants to turn those back into view ops though.
+    c10::impl::IncludeDispatchKeyGuard(c10::DispatchKey::FunctionalizeAddBackViews);
+    // Ensure that the input is up to date by committing any pending updates to the alias.
+    auto any_updates = functional->apply_updates();
+    if (any_updates) {
+      functional->regenerate_from_base();
+    }
+  } else {
+    auto any_updates = functional->apply_updates();
+    if (any_updates) {
+      functional->regenerate_from_base();
+    }
   }
   return functional->value();
 }

--- a/functorch/csrc/init.cpp
+++ b/functorch/csrc/init.cpp
@@ -30,14 +30,6 @@ static bool has_level(const Tensor& self, int64_t level) {
   return batched->level() >= level;
 }
 
-static bool has_functional_level(const Tensor& self, int64_t level) {
-  if (!at::functionalization::impl::isFunctionalTensor(self)) {
-    return false;
-  }
-  const auto* functional = at::functionalization::impl::unsafeGetFunctionalWrapper(self);
-  return functional->level() >= level;
-}
-
 Tensor _add_batch_dim(const Tensor& self, int64_t batch_dim, int64_t level) {
   return addBatchDim(self, batch_dim, level);
 }
@@ -249,8 +241,8 @@ int64_t _vmap_decrement_nesting() {
   return layer.layerId();
 }
 
-int64_t _func_increment_nesting() {
-  return initAndPushDynamicLayer(DispatchKey::Functionalize);
+int64_t _func_increment_nesting(bool reapply_views) {
+  return initAndPushDynamicLayer(DispatchKey::Functionalize, c10::nullopt, c10::nullopt, c10::nullopt, c10::nullopt, /*functionalize_add_back_views=*/reapply_views);
 }
 
 int64_t _func_decrement_nesting() {

--- a/functorch/csrc/init.cpp
+++ b/functorch/csrc/init.cpp
@@ -146,7 +146,7 @@ Tensor _unwrap_functional_tensor(const Tensor& self, bool add_back_views) {
     // when regenerating the (potentially mutated) input tensors, the functionalization pass
     // regenerates them through a series of view_copy() op calls.
     // Functorch wants to turn those back into view ops though.
-    c10::impl::IncludeDispatchKeyGuard(c10::DispatchKey::FunctionalizeAddBackViews);
+    at::functionalization::impl::FunctionalizationReapplyViewsGuard guard(functionalization_add_back_views);
     // Ensure that the input is up to date by committing any pending updates to the alias.
     auto any_updates = functional->apply_updates();
     if (any_updates) {


### PR DESCRIPTION
This PR goes with the core-side change here: https://github.com/pytorch/pytorch/pull/75302, which updates the functionalization pass to be able to turn view ops into view_copy ops. Mobile mentioned that they would like to be able to use the `functionalize()` transform to trace models for running on mobile, and removing view ops (cc @ZolotukhinM)

This PR updates `functionalize()` to be toggleable: `functionalize(remove='mutations')` (the default) will remove mutations but preserve views. `functionalize(remove='mutations_and_views')` will remove mutations, and additionally convert `view` operators into their corresponding `view_copy` operators.


Some extra stuff in the PR:
- added more testing for out= mutations, which I fixed in a corresponding core PR: https://github.com/pytorch/pytorch/pull/75818
- remove an unnecessary "regenerate_from_base()" call that gives you an extra view_copy call in some cases. Goes with core PR: https://github.com/pytorch/pytorch/pull/75819