### PR TITLE
Refactor DynamicLayer TLS logic

### DIFF
--- a/functorch/csrc/DynamicLayer.h
+++ b/functorch/csrc/DynamicLayer.h
@@ -10,6 +10,7 @@
 #include <c10/util/Optional.h>
 #include <unordered_map>
 #include <mutex>
+#include <c10/core/impl/LocalDispatchKeySet.h>
 
 // Forward declared bc I am lazy
 namespace c10 { struct AutogradMetaInterface; }
@@ -45,6 +46,11 @@ struct TORCH_API DynamicLayer {
 
   // only valid for jvp transform
   optional<bool> prevFwdGradMode() const;
+
+  void saveLocalDispatchKeySet(c10::impl::LocalDispatchKeySet keyset);
+  void clearSavedLocalDispatchKeySet();
+  c10::impl::LocalDispatchKeySet getSavedLocalDispatchKeySet() const;
+
  private:
   DispatchKey key_;
   int64_t layerId_;
@@ -55,6 +61,8 @@ struct TORCH_API DynamicLayer {
   optional<RandomnessType> randomness_;
   optional<bool> prevGradMode_;
   optional<bool> prevFwdGradMode_;
+
+  optional<c10::impl::LocalDispatchKeySet> savedLocalDispatchKeySet_;
 };
 
 TORCH_API int64_t initAndPushDynamicLayer(

--- a/test/test_eager_transforms.py
+++ b/test/test_eager_transforms.py
@@ -849,7 +849,7 @@ class TestGradTransform(TestCase):
                         fn = op(fn)
 
                 expected = f"{repr(x)}"
-                level = 1
+                level = 0
                 for op in op_list:
                     level += 1
                     if op == grad:


### PR DESCRIPTION
And change how we handle "default PyTorch autograd". The motivation behind this is that previously we special-cased a lot of things (e.g. PythonTLSSnapshot, autograd) and this PR cleans some of those special cases up.