### PR TITLE
Fix visibility macros

### DIFF
--- a/functorch/csrc/BatchedTensorImpl.h
+++ b/functorch/csrc/BatchedTensorImpl.h
@@ -12,6 +12,7 @@
 #include <ATen/SmallVector.h>
 #include <ATen/Tensor.h>
 
+#include <functorch/csrc/Macros.h>
 #include <functorch/csrc/Constants.h>
 
 namespace at {
@@ -121,10 +122,10 @@ inline std::bitset<kVmapNumLevels> createVmapLevelsBitset(int64_t level) {
 }
 
 // Use this to construct a BatchedTensor from a regular Tensor
-TORCH_API Tensor makeBatched(const Tensor& tensor, int64_t dim, int64_t level);
+FUNCTORCH_API Tensor makeBatched(const Tensor& tensor, int64_t dim, int64_t level);
 
 // Adds a batch dim to `tensor`, returning a BatchedTensor
-TORCH_API Tensor addBatchDim(const Tensor& tensor, int64_t dim, int64_t level);
+FUNCTORCH_API Tensor addBatchDim(const Tensor& tensor, int64_t dim, int64_t level);
 
 constexpr DispatchKeySet kKeysToPropagateToWrapper({
   DispatchKey::Negative,

--- a/functorch/csrc/CustomFunction.cpp
+++ b/functorch/csrc/CustomFunction.cpp
@@ -160,7 +160,7 @@ void copy_range(variable_list& out, torch::autograd::IndexRange range, at::Array
   std::copy(t.begin(), t.end(), out.begin() + range.first);
 }
 
-struct TORCH_API GenericPythonBackward : public torch::autograd::TraceableFunction {
+struct GenericPythonBackward : public torch::autograd::TraceableFunction {
   using TraceableFunction::TraceableFunction;
 
   variable_list apply(variable_list&& grads) override;

--- a/functorch/csrc/DynamicLayer.h
+++ b/functorch/csrc/DynamicLayer.h
@@ -5,6 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #pragma once
+#include <functorch/csrc/Macros.h>
 #include <c10/core/DispatchKey.h>
 #include <ATen/core/function_schema.h>
 #include <c10/util/Optional.h>
@@ -25,7 +26,7 @@ enum RandomnessType {
     END
 };
 
-struct TORCH_API DynamicLayer {
+struct FUNCTORCH_API DynamicLayer {
   explicit DynamicLayer(
       DispatchKey key,
       int64_t layerId,
@@ -65,24 +66,24 @@ struct TORCH_API DynamicLayer {
   optional<c10::impl::LocalDispatchKeySet> savedLocalDispatchKeySet_;
 };
 
-TORCH_API int64_t initAndPushDynamicLayer(
+FUNCTORCH_API int64_t initAndPushDynamicLayer(
     DispatchKey key,
     optional<int64_t> batch_size = nullopt,
     optional<RandomnessType> randomness = nullopt,
     optional<bool> prev_grad_mode = nullopt,
     optional<bool> prev_fwd_grad_mode = nullopt);
-TORCH_API DynamicLayer popDynamicLayerAndDeleteMetadata();
-TORCH_API c10::optional<DynamicLayer> maybeCurrentDynamicLayer();
-TORCH_API const std::vector<DynamicLayer>& getDynamicLayerStack();
-TORCH_API void setDynamicLayerStack(const std::vector<DynamicLayer>& stack);
-TORCH_API void setDynamicLayerFrontBackKeysIncluded(bool included);
+FUNCTORCH_API DynamicLayer popDynamicLayerAndDeleteMetadata();
+FUNCTORCH_API c10::optional<DynamicLayer> maybeCurrentDynamicLayer();
+FUNCTORCH_API const std::vector<DynamicLayer>& getDynamicLayerStack();
+FUNCTORCH_API void setDynamicLayerStack(const std::vector<DynamicLayer>& stack);
+FUNCTORCH_API void setDynamicLayerFrontBackKeysIncluded(bool included);
 
 // NB: Not lock safe, you should only call this from Python where the GIL will
 // prevent race conditions.
-TORCH_API bool areTransformsActive();
+FUNCTORCH_API bool areTransformsActive();
 
 // NB: not lock safe. TODO: does it need a lock?
-TORCH_API std::shared_ptr<bool> getLifeHandleForLevel(int64_t level);
+FUNCTORCH_API std::shared_ptr<bool> getLifeHandleForLevel(int64_t level);
 
 // Returns if an operator is in-place. An operator is inplace if:
 // 1. The first argument is a Tensor and it is being written to

--- a/functorch/csrc/Macros.h
+++ b/functorch/csrc/Macros.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// FUNCTORCH_BUILD_MAIN_LIB is set in setup.py.
+// We don't really need to use C10_IMPORT because no C++ project relies on
+// functorch. But leaving it here for future-proofing.
+#ifdef FUNCTORCH_BUILD_MAIN_LIB
+#define FUNCTORCH_API C10_EXPORT
+#else
+#define FUNCTORCH_API C10_IMPORT
+#endif

--- a/functorch/csrc/TensorWrapper.h
+++ b/functorch/csrc/TensorWrapper.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
+#include <functorch/csrc/Macros.h>
 #include <ATen/Tensor.h>
 
 namespace at {
 namespace functorch {
 
-struct TORCH_API TensorWrapper : public c10::TensorImpl {
+struct FUNCTORCH_API TensorWrapper : public c10::TensorImpl {
   explicit TensorWrapper(
       c10::DispatchKeySet key_set,
       Tensor value,
@@ -58,10 +59,10 @@ struct TORCH_API TensorWrapper : public c10::TensorImpl {
   std::shared_ptr<bool> is_alive_;
 };
 
-TORCH_API Tensor makeTensorWrapper(const Tensor& tensor, int64_t level);
-TORCH_API TensorWrapper* maybeGetTensorWrapper(const Tensor& tensor);
-TORCH_API void dumpTensor(std::ostream & ss, const Tensor& tensor);
-TORCH_API void dumpTensorCout(const Tensor& tensor);
+FUNCTORCH_API Tensor makeTensorWrapper(const Tensor& tensor, int64_t level);
+FUNCTORCH_API TensorWrapper* maybeGetTensorWrapper(const Tensor& tensor);
+FUNCTORCH_API void dumpTensor(std::ostream & ss, const Tensor& tensor);
+FUNCTORCH_API void dumpTensorCout(const Tensor& tensor);
 
 }
 } // namespace at

--- a/functorch/csrc/VmapTransforms.h
+++ b/functorch/csrc/VmapTransforms.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <functorch/csrc/Macros.h>
 #include <functorch/csrc/BatchedTensorImpl.h>
 
 namespace at {
@@ -54,11 +55,11 @@ using VmapDimVector = SmallVector<int64_t, kVmapStaticDimVecSize>;
 // argument.
 
 // VmapTransform for operators that take tensors with multiple batch dims.
-// Given one or more logical views on Tensors, `logicalToPhysical` 
+// Given one or more logical views on Tensors, `logicalToPhysical`
 // permutes all of the batch dims to the front of the tensor, aligns
 // and expands the batch dims to match each other (according to their `level`),
 // and returns a VmapPhysicalView on the tensor(s).
-struct TORCH_API MultiBatchVmapTransform {
+struct FUNCTORCH_API MultiBatchVmapTransform {
   static VmapPhysicalView logicalToPhysical(const Tensor& logical_tensor);
   static VmapPhysicalViewVec logicalToPhysical(TensorList logical_tensors);
 };
@@ -82,7 +83,7 @@ struct TORCH_API MultiBatchVmapTransform {
 // actually *need* to return a tensor of size (1, 2) for the second tensor
 // because the broadcasting operation takes care of that for us, but we do
 // it anyways to keep things simple.
-struct TORCH_API BroadcastingVmapTransform {
+struct FUNCTORCH_API BroadcastingVmapTransform {
   static VmapPhysicalViewVec logicalToPhysical(TensorList logical_tensors);
 };
 
@@ -114,7 +115,7 @@ struct VmapPhysicalToLogicalMap;
 //              ^
 //              |
 //   levels: 012345
-struct TORCH_API VmapPhysicalView {
+struct FUNCTORCH_API VmapPhysicalView {
   VmapPhysicalView(Tensor&& tensor, std::bitset<kVmapNumLevels> levels)
       : levels_(levels), tensor_(tensor) {
     // TORCH_INTERNAL_ASSERT(!isBatchedTensor(tensor));
@@ -156,7 +157,7 @@ struct TORCH_API VmapPhysicalView {
 // to a logical one (BatchedTensor). It holds some levels that are used to do the
 // mapping and assumes that the batch dimensions in the physical tensor all
 // occur at the front of the tensor.
-struct TORCH_API VmapPhysicalToLogicalMap {
+struct FUNCTORCH_API VmapPhysicalToLogicalMap {
   VmapPhysicalToLogicalMap(std::bitset<kVmapNumLevels> levels): levels_(levels) {}
 
   // Maps a physical tensor to a new logical tensor (BatchedTensor).

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,8 @@ class clean(distutils.command.clean.clean):
 def get_extensions():
     extension = CppExtension
 
-    define_macros = []
+    # See functorch/csrc/Macros.h
+    define_macros = [('FUNCTORCH_BUILD_MAIN_LIB', None)]
 
     extra_link_args = []
     extra_compile_args = {"cxx": [


### PR DESCRIPTION
Previously we were using TORCH_API, which doesn't actually mean much for
us because it is always set to import (windows) or default visibility
(gnu). This PR changes it so that FUNCTORCH_API is set to export/import
(windows) correctly.