### PR TITLE
Macro-guard the custom_vjp prototype from windows

### DIFF
--- a/functorch/csrc/CustomFunction.cpp
+++ b/functorch/csrc/CustomFunction.cpp
@@ -1,3 +1,4 @@
+#ifndef _WIN32
 #include <functorch/csrc/CustomFunction.h>
 #include <ATen/ATen.h>
 #include <torch/csrc/autograd/function.h>
@@ -288,3 +289,4 @@ void initDispatchBindings(PyObject* module) {
 
 
 }} // at::functorch
+#endif // #ifndef _WIN32

--- a/functorch/csrc/CustomFunction.h
+++ b/functorch/csrc/CustomFunction.h
@@ -1,3 +1,6 @@
+#pragma once
+
+#ifndef _WIN32
 #include <torch/extension.h>
 #include <torch/library.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
@@ -8,3 +11,4 @@ namespace at { namespace functorch {
 void initDispatchBindings(PyObject* module);
 
 }}
+#endif // #ifndef _WIN32

--- a/functorch/csrc/init.cpp
+++ b/functorch/csrc/init.cpp
@@ -401,7 +401,11 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("set_fwd_grad_enabled", &at::functorch::set_fwd_grad_enabled);
   m.def("get_fwd_grad_enabled", &at::functorch::get_fwd_grad_enabled);
   at::functorch::initCompileCacheBindings(m.ptr());
+
+  // Windows doesn't like this
+#ifndef _WIN32
   initDispatchBindings(m.ptr());
+#endif
 }
 
 }}

--- a/test/test_eager_transforms.py
+++ b/test/test_eager_transforms.py
@@ -16,6 +16,7 @@ import warnings
 import math
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, onlyCPU
 from torch.testing._internal.common_dtype import get_all_fp_dtypes
+from torch.testing._internal.common_utils import IS_WINDOWS
 from functools import partial
 from functorch.experimental import replace_all_batch_norm_modules_
 
@@ -1998,6 +1999,7 @@ class TestJvp(TestCase):
 
 
 class TestCustomFunction(TestCase):
+    @unittest.skipIf(IS_WINDOWS, "Prototype of custom_vjp doesn't link on windows")
     @onlyCPU
     def test_basic(self, device):
         called_impl = False


### PR DESCRIPTION
I think libtorch_python does not have visibility macros set correctly
for windows, so this PR guards our custom_vjp implementation (which
relies on some C++ bits from libtorch_python).

We'll either fix libtorch_python or actually write a better version of
custom_vjp in the future.