### PR TITLE
Add mode to AOTAutograd

### DIFF
--- a/test/test_pythonkey.py
+++ b/test/test_pythonkey.py
@@ -188,6 +188,14 @@ class TestPythonKey(TestCase):
         grads2 = [a.grad for a in mod.parameters()]
         self.assertEqual(grads, grads2)
 
+    def test_factory_functions(self, device):
+        def f(x):
+            return x * torch.randn(5)
+
+        fx_f = make_fx(f)(torch.randn(5))
+        ops = set([i.target for i in fx_f.graph.nodes])
+
+        self.assertEqual(torch.ops.aten.randn in ops, True)
 
 make_fx_failures = {
     xfail('allclose'),

--- a/test/test_pythonkey.py
+++ b/test/test_pythonkey.py
@@ -192,7 +192,7 @@ class TestPythonKey(TestCase):
         def f(x):
             return x * torch.randn(5)
 
-        fx_f = make_fx(f)(torch.randn(5))
+        fx_f = make_fx(f, trace_factory_fns=True)(torch.randn(5))
         ops = set([i.target for i in fx_f.graph.nodes])
 
         self.assertEqual(torch.ops.aten.randn in ops, True)


### PR DESCRIPTION
Using a mode, AOTAutograd is able to to trace factory functions. Because the tracer is saved as state on the PythonKey, this is doing some hacky stuff using globals to make the tracing work when we only have access to the PythonKey type (which is a requirement that will be lifted [here](https://github.com/pytorch/pytorch/pull/75965))

This also adds the ability to trace as a flag passed to make_fx...not sure if that's the API we want or if we want it to be always on