### PR TITLE
functionalize(): properly handle global return tensors

### DIFF
--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -1209,6 +1209,11 @@ def _wrap_all_tensors_to_functional(tensor_pytree, level):
 def _maybe_unwrap_functional_tensor(maybe_tensor, *, reapply_views: bool):
     if not isinstance(maybe_tensor, torch.Tensor):
         return maybe_tensor
+    if not torch._is_functional_tensor(maybe_tensor):
+        # If it's not a functional tensor, just return it.
+        # This can happen if we functionalize a fn that returns a global,
+        # which was never wrapped properly.
+        return maybe_tensor
     return _unwrap_functional_tensor(maybe_tensor, reapply_views)
 
 

--- a/test/test_eager_transforms.py
+++ b/test/test_eager_transforms.py
@@ -2944,6 +2944,23 @@ def forward(self, x_1) -> torch.Tensor:
     return view_1
     """)
 
+    def test_functionalize_nonfunctional_output(self, device):
+
+        global_out = torch.ones(2, device=device)
+
+        def f() -> torch.Tensor:
+            return global_out
+
+        out = make_fx(functionalize(f))()
+        self.assertExpectedInline(out.code, """\
+
+
+
+def forward(self) -> torch.Tensor:
+    _tensor_constant0 = self._tensor_constant0
+    return _tensor_constant0
+    """)
+
 
 only_for = ("cpu", "cuda")
 instantiate_device_type_tests(


### PR DESCRIPTION
`functionalize()` would always assume that the output of the function call was a `FunctionalTensorWrapper` that it should unwrap.

That isn't true though if you have a function that just returns a global tensor, because we have no way to ensure that it gets wrapped at any point.

Fixes the `tensor_constant` repro example from https://github.com/facebookresearch/torchdynamo/issues/88. With this patch, this runs without error:
```
class FxModule(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.register_buffer('_tensor_constant1', torch.empty([512], dtype=torch.int64))


    def forward(self):
        _tensor_constant1 = self._tensor_constant1
        return (_tensor_constant1, ) 


print("Starting 4")
mod = FxModule()
def fn4():
    return mod()

ref = fn4()
res = functionalize(fn4)()
for t1, t2 in zip(ref, res):
    assert torch.allclose(t1, t2)
```

