### PR TITLE
Promote AOTAutograd decompositions to the main set

### DIFF
--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -99,19 +99,6 @@ def normalize_as_list(x):
     return [x]
 
 
-aot_autograd_decompositions = {}
-
-
-@register_decomposition([aten.rsub.Scalar, aten.rsub.Tensor], aot_autograd_decompositions)
-def rsub(a, b, alpha=1):
-    return -aten.sub(a, b)
-
-
-@register_decomposition(aten._reshape_alias, aot_autograd_decompositions)
-def _reshape_alias(x, shape, strides):
-    return aten.view(x, shape)
-
-
 def create_aot_autograd_function(
     flat_fn, fw_compiler, bw_compiler, partition_fn, decompositions, grad_state
 ):
@@ -151,7 +138,7 @@ def create_aot_autograd_function(
                     num_outs = 1
 
                 joint_inputs = (flat_tensor_args, out)
-                aot_decompositions = {**aot_autograd_decompositions, **decompositions}
+                aot_decompositions = decompositions
                 with torch.set_grad_enabled(grad_state):
                     fx_g = make_fx(joint_forward_backward, aot_decompositions)(
                         *joint_inputs

--- a/functorch/_src/decompositions.py
+++ b/functorch/_src/decompositions.py
@@ -592,3 +592,13 @@ def cudnn_batch_norm(input: Tensor, weight: Tensor, bias: Optional[Tensor], runn
 @register_decomposition(aten.cudnn_batch_norm_backward)
 def cudnn_batch_norm_backward(input: Tensor, grad_output: Tensor, weight: Tensor, running_mean: Optional[Tensor], running_var: Optional[Tensor], save_mean: Optional[Tensor], save_var: Optional[Tensor], epsilon: float, reserveSpace: Tensor):
     return aten.native_batch_norm_backward(grad_output, input, weight, running_mean, running_var, save_mean, save_var, True, epsilon, [True, True, True])
+
+
+@register_decomposition([aten.rsub.Scalar, aten.rsub.Tensor])
+def rsub(a, b, alpha=1):
+    return torch.sub(b, a, alpha=alpha)
+
+
+@register_decomposition(aten._reshape_alias)
+def _reshape_alias(x, shape, strides):
+    return aten.view(x, shape)


### PR DESCRIPTION
I want there to only be one set of decomps, so get rid of the out of line AOTAutograd decomps and clean them up.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>