### PR TITLE
Generalize get_decompositions handling for OpOverloadPackets

### DIFF
--- a/functorch/_src/decompositions.py
+++ b/functorch/_src/decompositions.py
@@ -39,11 +39,8 @@ def get_decompositions(aten_ops: List[torch._ops.OpOverload]):
     decompositions = {}
     for op in aten_ops:
         if op in packets_to_overloads:
-            if len(packets_to_overloads[op]) == 1:
-                op_overload = packets_to_overloads[op][0]
+            for op_overload in packets_to_overloads[op]:
                 decompositions[op_overload] = decomposition_table[op_overload]
-            else:
-                raise RuntimeError(f"Multiple decompositions for overloads found for {op}: {packets_to_overloads[op]}, please specify")
         elif op in decomposition_table:
             decompositions[op] = decomposition_table[op]
     return decompositions


### PR DESCRIPTION
Previously, it required only a single overload be registered to
a packet, if you asked for that packet in decompositions.  But
this is not really necessary; you could easily just return decomps
for all overloads in the packet.  This is strictly more general
and I can't imagine a situation where it's not what you want.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>