### PR TITLE
DynamicLayer uses TransformType instead of DispatchKey to identify tr…

### DIFF
--- a/functorch/csrc/DynamicLayer.h
+++ b/functorch/csrc/DynamicLayer.h
@@ -26,9 +26,19 @@ enum RandomnessType {
     END
 };
 
+enum class TransformType {
+  Torch,  // Unused
+  Vmap,
+  Grad,  // reverse-mode AD, aka vjp
+  Jvp,  // forward-mode AD
+  Functionalize,
+};
+
+std::ostream& operator<<(std::ostream& os, const TransformType& t);
+
 struct FUNCTORCH_API DynamicLayer {
   explicit DynamicLayer(
-      DispatchKey key,
+      TransformType transform_type,
       int64_t layerId,
       optional<int64_t> batchSize = nullopt,
       optional<RandomnessType> randomness = nullopt,
@@ -36,7 +46,7 @@ struct FUNCTORCH_API DynamicLayer {
       optional<bool> pre_fwd_grad_mode = nullopt,
       optional<bool> functionalize_add_back_views = nullopt);
 
-  DispatchKey key() const;
+  TransformType key() const;
   int64_t layerId() const;
 
   // Only valid for vmap
@@ -56,7 +66,7 @@ struct FUNCTORCH_API DynamicLayer {
   // only valid for functionalization
   optional<bool> functionalizeAddBackViews() const;
  private:
-  DispatchKey key_;
+  TransformType transform_type_;
   int64_t layerId_;
 
   // Honestly these should be a union or some extendable metadata class.
@@ -72,7 +82,7 @@ struct FUNCTORCH_API DynamicLayer {
 };
 
 FUNCTORCH_API int64_t initAndPushDynamicLayer(
-    DispatchKey key,
+    TransformType transform_type,
     optional<int64_t> batch_size = nullopt,
     optional<RandomnessType> randomness = nullopt,
     optional<bool> prev_grad_mode = nullopt,

--- a/functorch/csrc/init.cpp
+++ b/functorch/csrc/init.cpp
@@ -214,44 +214,44 @@ bool get_fwd_grad_enabled() {
 int64_t _grad_increment_nesting() {
   // See NOTE [grad and vjp interaction with no_grad]
   bool prev_grad_mode = c10::GradMode::is_enabled();
-  return initAndPushDynamicLayer(at::DispatchKey::Autograd, nullopt, nullopt, prev_grad_mode);
+  return initAndPushDynamicLayer(TransformType::Grad, nullopt, nullopt, prev_grad_mode);
 }
 
 int64_t _grad_decrement_nesting() {
   auto layer = popDynamicLayerAndDeleteMetadata();
-  TORCH_INTERNAL_ASSERT(layer.key() == DispatchKey::Autograd);
+  TORCH_INTERNAL_ASSERT(layer.key() == TransformType::Grad);
   return layer.layerId();
 }
 
 int64_t _jvp_increment_nesting() {
   // See NOTE [grad and vjp interaction with no_grad]
   bool prev_fwd_grad_mode = get_fwd_grad_enabled();
-  return initAndPushDynamicLayer(at::DispatchKey::Autograd, nullopt, nullopt, nullopt, prev_fwd_grad_mode);
+  return initAndPushDynamicLayer(TransformType::Jvp, nullopt, nullopt, nullopt, prev_fwd_grad_mode);
 }
 
 int64_t _jvp_decrement_nesting() {
   auto layer = popDynamicLayerAndDeleteMetadata();
-  TORCH_INTERNAL_ASSERT(layer.key() == DispatchKey::Autograd);
+  TORCH_INTERNAL_ASSERT(layer.key() == TransformType::Jvp);
   return layer.layerId();
 }
 
 int64_t _vmap_increment_nesting(int64_t batch_size, const std::string& randomness) {
-  return initAndPushDynamicLayer(kBatchedKey, batch_size, get_randomness_enum(randomness));
+  return initAndPushDynamicLayer(TransformType::Vmap, batch_size, get_randomness_enum(randomness));
 }
 
 int64_t _vmap_decrement_nesting() {
   auto layer = popDynamicLayerAndDeleteMetadata();
-  TORCH_INTERNAL_ASSERT(layer.key() == kBatchedKey);
+  TORCH_INTERNAL_ASSERT(layer.key() == TransformType::Vmap);
   return layer.layerId();
 }
 
 int64_t _func_increment_nesting(bool reapply_views) {
-  return initAndPushDynamicLayer(DispatchKey::Functionalize, c10::nullopt, c10::nullopt, c10::nullopt, c10::nullopt, /*functionalize_add_back_views=*/reapply_views);
+  return initAndPushDynamicLayer(TransformType::Functionalize, c10::nullopt, c10::nullopt, c10::nullopt, c10::nullopt, /*functionalize_add_back_views=*/reapply_views);
 }
 
 int64_t _func_decrement_nesting() {
   auto layer = popDynamicLayerAndDeleteMetadata();
-  TORCH_INTERNAL_ASSERT(layer.key() == DispatchKey::Functionalize);
+  TORCH_INTERNAL_ASSERT(layer.key() == TransformType::Functionalize);
   return layer.layerId();
 }
 


### PR DESCRIPTION
…ansforms

Previously, we relied on c10::DispatchKey as the identification for a
transform. This was a little weird, because the grad and jvp tranforms
both mapped to DispatchKey::Autograd, and the vmap transform has 2
different dispatchkeys (VmapMode, Batched).

This PR changes it so that there is a single TransformType enum that is
used to identify the transform.