### PR TITLE
fix at::linear numeric accuracy for functorch, add test

### DIFF
--- a/test/test_eager_transforms.py
+++ b/test/test_eager_transforms.py
@@ -2858,6 +2858,20 @@ class TestFunctionalize(TestCase):
             return y
         self._check_functionalize_correctness(f, torch.zeros(4, 2, device=device))
 
+    # See https://github.com/pytorch/functorch/issues/780
+    def test_linear(self, device):
+
+        def f(x, y, z) -> torch.Tensor:
+            return torch._C._nn.linear(x, y, z)
+
+        x = torch.randn(14, 1, 384, device=device)
+        y = torch.randn(96, 384, device=device)
+        z = torch.randn(96, device=device)
+
+        out_expected = f(x, y, z)
+        out_actual = functionalize(f)(x, y, z)
+        self.assertEqual(out_expected, out_actual)
+
     def test_multioutput_inplace_slice_view(self, device):
 
         def f(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
This should fix #780.

cc @Chillee @zou3519, would it be reasonable to make the `aten::linear` op composite compliant instead, so you don't have to worry about keeping the code in sync from in core? Not 100% sure but I think you can do the same "if isSubclassLike()" stuff in `linear`.