### PR TITLE
Make jvpvjp actually run all the tests for decompositions

### DIFF
--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -1302,6 +1302,7 @@ def _register_jit_decomposition(decomp, use_python=False):
 
 _register_jit_decomposition(torch.ops.aten.trace.default)
 _register_jit_decomposition(torch.ops.aten.nll_loss_backward.default)
+_register_jit_decomposition(torch.ops.aten.nll_loss2d_backward.default)
 _register_jit_decomposition(torch.ops.aten.mse_loss_backward.default)
 _register_jit_decomposition(torch.ops.aten.l1_loss_backward.default)
 _register_jit_decomposition(torch.ops.aten._log_softmax_backward_data.default)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1259,10 +1259,9 @@ class TestOperators(TestCase):
                 if op.name == 'nn.functional.binary_cross_entropy':  # reverse second derivative wrt target not defined
                     in_dims = 1
                 compare_jacobians(primals, cotangents, in_dims)
-                return
-
-            expected = reference(primals, cotangents, primals_tangents, cotangents_tangents)
-            self.assertEqual(result, expected)
+            else:
+                expected = reference(primals, cotangents, primals_tangents, cotangents_tangents)
+                self.assertEqual(result, expected)
 
     @ops(filter(lambda op: op.name == "nn.functional.group_norm", functorch_lagging_op_db + additional_op_db),
          allowed_dtypes=(torch.float32, torch.double))  # TODO: generalize


### PR DESCRIPTION
jvpvjp for decompositions was only running one sample per opinfo. This fixes that

This is currently broken since `nll_loss2d_backward` doesn't have actually have a decomposition and this is finally hitting that case for 2 tests