### PR TITLE
Disable autocast

### DIFF
--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -187,23 +187,26 @@ def create_aot_autograd_function(
                 fw_module, bw_module = partition_fn(fx_g, joint_inputs)
                 # print(fw_module.code, bw_module.code)
 
-                compiled_fw = fw_compiler(fw_module, flat_tensor_args)
-                fw_outs = normalize_as_list(compiled_fw(*flat_tensor_args))
+                with torch.cuda.amp.autocast(enabled=False):
+                    compiled_fw = fw_compiler(fw_module, flat_tensor_args)
+                    fw_outs = normalize_as_list(compiled_fw(*flat_tensor_args))
 
-                bw_args = fw_outs[num_outs:] + fw_outs[0:num_outs]
-                compiled_bw = bw_compiler(bw_module, bw_args)
+                    bw_args = fw_outs[num_outs:] + fw_outs[0:num_outs]
+                    compiled_bw = bw_compiler(bw_module, bw_args)
             else:
-                fw_outs = normalize_as_list(compiled_fw(*flat_tensor_args))
+                with torch.cuda.amp.autocast(enabled=False):
+                    fw_outs = normalize_as_list(compiled_fw(*flat_tensor_args))
             ctx.save_for_backward(*fw_outs[num_outs:])
             return tuple(fw_outs[0:num_outs])
 
         @staticmethod
         @disable_torchdynamo
         def backward(ctx, *flat_args):
-            contiguous_args = [t.contiguous() for t in flat_args]
-            # contiguous_args = [t for t in flat_args]
-            out = normalize_as_list(compiled_bw(*ctx.saved_tensors, *contiguous_args))
-            return tuple(out)
+            with torch.cuda.amp.autocast(enabled=False):
+                contiguous_args = [t.contiguous() for t in flat_args]
+                # contiguous_args = [t for t in flat_args]
+                out = normalize_as_list(compiled_bw(*ctx.saved_tensors, *contiguous_args))
+                return tuple(out)
 
     return CompiledFunction
 

--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -161,6 +161,7 @@ def create_aot_autograd_function(
         def forward(ctx, *flat_tensor_args):
             nonlocal compiled_fw, compiled_bw, num_outs
             # Disable the JIT Autocast flag to prevent re-autocasting of jitted graph.
+            # TODO - Remove when https://github.com/pytorch/functorch/pull/794 is fixed.
             old_jit_autocast_flag = torch._C._jit_set_autocast_mode(False)
             if compiled_fw is None:
                 with preserve_rng_state():
@@ -204,6 +205,7 @@ def create_aot_autograd_function(
         @disable_torchdynamo
         def backward(ctx, *flat_args):
             # Disable the JIT Autocast flag to prevent re-autocasting of jitted graph.
+            # TODO - Remove when https://github.com/pytorch/functorch/pull/794 is fixed.
             old_jit_autocast_flag = torch._C._jit_set_autocast_mode(False)
             contiguous_args = [t.contiguous() for t in flat_args]
             # contiguous_args = [t for t in flat_args]


### PR DESCRIPTION
With AMP, AOT Autograd traced graph already reflects the AMP modifications.

However, Torchscript does not know that, and can try to AMP-ify already AMP-ified AOTAutograd traced graph, resulting in weird type promotion errors.


Concern (and that's why WIP) - Calling `with` for each forward and backward pass, might add overhead. Is there any better way?