### PR TITLE
make sync logic more accurate for functionalization

### DIFF
--- a/functorch/csrc/init.cpp
+++ b/functorch/csrc/init.cpp
@@ -53,10 +53,7 @@ void _propagate_functional_input_mutation(const Tensor& unwrapped, const Tensor&
   TORCH_INTERNAL_ASSERT(!at::functionalization::impl::isFunctionalTensor(unwrapped));
   auto wrapped_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(wrapped);
   // Ensure that the input is up to date by committing any pending updates to the alias.
-  bool any_updates = wrapped_impl->apply_updates();
-  if (any_updates) {
-    wrapped_impl->regenerate_from_base();
-  }
+  wrapped_impl->sync_();
   auto& wrapped_inner = wrapped_impl->value();
   // It would probably be more reasonable to check that the two tensors are aliased,
   // but we can't do that unless we give BatchedTensorImpl a notion of storage.


### PR DESCRIPTION
Richard left a comment here a while ago that I forgot about: https://github.com/pytorch/functorch/pull/235#discussion_r760258758

I had a crappy fix  for ensuring that `functionalize()` doesn't emit extra unnecessary `view_copy` ops that was actually wrong in some cases, but this should really fix it