### PR TITLE
Add extremal testing for forward over reverse using decompositions 

### DIFF
--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -1306,7 +1306,7 @@ def _register_jit_decomposition(decomp, use_python=False):
 
 
 _register_jit_decomposition(torch.ops.aten.trace.default)
-_register_jit_decomposition(torch.ops.aten.nll_loss_backward.default)
+_register_jit_decomposition(torch.ops.aten.nll_loss_backward.default, use_python=True)
 _register_jit_decomposition(torch.ops.aten.nll_loss2d_backward.default)
 _register_jit_decomposition(torch.ops.aten.mse_loss_backward.default)
 _register_jit_decomposition(torch.ops.aten.l1_loss_backward.default)

--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -1306,7 +1306,7 @@ def _register_jit_decomposition(decomp, use_python=False):
 
 
 _register_jit_decomposition(torch.ops.aten.trace.default)
-_register_jit_decomposition(torch.ops.aten.nll_loss_backward.default, use_python=True)
+_register_jit_decomposition(torch.ops.aten.nll_loss_backward.default)
 _register_jit_decomposition(torch.ops.aten.nll_loss2d_backward.default)
 _register_jit_decomposition(torch.ops.aten.mse_loss_backward.default)
 _register_jit_decomposition(torch.ops.aten.l1_loss_backward.default)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
+
 from torch.testing._internal.common_utils import TestCase, run_tests, is_iterable_of_tensors
 import torch
 from torch import Tensor
@@ -1102,6 +1104,24 @@ class TestOperators(TestCase):
 
                 self.assertEqual(result_vjps, expected_vjps)
 
+    def _compare_jacobians(self, fn, cotangents_and_primals, argnums, atol_rtol=None):
+        def get_vjp(cotangents, *primals):
+            _, vjp_fn = vjp(fn, *primals)
+            return vjp_fn(cotangents)
+
+        jacobian_jvp = jacfwd(get_vjp, argnums)(*cotangents_and_primals)
+        jacobian_vjp = jacrev(get_vjp, argnums)(*cotangents_and_primals)
+
+        # For dtype changing operations, the jacobians have different dtype.
+        jacobian_jvp = tree_map(lambda x: x.to(torch.float), jacobian_jvp)
+        jacobian_vjp = tree_map(lambda x: x.to(torch.float), jacobian_vjp)
+
+        if atol_rtol is not None:
+            (atol, rtol) = atol_rtol
+            self.assertEqual(jacobian_jvp, jacobian_vjp, atol=atol, rtol=rtol)
+        else:
+            self.assertEqual(jacobian_jvp, jacobian_vjp)
+
     @ops(functorch_lagging_op_db + additional_op_db, allowed_dtypes=(torch.float,))
     @skipOps('TestOperators', 'test_jvpvjp', vjp_fail.union({
         # These are weirdly non-deterministic
@@ -1223,24 +1243,6 @@ class TestOperators(TestCase):
                     expected = (tree_unflatten(primals_out, spec), tree_unflatten(tangents_out, spec))
                 return expected
 
-            def compare_jacobians(cotangents_and_primals, in_dims, atol_rtol):
-                def get_vjp(cotangents, *primals):
-                    _, vjp_fn = vjp(fn, *primals)
-                    return vjp_fn(cotangents)
-
-                jacobian_jvp = jacfwd(get_vjp, in_dims)(*cotangents_and_primals)
-                jacobian_vjp = jacrev(get_vjp, in_dims)(*cotangents_and_primals)
-
-                # For dtype changing operations, the jacobians have different dtype.
-                jacobian_jvp = tree_map(lambda x: x.to(torch.float), jacobian_jvp)
-                jacobian_vjp = tree_map(lambda x: x.to(torch.float), jacobian_vjp)
-
-                if atol_rtol is not None:
-                    (atol, rtol) = atol_rtol
-                    self.assertEqual(jacobian_jvp, jacobian_vjp, atol=atol, rtol=rtol)
-                else:
-                    self.assertEqual(jacobian_jvp, jacobian_vjp)
-
             # HACK: obviously pytorch should also have the same coverage
             # For things that do have the same coverage, we test that jvp x vjp
             # are the same between PyTorch and functorch. For things that don't,
@@ -1261,15 +1263,157 @@ class TestOperators(TestCase):
                     return isinstance(t, torch.Tensor) and t.dtype == torch.float32
                 args = (cotangents, *primals)
                 if op.name == 'nn.functional.binary_cross_entropy':
-                    in_dims = (0, 1)  # targets is float32 but isn't differentiable
+                    argnums = (0, 1)  # targets is float32 but isn't differentiable
                     atol_rtol = 1.5E-4, 1.3e-06
                 else:
-                    in_dims = tuple(i for i in range(len(args)) if is_differentiable(args[i]))
+                    argnums = tuple(i for i in range(len(args)) if is_differentiable(args[i]))
                     atol_rtol = None
-                compare_jacobians(args, in_dims, atol_rtol)
+                self._compare_jacobians(fn, args, argnums, atol_rtol)
             else:
                 expected = reference(primals, cotangents, primals_tangents, cotangents_tangents)
                 self.assertEqual(result, expected)
+
+    def _make_extremal_inputs(self, shape, device):
+        if shape == None:
+            return (None,)
+        return (
+            torch.full(shape, -1000., device=device),
+            torch.zeros(shape, device=device),
+            torch.full(shape, 1000., device=device),
+        )
+
+    def _arg_and_kwarg_options(self, args_options, kwargs_options):
+        return itertools.product(*args_options, kwargs_options)
+
+    def test_extremal_numerics_nll_loss(self, device):
+        N, C = 3, 4
+        d1, d2, d3 = 5, 6, 7
+        shapes = (
+            # ((N, C), (N,), (C,)),
+            ((N, C), (N,), None),
+            # ((N, C, d1, d2, d3), (N, d1, d2, d3), (C,)),
+            ((N, C, d1, d2, d3), (N, d1, d2, d3), None),
+        )
+        kwargs_options = ({'ignore_index': 0, 'reduction': 'mean'}, {'reduction': 'sum'}, {'reduction': 'none'}, {})
+        for input_shape, target_shape, weight_shape in shapes:
+            input_options = self._make_extremal_inputs(input_shape, device)
+            weight_options = self._make_extremal_inputs(weight_shape, device)
+            for input, weight, kwargs in self._arg_and_kwarg_options((input_options, weight_options), kwargs_options):
+                target = torch.randint(0, C, target_shape, device=device)
+                fn = functools.partial(torch.nn.functional.nll_loss, target=target, weight=weight, **kwargs)
+                result = fn(input)
+                cotangents = torch.randn_like(result)
+                self._compare_jacobians(fn, (cotangents, input), argnums=(0, 1))
+
+    def test_extremal_numerics_l1_loss(self, device):
+        N, C, H, W = 3, 4, 5, 6
+        shapes = ((N, C), (N, C, H), (N, C, H, W))
+        kwargs_options = ({'reduction': 'sum'}, {'reduction': 'none'}, {})
+        for shape in shapes:
+            input_options = self._make_extremal_inputs(shape, device)
+            target_options = self._make_extremal_inputs(shape, device)
+            for input, target, kwargs in self._arg_and_kwarg_options((input_options, target_options), kwargs_options):
+                result = torch.nn.functional.l1_loss(input, target)
+                cotangents = torch.randn_like(result)
+                self._compare_jacobians(torch.nn.functional.l1_loss, (cotangents, input, target), argnums=(0, 1, 2))
+
+    def test_extremal_numerics_mse_loss(self, device):
+        N, C, H, W = 3, 4, 5, 6
+        shapes = ((N, C), (N, C, H), (N, C, H, W))
+        kwargs_options = ({'reduction': 'sum'}, {'reduction': 'none'}, {})
+        for shape in shapes:
+            input_options = self._make_extremal_inputs(shape, device)
+            target_options = self._make_extremal_inputs(shape, device)
+            for input, target, kwargs in self._arg_and_kwarg_options((input_options, target_options), kwargs_options):
+                result = torch.nn.functional.mse_loss(input, target)
+                cotangents = torch.randn_like(result)
+                self._compare_jacobians(torch.nn.functional.mse_loss, (cotangents, input, target), argnums=(0, 1, 2))
+
+    def test_extremal_numerics_softmax(self, device):
+        N, C, H, W = 3, 4, 5, 6
+        shapes = ((N, C), (N, C, H), (N, C, H, W))
+        kwargs_options = ({'dim': 1}, {})
+        for shape in shapes:
+            input_options = self._make_extremal_inputs(shape, device)
+            for input, kwargs in self._arg_and_kwarg_options((input_options,), kwargs_options):
+                result = torch.nn.functional.softmax(input)
+                cotangents = torch.randn_like(result)
+                self._compare_jacobians(torch.nn.functional.softmax, (cotangents, input), argnums=(0, 1))
+
+
+    def test_extremal_numerics_log_softmax(self, device):
+        N, C, H, W = 3, 4, 5, 6
+        shapes = ((N, C), (N, C, H), (N, C, H, W))
+        kwargs_options = ({'dim': 1}, {})
+        for shape in shapes:
+            input_options = self._make_extremal_inputs(shape, device)
+            for input, kwargs in self._arg_and_kwarg_options((input_options,), kwargs_options):
+                result = torch.nn.functional.log_softmax(input)
+                cotangents = torch.randn_like(result)
+                self._compare_jacobians(torch.nn.functional.log_softmax, (cotangents, input), argnums=(0, 1))
+
+    def test_extremal_numerics_cross_entropy(self, device):
+        N, C = 3, 4
+        d1, d2, d3 = 5, 6, 7
+        shapes = (
+            # ((N, C), (N,), (C,)),
+            # ((N, C), (N,), None),
+            ((N, C), (N, C), (C,)),
+            ((N, C), (N, C), None),
+            # ((C,), (), (C,)),
+            # ((C,), (), None),
+            # ((N, C, d1, d2, d3), (N, d1, d2, d3), (C,)),
+            ((N, C, d1, d2, d3), (N, d1, d2, d3), None),
+            ((N, C, d1, d2, d3), (N, C, d1, d2, d3), (C,)),
+            ((N, C, d1, d2, d3), (N, C, d1, d2, d3), None),
+        )
+        for input_shape, target_shape, weight_shape in shapes:
+            input_options = self._make_extremal_inputs(input_shape, device)
+            weight_options = self._make_extremal_inputs(weight_shape, device)
+            kwargs_options = [{'reduction': 'sum'}, {'reduction': 'none'}, {}]
+            if input_shape != target_shape:
+                kwargs_options.append({'ignore_index': 0, 'reduction': 'mean'})
+
+            for input, weight, kwargs in self._arg_and_kwarg_options((input_options, weight_options), kwargs_options):
+                if input_shape == target_shape:
+                    target = torch.rand(target_shape, device=device)
+                else:
+                    target = torch.randint(0, C, target_shape, device=device)
+                fn = functools.partial(torch.nn.functional.cross_entropy, target=target, weight=weight, **kwargs)
+                result = fn(input)
+                cotangents = torch.randn_like(result)
+                self._compare_jacobians(fn, (cotangents, input), argnums=(0, 1), atol_rtol=(1e-4, 1e-5))
+
+    def test_extremal_numerics_binary_cross_entropy(self, device):
+        N, C, H, W = 3, 4, 5, 6
+        shapes = ((N, C), (N, C, H), (N, C, H, W))
+        for shape in shapes:
+            weight_options = self._make_extremal_inputs(shape, device)
+            kwargs_options = [{'reduction': 'sum'}, {'reduction': 'none'}, {}]
+
+            for weight, kwargs in self._arg_and_kwarg_options((weight_options,), kwargs_options):
+                input = torch.rand(shape, device=device)
+                target = torch.rand(shape, device=device)
+                fn = functools.partial(torch.nn.functional.binary_cross_entropy, target=target, weight=weight, **kwargs)
+                result = fn(input)
+                cotangents = torch.randn_like(result)
+                self._compare_jacobians(fn, (cotangents, input), argnums=(0, 1), atol_rtol=(1e-4, 2e-5))
+
+    def test_extremal_numerics_layer_norm(self, device):
+        N, C, H, W = 3, 4, 5, 6
+        shapes = ((N, C), (N, C, H), (N, C, H, W))
+        for shape in shapes:
+            input_options = self._make_extremal_inputs(shape, device)
+            normalized_shape = shape[1:]
+            weight_options = self._make_extremal_inputs(normalized_shape, device)
+            bias_options = self._make_extremal_inputs(normalized_shape, device)
+
+            for input, bias, weight in self._arg_and_kwarg_options((input_options, bias_options, weight_options), ()):
+                def fn(input, weight, bias):
+                    return torch.nn.functional.layer_norm(input, normalized_shape, weight=weight, bias=bias)
+                result = fn(input, weight, bias)
+                cotangents = torch.randn_like(result)
+                self._compare_jacobians(fn, (cotangents, input, weight, bias), argnums=(0, 1, 2, 3))
 
     @ops(filter(lambda op: op.name == "nn.functional.group_norm", functorch_lagging_op_db + additional_op_db),
          allowed_dtypes=(torch.float32, torch.double))  # TODO: generalize

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1304,13 +1304,13 @@ class TestOperators(TestCase):
                 if weight_shape is None:
                     weight = None
                 else:
-                    weight = torch.randn(weight_shape)
+                    weight = torch.randn(weight_shape, device=device)
                 target = torch.randint(0, C, target_shape, device=device)
                 target[0] = 1  # since we're ignoring index 0, at least one element must be non-zero
 
                 fn = functools.partial(torch.nn.functional.nll_loss, target=target, weight=weight, **kwargs)
                 result = fn(input)
-                cotangents = torch.randn_like(result)
+                cotangents = torch.randn_like(result, device=device)
                 self._compare_jacobians_of_vjp(fn, (cotangents, input))
 
     def test_extremal_numerics_l1_loss(self, device):
@@ -1322,7 +1322,7 @@ class TestOperators(TestCase):
             target_options = self._make_extremal_inputs(shape, device)
             for input, target, kwargs in self._arg_and_kwarg_options((input_options, target_options), kwargs_options):
                 result = torch.nn.functional.l1_loss(input, target)
-                cotangents = torch.randn_like(result)
+                cotangents = torch.randn_like(result, device=device)
                 self._compare_jacobians_of_vjp(torch.nn.functional.l1_loss, (cotangents, input, target))
 
     def test_extremal_numerics_mse_loss(self, device):
@@ -1334,7 +1334,7 @@ class TestOperators(TestCase):
             target_options = self._make_extremal_inputs(shape, device)
             for input, target, kwargs in self._arg_and_kwarg_options((input_options, target_options), kwargs_options):
                 result = torch.nn.functional.mse_loss(input, target)
-                cotangents = torch.randn_like(result)
+                cotangents = torch.randn_like(result, device=device)
                 self._compare_jacobians_of_vjp(torch.nn.functional.mse_loss, (cotangents, input, target))
 
     def test_extremal_numerics_softmax(self, device):
@@ -1345,7 +1345,7 @@ class TestOperators(TestCase):
             input_options = self._make_extremal_inputs(shape, device)
             for input, kwargs in self._arg_and_kwarg_options((input_options,), kwargs_options):
                 result = torch.nn.functional.softmax(input)
-                cotangents = torch.randn_like(result)
+                cotangents = torch.randn_like(result, device=device)
                 self._compare_jacobians_of_vjp(torch.nn.functional.softmax, (cotangents, input))
 
 
@@ -1357,7 +1357,7 @@ class TestOperators(TestCase):
             input_options = self._make_extremal_inputs(shape, device)
             for input, kwargs in self._arg_and_kwarg_options((input_options,), kwargs_options):
                 result = torch.nn.functional.log_softmax(input)
-                cotangents = torch.randn_like(result)
+                cotangents = torch.randn_like(result, device=device)
                 self._compare_jacobians_of_vjp(torch.nn.functional.log_softmax, (cotangents, input))
 
     def test_extremal_numerics_cross_entropy(self, device):
@@ -1387,18 +1387,18 @@ class TestOperators(TestCase):
                 if weight_shape is None:
                     weight = None
                 else:
-                    weight = torch.randn(weight_shape)
+                    weight = torch.randn(weight_shape, device=device)
 
                 if input_shape == target_shape:
                     target = torch.rand(target_shape, device=device)
                 elif len(target_shape) == 0:
-                    target = torch.tensor(1)  # must be non-zero since we're ignoring index 0 for one kwarg
+                    target = torch.tensor(1, device=device)  # must be non-zero since ignore_index may be 0
                 else:
                     target = torch.randint(0, C, target_shape, device=device)
 
                 fn = functools.partial(torch.nn.functional.cross_entropy, target=target, weight=weight, **kwargs)
                 result = fn(input)
-                cotangents = torch.randn_like(result)
+                cotangents = torch.randn_like(result, device=device)
                 self._compare_jacobians_of_vjp(fn, (cotangents, input), atol_rtol=(1e-4, 1e-5))
 
     def test_extremal_numerics_binary_cross_entropy(self, device):
@@ -1413,7 +1413,7 @@ class TestOperators(TestCase):
                 target = torch.rand(shape, device=device)
                 fn = functools.partial(torch.nn.functional.binary_cross_entropy, target=target, weight=weight, **kwargs)
                 result = fn(input)
-                cotangents = torch.randn_like(result)
+                cotangents = torch.randn_like(result, device=device)
                 self._compare_jacobians_of_vjp(fn, (cotangents, input), atol_rtol=(1e-4, 2e-5))
 
     def test_extremal_numerics_layer_norm(self, device):
@@ -1429,7 +1429,7 @@ class TestOperators(TestCase):
                 def fn(input, weight, bias):
                     return torch.nn.functional.layer_norm(input, normalized_shape, weight=weight, bias=bias)
                 result = fn(input, weight, bias)
-                cotangents = torch.randn_like(result)
+                cotangents = torch.randn_like(result, device=device)
                 self._compare_jacobians_of_vjp(fn, (cotangents, input, weight, bias))
 
     @ops(filter(lambda op: op.name == "nn.functional.group_norm", functorch_lagging_op_db + additional_op_db),

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1104,7 +1104,7 @@ class TestOperators(TestCase):
 
                 self.assertEqual(result_vjps, expected_vjps)
 
-    def _compare_jacobians(self, fn, cotangents_and_primals, argnums=None, atol_rtol=None):
+    def _compare_jacobians_of_vjp(self, fn, cotangents_and_primals, argnums=None, atol_rtol=None):
         if argnums is None:
             argnums = tuple(range(len(cotangents_and_primals)))
 
@@ -1271,7 +1271,7 @@ class TestOperators(TestCase):
                 else:
                     argnums = tuple(i for i in range(len(args)) if is_differentiable(args[i]))
                     atol_rtol = None
-                self._compare_jacobians(fn, args, argnums, atol_rtol)
+                self._compare_jacobians_of_vjp(fn, args, argnums, atol_rtol)
             else:
                 expected = reference(primals, cotangents, primals_tangents, cotangents_tangents)
                 self.assertEqual(result, expected)
@@ -1311,7 +1311,7 @@ class TestOperators(TestCase):
                 fn = functools.partial(torch.nn.functional.nll_loss, target=target, weight=weight, **kwargs)
                 result = fn(input)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(fn, (cotangents, input))
+                self._compare_jacobians_of_vjp(fn, (cotangents, input))
 
     def test_extremal_numerics_l1_loss(self, device):
         N, C, H, W = 3, 4, 5, 6
@@ -1323,7 +1323,7 @@ class TestOperators(TestCase):
             for input, target, kwargs in self._arg_and_kwarg_options((input_options, target_options), kwargs_options):
                 result = torch.nn.functional.l1_loss(input, target)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(torch.nn.functional.l1_loss, (cotangents, input, target))
+                self._compare_jacobians_of_vjp(torch.nn.functional.l1_loss, (cotangents, input, target))
 
     def test_extremal_numerics_mse_loss(self, device):
         N, C, H, W = 3, 4, 5, 6
@@ -1335,7 +1335,7 @@ class TestOperators(TestCase):
             for input, target, kwargs in self._arg_and_kwarg_options((input_options, target_options), kwargs_options):
                 result = torch.nn.functional.mse_loss(input, target)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(torch.nn.functional.mse_loss, (cotangents, input, target))
+                self._compare_jacobians_of_vjp(torch.nn.functional.mse_loss, (cotangents, input, target))
 
     def test_extremal_numerics_softmax(self, device):
         N, C, H, W = 3, 4, 5, 6
@@ -1346,7 +1346,7 @@ class TestOperators(TestCase):
             for input, kwargs in self._arg_and_kwarg_options((input_options,), kwargs_options):
                 result = torch.nn.functional.softmax(input)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(torch.nn.functional.softmax, (cotangents, input))
+                self._compare_jacobians_of_vjp(torch.nn.functional.softmax, (cotangents, input))
 
 
     def test_extremal_numerics_log_softmax(self, device):
@@ -1358,7 +1358,7 @@ class TestOperators(TestCase):
             for input, kwargs in self._arg_and_kwarg_options((input_options,), kwargs_options):
                 result = torch.nn.functional.log_softmax(input)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(torch.nn.functional.log_softmax, (cotangents, input))
+                self._compare_jacobians_of_vjp(torch.nn.functional.log_softmax, (cotangents, input))
 
     def test_extremal_numerics_cross_entropy(self, device):
         N, C = 3, 4
@@ -1399,7 +1399,7 @@ class TestOperators(TestCase):
                 fn = functools.partial(torch.nn.functional.cross_entropy, target=target, weight=weight, **kwargs)
                 result = fn(input)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(fn, (cotangents, input), atol_rtol=(1e-4, 1e-5))
+                self._compare_jacobians_of_vjp(fn, (cotangents, input), atol_rtol=(1e-4, 1e-5))
 
     def test_extremal_numerics_binary_cross_entropy(self, device):
         N, C, H, W = 3, 4, 5, 6
@@ -1414,7 +1414,7 @@ class TestOperators(TestCase):
                 fn = functools.partial(torch.nn.functional.binary_cross_entropy, target=target, weight=weight, **kwargs)
                 result = fn(input)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(fn, (cotangents, input), atol_rtol=(1e-4, 2e-5))
+                self._compare_jacobians_of_vjp(fn, (cotangents, input), atol_rtol=(1e-4, 2e-5))
 
     def test_extremal_numerics_layer_norm(self, device):
         N, C, H, W = 3, 4, 5, 6
@@ -1430,7 +1430,7 @@ class TestOperators(TestCase):
                     return torch.nn.functional.layer_norm(input, normalized_shape, weight=weight, bias=bias)
                 result = fn(input, weight, bias)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(fn, (cotangents, input, weight, bias))
+                self._compare_jacobians_of_vjp(fn, (cotangents, input, weight, bias))
 
     @ops(filter(lambda op: op.name == "nn.functional.group_norm", functorch_lagging_op_db + additional_op_db),
          allowed_dtypes=(torch.float32, torch.double))  # TODO: generalize

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1104,7 +1104,10 @@ class TestOperators(TestCase):
 
                 self.assertEqual(result_vjps, expected_vjps)
 
-    def _compare_jacobians(self, fn, cotangents_and_primals, argnums, atol_rtol=None):
+    def _compare_jacobians(self, fn, cotangents_and_primals, argnums=None, atol_rtol=None):
+        if argnums is None:
+            argnums = tuple(range(len(cotangents_and_primals)))
+
         def get_vjp(cotangents, *primals):
             _, vjp_fn = vjp(fn, *primals)
             return vjp_fn(cotangents)
@@ -1264,7 +1267,7 @@ class TestOperators(TestCase):
                 args = (cotangents, *primals)
                 if op.name == 'nn.functional.binary_cross_entropy':
                     argnums = (0, 1)  # targets is float32 but isn't differentiable
-                    atol_rtol = 1.5E-4, 1.3e-06
+                    atol_rtol = 1.5e-4, 1.3e-06
                 else:
                     argnums = tuple(i for i in range(len(args)) if is_differentiable(args[i]))
                     atol_rtol = None
@@ -1308,7 +1311,7 @@ class TestOperators(TestCase):
                 fn = functools.partial(torch.nn.functional.nll_loss, target=target, weight=weight, **kwargs)
                 result = fn(input)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(fn, (cotangents, input), argnums=(0, 1))
+                self._compare_jacobians(fn, (cotangents, input))
 
     def test_extremal_numerics_l1_loss(self, device):
         N, C, H, W = 3, 4, 5, 6
@@ -1320,7 +1323,7 @@ class TestOperators(TestCase):
             for input, target, kwargs in self._arg_and_kwarg_options((input_options, target_options), kwargs_options):
                 result = torch.nn.functional.l1_loss(input, target)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(torch.nn.functional.l1_loss, (cotangents, input, target), argnums=(0, 1, 2))
+                self._compare_jacobians(torch.nn.functional.l1_loss, (cotangents, input, target))
 
     def test_extremal_numerics_mse_loss(self, device):
         N, C, H, W = 3, 4, 5, 6
@@ -1332,7 +1335,7 @@ class TestOperators(TestCase):
             for input, target, kwargs in self._arg_and_kwarg_options((input_options, target_options), kwargs_options):
                 result = torch.nn.functional.mse_loss(input, target)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(torch.nn.functional.mse_loss, (cotangents, input, target), argnums=(0, 1, 2))
+                self._compare_jacobians(torch.nn.functional.mse_loss, (cotangents, input, target))
 
     def test_extremal_numerics_softmax(self, device):
         N, C, H, W = 3, 4, 5, 6
@@ -1343,7 +1346,7 @@ class TestOperators(TestCase):
             for input, kwargs in self._arg_and_kwarg_options((input_options,), kwargs_options):
                 result = torch.nn.functional.softmax(input)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(torch.nn.functional.softmax, (cotangents, input), argnums=(0, 1))
+                self._compare_jacobians(torch.nn.functional.softmax, (cotangents, input))
 
 
     def test_extremal_numerics_log_softmax(self, device):
@@ -1355,7 +1358,7 @@ class TestOperators(TestCase):
             for input, kwargs in self._arg_and_kwarg_options((input_options,), kwargs_options):
                 result = torch.nn.functional.log_softmax(input)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(torch.nn.functional.log_softmax, (cotangents, input), argnums=(0, 1))
+                self._compare_jacobians(torch.nn.functional.log_softmax, (cotangents, input))
 
     def test_extremal_numerics_cross_entropy(self, device):
         N, C = 3, 4
@@ -1396,7 +1399,7 @@ class TestOperators(TestCase):
                 fn = functools.partial(torch.nn.functional.cross_entropy, target=target, weight=weight, **kwargs)
                 result = fn(input)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(fn, (cotangents, input), argnums=(0, 1), atol_rtol=(1e-4, 1e-5))
+                self._compare_jacobians(fn, (cotangents, input), atol_rtol=(1e-4, 1e-5))
 
     def test_extremal_numerics_binary_cross_entropy(self, device):
         N, C, H, W = 3, 4, 5, 6
@@ -1411,7 +1414,7 @@ class TestOperators(TestCase):
                 fn = functools.partial(torch.nn.functional.binary_cross_entropy, target=target, weight=weight, **kwargs)
                 result = fn(input)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(fn, (cotangents, input), argnums=(0, 1), atol_rtol=(1e-4, 2e-5))
+                self._compare_jacobians(fn, (cotangents, input), atol_rtol=(1e-4, 2e-5))
 
     def test_extremal_numerics_layer_norm(self, device):
         N, C, H, W = 3, 4, 5, 6
@@ -1427,7 +1430,7 @@ class TestOperators(TestCase):
                     return torch.nn.functional.layer_norm(input, normalized_shape, weight=weight, bias=bias)
                 result = fn(input, weight, bias)
                 cotangents = torch.randn_like(result)
-                self._compare_jacobians(fn, (cotangents, input, weight, bias), argnums=(0, 1, 2, 3))
+                self._compare_jacobians(fn, (cotangents, input, weight, bias))
 
     @ops(filter(lambda op: op.name == "nn.functional.group_norm", functorch_lagging_op_db + additional_op_db),
          allowed_dtypes=(torch.float32, torch.double))  # TODO: generalize


### PR DESCRIPTION
This adds tests that have tensors filled with -1000, 0, or 1000 (-1000 and 1000 because it hits inf for exp(-x) or exp(x), respectively) for the functions that use decompositions for forward over reverse coverage

~Currently, there's a bug in the nll loss decomposition that I didn't catch earlier so some of the shapes are commented out (specifically it fails if the weight is 0). I'm working on a fix for that before the branch cut tomorrow~ This bug was coming when weight was all 0s, so we decided that a user should not end up doing this. I'll check that this works with a weight of mostly 0s and a single 1 entry