### PR TITLE
 Replace addr_decomp with the one in PyTorch Core, issue #833

### DIFF
--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -1312,7 +1312,7 @@ def _register_jit_decomposition(decomp, use_python=False):
 vmap_decompositions_lib = torch.library.Library("aten", "IMPL", "FuncTorchBatched")
 
 
-def _register_jit_decomposition_bypass_script(decomp):
+def _register_python_decomposition_vmap(decomp):
     if decomp in decomposition_table:
         vmap_decompositions_lib.impl(decomp, decomposition_table[decomp])
     else:
@@ -1330,4 +1330,4 @@ _register_jit_decomposition(torch.ops.aten.log_sigmoid_forward.default)
 _register_jit_decomposition(torch.ops.aten.binary_cross_entropy_backward.default)
 _register_jit_decomposition(torch.ops.aten.binary_cross_entropy.default)
 _register_jit_decomposition(torch.ops.aten.native_layer_norm_backward.default)
-_register_jit_decomposition_bypass_script(torch.ops.aten.addr.default)
+_register_python_decomposition_vmap(torch.ops.aten.addr.default)

--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -1310,10 +1310,11 @@ def _register_jit_decomposition(decomp, use_python=False):
 #  because the Tensor types generated cannot be unioned by torchscript
 # decomp should be type OpOverload
 _register_jit_decomposition_lib = torch.library.Library("aten", "IMPL", "FuncTorchBatched")
+
+
 def _register_jit_decomposition_bypass_script(decomp):
     if decomp in decomposition_table:
-        decomposition_table_used = decomposition_table
-        _register_jit_decomposition_lib.impl(decomp, torch._decomp.decomposition_table[decomp])   
+        _register_jit_decomposition_lib.impl(decomp, decomposition_table[decomp])
     else:
         raise RuntimeError(f"could not find decomposition for {decomp}")
 

--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -1309,12 +1309,12 @@ def _register_jit_decomposition(decomp, use_python=False):
 # _register_jit_decomposition doesn't work for some operators, e.g. addr,
 #  because the Tensor types generated cannot be unioned by torchscript
 # decomp should be type OpOverload
-_register_jit_decomposition_lib = torch.library.Library("aten", "IMPL", "FuncTorchBatched")
+vmap_decompositions_lib = torch.library.Library("aten", "IMPL", "FuncTorchBatched")
 
 
 def _register_jit_decomposition_bypass_script(decomp):
     if decomp in decomposition_table:
-        _register_jit_decomposition_lib.impl(decomp, decomposition_table[decomp])
+        vmap_decompositions_lib.impl(decomp, decomposition_table[decomp])
     else:
         raise RuntimeError(f"could not find decomposition for {decomp}")
 

--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -1308,12 +1308,12 @@ def _register_jit_decomposition(decomp, use_python=False):
 # use an alternate way to register an operator into the decomposition table
 # _register_jit_decomposition doesn't work for some operators, e.g. addr,
 #  because the Tensor types generated cannot be unioned by torchscript
+# decomp should be type OpOverload
 _register_jit_decomposition_lib = torch.library.Library("aten", "IMPL", "FuncTorchBatched")
 def _register_jit_decomposition_bypass_script(decomp):
     if decomp in decomposition_table:
         decomposition_table_used = decomposition_table
-        name =  decomp.overloadpacket.__name__
-        _register_jit_decomposition_lib.impl(name, torch._decomp.decomposition_table[decomp])   
+        _register_jit_decomposition_lib.impl(decomp, torch._decomp.decomposition_table[decomp])   
     else:
         raise RuntimeError(f"could not find decomposition for {decomp}")
 

--- a/functorch/csrc/BatchRulesBinaryOps.cpp
+++ b/functorch/csrc/BatchRulesBinaryOps.cpp
@@ -264,14 +264,6 @@ std::tuple<Tensor,optional<int64_t>> masked_select_backward_batch_rule(
   return std::make_tuple(result, 0);
 }
 
-Tensor addr_decomposition(
-    const Tensor& self, const Tensor& vec1, const Tensor& vec2,
-    const Scalar& beta, const Scalar& alpha) {
-
-  auto outer = alpha * vec1.unsqueeze(-1) * vec2.unsqueeze(-2);
-  return self * beta + outer;
-}
-
 std::tuple<Tensor,optional<int64_t>> cdist_backward_batch_rule(
     const Tensor& grad, optional<int64_t> grad_bdim,
     const Tensor& x1, optional<int64_t> x1_bdim,
@@ -369,7 +361,6 @@ TORCH_LIBRARY_IMPL(aten, FT_BATCHED_KEY, m) {
   BINARY_SCALAR_2(add, Tensor, Scalar);
   POINTWISE_BOXED(addcdiv);
   POINTWISE_BOXED(addcmul);
-  m.impl("addr", addr_decomposition);
   BINARY_POINTWISE(atan2);
   BINARY_SCALAR_2(bitwise_and, Tensor, Scalar);
   BINARY_POINTWISE2(bitwise_or, Tensor);


### PR DESCRIPTION
Remove the `addr` decomposition in `functorch` to use the one in  PyTorch core. 
1. removed the `addr` decomposition in functorch/csrc/BatchRulesBinaryOps.cpp
2. registered the Pytorch core decomposition in functorch/_src/eager_transforms.py. A new register method `_register_jit_decomposition_bypass_script` is implemented to bypass torch script. The existing `_register_jit_decomposition` does not work for `addr` because the Tensor types generated cannot be unioned by torch script. 