### PR TITLE
Fix MSE foward, use decomposition for MSE backward

### DIFF
--- a/functorch/csrc/BatchRulesLoss.cpp
+++ b/functorch/csrc/BatchRulesLoss.cpp
@@ -34,7 +34,10 @@ mse_loss_batch_rule(const at::Tensor& self, optional<int64_t> self_bdim, const a
   if (result.dim() == 1) {
     return std::make_tuple(result, 0);
   } else if (reduction == Reduction::None) {
-    return std::make_tuple(result, 0);
+    DimVector end_shape;
+    const auto batched_elem = self_bdim.has_value() ?
+        moveBatchDimToFront(self, self_bdim) : moveBatchDimToFront(target, target_bdim);
+    return std::make_tuple(result.reshape(batched_elem.sizes()), 0);
   } else if (reduction == Reduction::Sum) {
     return std::make_tuple(result.sum(-1), 0);
   } else if (reduction == Reduction::Mean) {

--- a/functorch/csrc/BatchRulesLoss.cpp
+++ b/functorch/csrc/BatchRulesLoss.cpp
@@ -58,7 +58,7 @@ mse_loss_backward_batch_rule(
   auto target_rank = rankWithoutBatchDim(target, target_bdim);
   auto logicalRank = std::max(grad_output_rank, std::max(self_rank, target_rank));
 
-  if (grad_output_bdim.has_value()) {
+  if (reduction == Reduction::None && grad_output_bdim.has_value()) {
     DimVector view_shape;
     view_shape.reserve(self_rank + 1);
     if (grad_output_bdim.has_value()) {

--- a/test/functorch_additional_op_db.py
+++ b/test/functorch_additional_op_db.py
@@ -185,6 +185,37 @@ additional_op_db.append(
     ))
 
 
+def sample_inputs_mse_loss(op_info, device, dtype, requires_grad, **kwargs):
+    def make_input(shape, requires_grad=requires_grad):
+        return make_tensor(shape, device=device, dtype=dtype, requires_grad=requires_grad)
+
+    rhs_requires_grad = kwargs.get('rhs_requires_grad', requires_grad)
+    S = 5
+
+    shapes = ((S, S), (S, S, S), (S, S, S, S))
+    reductions = ("none", "mean", "sum")
+
+    for shape, reduction in itertools.product(shapes, reductions):
+        yield SampleInput(make_input(shape),
+                          args=(make_input(shape, requires_grad=rhs_requires_grad),),
+                          kwargs={"reduction": reduction})
+
+
+additional_op_db.append(
+    OpInfo(
+        "nn.functional.mse_loss",
+        variant_test_name="functorch",
+        sample_inputs_func=sample_inputs_mse_loss,
+        supports_out=False,
+        supports_forward_ad=True,
+        supports_fwgrad_bwgrad=True,
+        dtypes=floating_types_and(torch.float16),
+        backward_dtypes=floating_types(),
+        dtypesIfCUDA=floating_types_and(torch.bfloat16, torch.float16),
+        backward_dtypesIfCUDA=floating_types_and(torch.bfloat16, torch.float16),
+    ))
+
+
 def sample_inputs_getitem(op_info, device, dtype, requires_grad, **kwargs):
     S = 5
     test_args = [

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1322,8 +1322,6 @@ class TestOperators(TestCase):
                 cotangents = torch.randn_like(result, device=device)
                 self._compare_jacobians_of_vjp(torch.nn.functional.l1_loss, (cotangents, input, target))
 
-    # ("https://github.com/pytorch/functorch/issues/858")
-    @unittest.expectedFailure
     def test_extremal_numerics_mse_loss(self, device):
         N, C, H, W = 3, 4, 5, 6
         shapes = ((N, C), (N, C, H), (N, C, H, W))


### PR DESCRIPTION
Because MSE backward was redispatching, it ended up having some shape errors if it redispatched twice. This switches it to use the decomposition from core so that we don't try to guess based on the size of the input if it came from a redispatch or an original call. Specifically:

- when reduction != none, the original output would be of size [N]. We would be padding the grad_output with 1s if need be and then redispatching (with reduction == none). This led to issues because reduction == none assumes that grad output and self have the same number of elements
- when reduction == none, often times the grad_output would be flattened (a little unclear why this was happening, tbh). This was causing reshape errors. If we tried to fix this by just reshaping grad_output to match self, we would end up with errors from the redispatch because grad_output wouldn't have enough elements in that case

There were also some issues in the forward rule where if reduction was none, the output would be flattened where it shouldn't be. Specifically, if you had
```
input: [B, in_0, in_1, ...]
target: [B, in_0, in_1, ...]
output (should be): [B, in_0, in_1, ...]
output (produced): [B, in_0 * in_1 * ...]
```

This was not caught because all op info tests that had a none reduction only had 1D inputs. This adds new tests and fixes the forward + backward formula

Fixes #858 