### PR TITLE
Clearly mark the old batching rule API as "legacy"

### DIFF
--- a/functorch/csrc/BatchRulesHelper.h
+++ b/functorch/csrc/BatchRulesHelper.h
@@ -12,7 +12,7 @@
 #include <functorch/csrc/DynamicLayer.h>
 #include <functorch/csrc/TensorWrapper.h>
 #include <functorch/csrc/BatchingMetaprogramming.h>
-#include <functorch/csrc/VmapTransforms.h>
+#include <functorch/csrc/LegacyVmapTransforms.h>
 #include <functorch/csrc/BatchedFallback.h>
 #include <functorch/csrc/PlumbingHelper.h>
 #include <ATen/core/dispatch/Dispatcher.h>

--- a/functorch/csrc/BatchedFallback.cpp
+++ b/functorch/csrc/BatchedFallback.cpp
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include <functorch/csrc/BatchedFallback.h>
-#include <functorch/csrc/VmapTransforms.h>
+#include <functorch/csrc/LegacyVmapTransforms.h>
 #include <functorch/csrc/Constants.h>
 #include <functorch/csrc/TensorWrapper.h>
 #include <functorch/csrc/DynamicLayer.h>

--- a/functorch/csrc/LegacyBatchingRegistrations.cpp
+++ b/functorch/csrc/LegacyBatchingRegistrations.cpp
@@ -12,7 +12,7 @@
 #include <functorch/csrc/DynamicLayer.h>
 #include <functorch/csrc/TensorWrapper.h>
 #include <functorch/csrc/BatchingMetaprogramming.h>
-#include <functorch/csrc/VmapTransforms.h>
+#include <functorch/csrc/LegacyVmapTransforms.h>
 #include <functorch/csrc/BatchedFallback.h>
 #include <functorch/csrc/Constants.h>
 #include <functorch/csrc/BatchRulesHelper.h>
@@ -22,6 +22,10 @@ namespace functorch {
 
 
 // NOTE: [What is a batching rule?]
+//
+// This files contains batching rules written with the legacy (now-deprecated)
+// batching rule API.
+// Please try to use the new-style batching rule API (see writing_batch_rules.md)
 //
 // A *batching rule* implements the logic of how to call an operator on inputs
 // that have zero or more additional batch dimensions. When one does a vmap, the

--- a/functorch/csrc/LegacyVmapTransforms.cpp
+++ b/functorch/csrc/LegacyVmapTransforms.cpp
@@ -4,7 +4,7 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include <functorch/csrc/VmapTransforms.h>
+#include <functorch/csrc/LegacyVmapTransforms.h>
 #include <functorch/csrc/DynamicLayer.h>
 
 #include <ATen/ATen.h>

--- a/functorch/csrc/LegacyVmapTransforms.h
+++ b/functorch/csrc/LegacyVmapTransforms.h
@@ -12,6 +12,9 @@
 namespace at {
 namespace functorch {
 
+// This files contains the legacy (now-deprecated) batching rule API.
+// Please try to use the new-style batching rule API (see writing_batch_rules.md)
+
 // This file contains abstractions used for transforming *logical* vmap arguments
 // into *physical* arguments. (Keep reading for definitions of these terms).
 

--- a/functorch/csrc/VmapModeRegistrations.cpp
+++ b/functorch/csrc/VmapModeRegistrations.cpp
@@ -6,7 +6,7 @@
 
 #include <torch/library.h>
 #include <ATen/ATen.h>
-#include <functorch/csrc/VmapTransforms.h>
+#include <functorch/csrc/LegacyVmapTransforms.h>
 #include <functorch/csrc/BatchedTensorImpl.h>
 #include <functorch/csrc/PlumbingHelper.h>
 #include <functorch/csrc/Constants.h>

--- a/functorch/csrc/init.cpp
+++ b/functorch/csrc/init.cpp
@@ -11,7 +11,7 @@
 #include <functorch/csrc/TensorWrapper.h>
 #include <functorch/csrc/DynamicLayer.h>
 #include <functorch/csrc/BatchedTensorImpl.h>
-#include <functorch/csrc/VmapTransforms.h>
+#include <functorch/csrc/LegacyVmapTransforms.h>
 #include <functorch/csrc/BatchedFallback.h>
 #include <functorch/csrc/BatchRulesHelper.h>
 #include <functorch/csrc/CompileCache.h>


### PR DESCRIPTION
It's possible it is buggy and we should aim to delete the old batching
rule API in the future.