### PR TITLE
Remove cross_entropy monkey patch

### DIFF
--- a/functorch/_src/monkey_patching.py
+++ b/functorch/_src/monkey_patching.py
@@ -62,26 +62,6 @@ def _functorch_str(tensor, *, tensor_contents=None):
 torch._tensor_str._str = _functorch_str
 
 
-_old_cross_entropy = torch.nn.functional.cross_entropy
-
-
-# **kwargs to handle the new label_smoothing arg
-def cross_entropy(input, target, weight=None, size_average=None,
-                  ignore_index=-100, reduce=None, reduction='mean', **kwargs):
-    if input.dim() == 1 and target.dim() == 0:
-        input = input.unsqueeze(0)
-        target = target.unsqueeze(0)
-
-    result = _old_cross_entropy(
-        input, target, weight, size_average,
-        ignore_index, reduce, reduction, **kwargs)
-    if reduction == 'none':
-        return result.squeeze(0)
-    return result
-
-
-torch.nn.functional.cross_entropy = cross_entropy
-
 # Monkeypatch .backward() to error out if any transforms are active.
 # TODO: remove the monkeypatching and add an extension point into PyTorch core
 _old_backward = torch.Tensor.backward


### PR DESCRIPTION
We don't need it anymore because we upstreamed the changes into
pytorch/pytorch a while ago.