### PR TITLE
Fix expand.SymInt issues by adding a decomp

### DIFF
--- a/functorch/csrc/BatchRulesViews.cpp
+++ b/functorch/csrc/BatchRulesViews.cpp
@@ -502,6 +502,14 @@ std::tuple<Tensor, optional<int64_t>> diag_embed_batch_rule(const Tensor& self, 
   return std::make_tuple(at::diag_embed(self_, offset, dim1, dim2), 0);
 }
 
+// We need to write a real batching rule to fully support symint.
+// This requires symint variants of other operations, like `view`,
+// which don't exist yet.
+Tensor expand_symint_decomp_hack(const Tensor& self, SymIntArrayRef packed_size, bool implicit) {
+   auto size = asIntArrayRefSlow(packed_size);
+   return self.expand(size, implicit);
+}
+
 TORCH_LIBRARY_IMPL(aten, FT_BATCHED_KEY, m) {
   VMAP_SUPPORT(diag, diag_batch_rule);
   VMAP_SUPPORT(chunk, chunk_batching_rule);
@@ -532,6 +540,7 @@ TORCH_LIBRARY_IMPL(aten, FT_BATCHED_KEY, m) {
   VMAP_SUPPORT2(slice, Tensor, slice_batch_rule);
   VMAP_SUPPORT2(transpose, int, transpose_int_batch_rule);
   VMAP_SUPPORT(diag_embed, diag_embed_batch_rule);
+  m.impl("expand.SymInt", expand_symint_decomp_hack);
 }
 
 }}


### PR DESCRIPTION
To fully support expand.SymInt, we should write a batching rule for it.
Unfortunately, we are unable to write a batching rule because there are
not enough SymInt overloads (e.g. we need a view.SymInt, that doesn't
exist today).

This PR adds a decomp for expand.SymInt as a short-term fix.