### PR TITLE
Fix binaries tag (macos, Python 3.10)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python_version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python_version: [ "3.7", "3.8", "3.9", "3.10.3" ]
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
GHA seems to be installing universal2 Python 3.10, which is causing our
binary tag to say universal2 when it should be x86_64. This PR
attempts to get GHA to install an older version of Python 3.10
(in previous functorch releases we did not have this problem).