### PR TITLE
Fix binaries tag (macos, Python 3.10)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,12 +49,12 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python_version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python_version: [["3.7", "3.7"], ["3.8", "3.8"], ["3.9", "3.9"], ["3.10", "3.10.3"]]
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: ${{ matrix.python_version[1] }}
           architecture: x64
       - name: Checkout functorch
         uses: actions/checkout@v2
@@ -69,7 +69,7 @@ jobs:
       - name: Upload wheel for the test-wheel job
         uses: actions/upload-artifact@v2
         with:
-          name: functorch-mac-${{ matrix.python_version }}.whl
+          name: functorch-mac-${{ matrix.python_version[0] }}.whl
           path: dist/*.whl
       - name: Upload wheel for download
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
GHA seems to be installing universal2 Python 3.10, which is causing our
binary tag to say universal2 when it should be x86_64. This PR
attempts to get GHA to install an older version of Python 3.10
(in previous functorch releases we did not have this problem).