### PR TITLE
Drop cuda 10.2 support for functorch 0.2.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ workflows:
           matrix:
             parameters:
               python_version: ["3.7", "3.8", "3.9", "3.10"]
-              cu_version: ["cu102"]
+              cu_version: ["cu113"]
 
       - unittest_macos_cpu:
           name: unittest_macos_<< matrix.cu_version >>_py<< matrix.python_version >>

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -53,11 +53,11 @@ gcc --version
 pip install expecttest
 
 if [ "${CU_VERSION:-}" == cpu ] ; then
-    pip install torch~=1.12 torchvision -f https://download.pytorch.org/whl/test/cpu/torch_test.html --pre
+    pip install torch==1.12 torchvision --extra-index-url https://download.pytorch.org/whl/cpu
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 else
     # pip install torch~=1.12 torchvision -f https://download.pytorch.org/whl/test/cu102/torch_test.html --pre
     # Workaround pip wheel cuda linking issue
-    conda install -y pytorch torchvision cudatoolkit=10.2 -c pytorch-test
+    conda install -y pytorch=1.12 torchvision cudatoolkit=11.3 -c pytorch
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 fi

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -28,7 +28,7 @@ else
 fi
 
 printf "Installing PyTorch with %s\n" "${cudatoolkit}"
-conda install -y -c "pytorch-test" -c nvidia "pytorch-test"::pytorch[build="*${version}*"] "${cudatoolkit}"
+conda install -y pytorch "${cudatoolkit}" -c pytorch
 
 torch_cuda=$(python -c "import torch; print(torch.cuda.is_available())")
 echo torch.cuda.is_available is $torch_cuda

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,14 +20,14 @@ jobs:
       - name: Install PyTorch 1.12 RC
         run: |
           export PATH="/opt/python/${{ matrix.python_version[1] }}/bin:$PATH"
-          python3 -mpip install --pre torch~=1.12 -f https://download.pytorch.org/whl/test/cpu/torch_test.html
+          python3 -mpip install torch==1.12 --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Build wheel
         run: |
           export PATH="/opt/python/${{ matrix.python_version[1] }}/bin:$PATH"
           python3 -mpip install wheel
           python3 setup.py bdist_wheel
           # NB: wheels have the linux_x86_64 tag so we rename to manylinux1
-          find . -name 'dist/*whl' -exec bash -c ' mv $0 ${0/linux/manylinux1}' {} \;
+          # find . -name 'dist/*whl' -exec bash -c ' mv $0 ${0/linux/manylinux1}' {} \;
       # pytorch/pytorch binaries are also manylinux_2_17 compliant but they
       # pretend that they're manylinux1 compliant so we do the same.
       - name: Show auditwheel output; confirm 2-17
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install PyTorch 1.12 RC
         run: |
-          python3 -mpip install --pre torch~=1.12 -f https://download.pytorch.org/whl/test/cpu/torch_test.html
+          python3 -mpip install torch==1.12 --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Build wheel
         run: |
           export CC=clang CXX=clang++
@@ -94,7 +94,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install PyTorch 1.12 RC
         run: |
-          python3 -mpip install --pre torch~=1.12 -f https://download.pytorch.org/whl/test/cpu/torch_test.html
+          python3 -mpip install torch==1.12 torchvision --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Upgrade pip
         run: |
           python3 -mpip install --upgrade pip

--- a/functorch/__init__.py
+++ b/functorch/__init__.py
@@ -4,6 +4,17 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import torch
+
+if torch.version.cuda == '10.2':
+    raise RuntimeError(
+        "We've detected an installation of PyTorch 1.12 with CUDA 10.2 support. "
+        "The official functorch 0.2.0 binaries are not compatible with the "
+        "PyTorch 1.12 CUDA 10.2 binaries. "
+        "Please install PyTorch with support for a different version of CUDA "
+        "(either cpu-only, 11.3, or 11.6; see pytorch.org for instructions) or "
+        "file an issue on GitHub to discuss more.")
+
+
 from . import _C
 
 # Monkey patch PyTorch. This is a hack, we should try to upstream

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import OrderedDict
-from unittest.case import skipIf, skip
+from unittest.case import skipIf
 from torch.testing._internal.common_utils import TestCase, run_tests
 import torch
 import torch.nn.functional as F
@@ -29,6 +29,7 @@ from functorch_additional_op_db import additional_op_db
 from common_utils import (
     get_fallback_and_vmap_exhaustive,
     xfail,
+    skip,
     skipOps,
     check_vmap_fallback,
     tol1,
@@ -1066,7 +1067,7 @@ class TestVmapAPI(TestCase):
 
         assert expected.allclose(out)
 
-    @skip("Somehow, vmap and autocast do not work on CPU")
+    @unittest.case.skip("Somehow, vmap and autocast do not work on CPU")
     def test_vmap_autocast_cpu(self):
         self._test_vmap_autocast("cpu")
 
@@ -3130,6 +3131,9 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('int'),
         xfail('long'),
         xfail('short'),
+
+        # flakey
+        skip('linalg.eigh'),
     }
 
     @ops(functorch_lagging_op_db + additional_op_db, allowed_dtypes=(torch.float,))


### PR DESCRIPTION
This PR:
- adds an error message when functorch is imported alongside a PyTorch
CUDA 10.2 binary (pip or conda)
- changes the CI to use cuda 11.3 for linux (since the error message
triggers no matter if it's a source build or binary build)
- Updates the links to PyTorch binaries to the officially released ones
instead of using the pytorch-test channel.

Test Plan:
- wait for tests
- manually test binaries offline