### PR TITLE
Add _unsafe_set_level for torchdim

### DIFF
--- a/functorch/csrc/BatchedTensorImpl.h
+++ b/functorch/csrc/BatchedTensorImpl.h
@@ -78,7 +78,9 @@ struct BatchedTensorImpl : public c10::TensorImpl {
 #endif
 
   void refreshTensorMetadata();
-
+  void _unsafe_set_level(int64_t level) {
+    level_ = level;
+  }
  private:
   // see NOTE: [BatchedTensorImpl levels invariant]
   void checkInvariants() const;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #924

[torchdim](https://github.com/facebookresearch/torchdim) reuses BatchTensorImpl objects
where it can across batched invocations, but needs to patch their levels to match
what _vmap_increment_nesting returns.