### PR TITLE
Add skips to coordinate land

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -706,6 +706,7 @@ class TestOperators(TestCase):
         xfail('nn.functional.huber_loss'),
         xfail('nn.functional.poisson_nll_loss'),
         xfail('lu'),
+        skip('linalg.det', 'singular'),  # https://github.com/pytorch/functorch/issues/961
         xfail('cumprod'),
         xfail('lu_solve'),
         xfail('linalg.det'),
@@ -830,6 +831,7 @@ class TestOperators(TestCase):
         xfail('pinverse'),
         xfail('prod'),
         xfail('put'),
+        skip('linalg.det'),  # https://github.com/pytorch/functorch/issues/961
         xfail('quantile'),
         xfail('renorm'),
         xfail('take'),


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/pull/80217.
https://github.com/pytorch/functorch/issues/961 is the tracking issue so
we don't forget to remove the skips.