### PR TITLE
add view.SymInt kernel

### DIFF
--- a/functorch/csrc/BatchRulesViews.cpp
+++ b/functorch/csrc/BatchRulesViews.cpp
@@ -11,6 +11,7 @@
 #include <functorch/csrc/PlumbingHelper.h>
 #include <functorch/csrc/BatchedFallback.h>
 #include <ATen/core/dispatch/Dispatcher.h>
+#include <ATen/core/TensorBody.h>
 #include <c10/core/SymIntArrayRef.h>
 #include <c10/util/SmallBuffer.h>
 #include <ATen/InferSize.h>
@@ -439,13 +440,7 @@ std::tuple<Tensor, optional<int64_t>> view_batching_rule(
 
 Tensor view_symint_decomposition(const Tensor& self,
             c10::SymIntArrayRef size) {
-  return at::view(self, c10::asIntArrayRefSlow(size));
-}
-
-std::tuple<Tensor, optional<int64_t>> view_symint_batching_rule(
-    const Tensor &self, optional<int64_t> self_bdim, c10::SymIntArrayRef size)
-{
-  return self.view(self_bdim, c10::asIntArrayRefSlow(size));
+  return self.view( c10::asIntArrayRefSlow(size));
 }
 
 

--- a/functorch/csrc/BatchRulesViews.cpp
+++ b/functorch/csrc/BatchRulesViews.cpp
@@ -6,11 +6,12 @@
 
 #include <functorch/csrc/BatchRulesHelper.h>
 #include <iostream>
-#include "c10/core/SymIntArrayRef.h"
+
 #include <ATen/Operators.h>
 #include <functorch/csrc/PlumbingHelper.h>
 #include <functorch/csrc/BatchedFallback.h>
 #include <ATen/core/dispatch/Dispatcher.h>
+#include <c10/core/SymIntArrayRef.h>
 #include <c10/util/SmallBuffer.h>
 #include <ATen/InferSize.h>
 
@@ -436,6 +437,11 @@ std::tuple<Tensor, optional<int64_t>> view_batching_rule(
   return std::make_tuple(self_.view(size_), 0);
 }
 
+Tensor view_symint_decomposition(const Tensor& self,
+            c10::SymIntArrayRef size) {
+  return at::view(self, c10::asIntArrayRefSlow(size));
+}
+
 std::tuple<Tensor, optional<int64_t>> view_symint_batching_rule(
     const Tensor &self, optional<int64_t> self_bdim, c10::SymIntArrayRef size)
 {
@@ -549,7 +555,7 @@ TORCH_LIBRARY_IMPL(aten, FT_BATCHED_KEY, m) {
   VMAP_SUPPORT2(transpose, int, transpose_int_batch_rule);
   VMAP_SUPPORT(diag_embed, diag_embed_batch_rule);
   m.impl("expand.SymInt", expand_symint_decomp_hack);
-  m.impl("view.SymInt", view_symint_batching_rule);
+  m.impl("view.SymInt", view_symint_decomposition);
 }
 
 }}

--- a/functorch/csrc/BatchRulesViews.cpp
+++ b/functorch/csrc/BatchRulesViews.cpp
@@ -6,6 +6,7 @@
 
 #include <functorch/csrc/BatchRulesHelper.h>
 #include <iostream>
+#include "c10/core/SymIntArrayRef.h"
 #include <ATen/Operators.h>
 #include <functorch/csrc/PlumbingHelper.h>
 #include <functorch/csrc/BatchedFallback.h>
@@ -435,6 +436,13 @@ std::tuple<Tensor, optional<int64_t>> view_batching_rule(
   return std::make_tuple(self_.view(size_), 0);
 }
 
+std::tuple<Tensor, optional<int64_t>> view_symint_batching_rule(
+    const Tensor &self, optional<int64_t> self_bdim, c10::SymIntArrayRef size)
+{
+  return self.view(self_bdim, c10::asIntArrayRefSlow(size));
+}
+
+
 template <typename F, F Func>
 std::tuple<Tensor, optional<int64_t>> expand_batch_rule(
     const Tensor &self, optional<int64_t> self_bdim, IntArrayRef size, bool implicit)
@@ -541,6 +549,7 @@ TORCH_LIBRARY_IMPL(aten, FT_BATCHED_KEY, m) {
   VMAP_SUPPORT2(transpose, int, transpose_int_batch_rule);
   VMAP_SUPPORT(diag_embed, diag_embed_batch_rule);
   m.impl("expand.SymInt", expand_symint_decomp_hack);
+  m.impl("view.SymInt", view_symint_batching_rule);
 }
 
 }}


### PR DESCRIPTION
This PR introduces `view.SymInt` overload to functorch ahead of time, so https://github.com/pytorch/pytorch/pull/81145 can pick it up and hopefully to not break functorch tests. 