### PR TITLE
Remove eig mentions in test

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -553,7 +553,6 @@ class TestOperators(TestCase):
         skip('linalg.svdvals'),  # # really annoying thing where it passes correctness check but not has_batch_rule
         xfail('__getitem__', ''),  # dynamic error
         xfail('_masked.prod'),  # calls aten::item
-        xfail('eig'),  # calls aten::item
         xfail('linalg.eig'),  # Uses aten::allclose
         xfail('linalg.householder_product'),  # needs select_scatter
         xfail('matrix_exp'),  # would benefit from narrow_scatter

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -3191,7 +3191,6 @@ class TestVmapOperatorsOpInfo(TestCase):
     @skipOps('TestVmapOperatorsOpInfo', 'test_op_has_batch_rule', vmap_fail.union({
         xfail('complex'),
         xfail('copysign'),
-        xfail('eig'),
         xfail('histogram'),
         xfail('index_fill'),
         xfail('nansum'),


### PR DESCRIPTION
This PR is needed because tests are failing when trying to remove deprecated `torch.eig`, see https://github.com/pytorch/pytorch/pull/70982#issuecomment-1191783202.