### PR TITLE
Re-add some notebooks back for BC

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,5 @@
+The new, updated versions of these notebooks may be found in the pytorch/pytorch repo.
+
+We're leaving the old notebooks here as a temporary solution so that our website still
+points to the correct thing. We plan to rewrite the links on the website to point to
+their newer counterparts soon.

--- a/notebooks/colab/aot_autograd_optimizations.ipynb
+++ b/notebooks/colab/aot_autograd_optimizations.ipynb
@@ -1,0 +1,415 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# AOT Autograd - How to use and optimize?\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/aot_autograd_optimizations.ipynb\">\n",
+    "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "</a>\n",
+    "\n",
+    "## Background\n",
+    "In this tutorial, we will learn how to use AOT Autograd to speedup training of deep learning models.\n",
+    "\n",
+    "For background, AOT Autograd is a toolkit to assist developers in accelerating training on PyTorch. Broadly, it has two key features\n",
+    "* AOT Autograd traces the forward and backward graph ahead of time. Presence of forward and backward graph ahead of time facilitates joint graph optimizations such as recomputation or activation checkpointing.\n",
+    "* AOT Autograd provides simple mechanisms to compile the extracted forward and backward graphs through deep learning compilers, such as NVFuser, NNC, TVM and others.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## What will you learn?\n",
+    "In this tutorial, we will look at how AOT Autograd can be used, in conjunction with backend compilers, to accelerate the training of PyTorch models. More specifically, you will learn\n",
+    "* How to use AOT Autograd?\n",
+    "* How AOT Autograd uses backend compilers to perform operation fusion?\n",
+    "* How AOT Autograd enables training-specific optimizations such as Recomputation?\n",
+    "\n",
+    "So, lets get started.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Let's setup a simple model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "def fn(a, b, c, d):\n",
+    "    x = a + b + c + d\n",
+    "    return x.cos().cos()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test that it works\n",
+    "a, b, c, d = [torch.randn(2, 4, requires_grad=True) for _ in range(4)]\n",
+    "ref = fn(a, b, c, d)\n",
+    "loss = ref.sum()\n",
+    "loss.backward()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use AOT Autograd\n",
+    "\n",
+    "Now, lets use AOT Autograd and look at the extracted forward and backward graphs. Internally, AOT uses `__torch_dispatch__` based tracing mechanism to extract forward and backward graphs, and wraps them in `torch.Fx` GraphModule containers. Note that AOT Autograd tracing is different from the usual Fx symbolic tracing. AOT Autograd uses Fx GraphModule just to represent the traced graphs (and not for tracing).\n",
+    "\n",
+    "AOT Autograd then sends these forward and backward graphs to the user supplied compilers. So, lets write a compiler that just prints the graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\n",
+      "def forward(self, primals_1, primals_2, primals_3, primals_4):\n",
+      "    add = torch.ops.aten.add(primals_1, primals_2);  primals_1 = primals_2 = None\n",
+      "    add_1 = torch.ops.aten.add(add, primals_3);  add = primals_3 = None\n",
+      "    add_2 = torch.ops.aten.add(add_1, primals_4);  add_1 = primals_4 = None\n",
+      "    cos = torch.ops.aten.cos(add_2)\n",
+      "    cos_1 = torch.ops.aten.cos(cos)\n",
+      "    return [cos_1, add_2, cos]\n",
+      "    \n",
+      "\n",
+      "\n",
+      "\n",
+      "def forward(self, add_2, cos, tangents_1):\n",
+      "    sin = torch.ops.aten.sin(cos);  cos = None\n",
+      "    neg = torch.ops.aten.neg(sin);  sin = None\n",
+      "    mul = torch.ops.aten.mul(tangents_1, neg);  tangents_1 = neg = None\n",
+      "    sin_1 = torch.ops.aten.sin(add_2);  add_2 = None\n",
+      "    neg_1 = torch.ops.aten.neg(sin_1);  sin_1 = None\n",
+      "    mul_1 = torch.ops.aten.mul(mul, neg_1);  mul = neg_1 = None\n",
+      "    return [mul_1, mul_1, mul_1, mul_1]\n",
+      "    \n"
+     ]
+    }
+   ],
+   "source": [
+    "from functorch.compile import aot_function\n",
+    "\n",
+    "# The compiler_fn is called after the forward and backward graphs are extracted.\n",
+    "# Here, we just print the code in the compiler_fn. Return of this function is a callable.\n",
+    "def compiler_fn(fx_module: torch.fx.GraphModule, _):\n",
+    "    print(fx_module.code)\n",
+    "    return fx_module\n",
+    "\n",
+    "# Pass on the compiler_fn to the aot_function API\n",
+    "aot_print_fn = aot_function(fn, fw_compiler=compiler_fn, bw_compiler=compiler_fn)\n",
+    "\n",
+    "# Run the aot_print_fn once to trigger the compilation and print the graphs\n",
+    "res = aot_print_fn(a, b, c, d).sum().backward()\n",
+    "assert torch.allclose(ref, res)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The above code prints the Fx graph for the forward and backward graph. You can see that in addition to the original input of the forward pass, the forward graph outputs some additional tensors. These tensors are saved for the backward pass for gradient calculation. We will come back to these later while talking about recomputation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Operator Fusion\n",
+    "Now that we understand how to use AOT Autograd to print forward and backward graphs, let us use AOT Autograd to use some actual deep learning compiler. In this tutorial, we use PyTorch Neural Network Compiler (NNC) to perform pointwise operator fusion for CPU devices. For CUDA devices, a suitable alternative is NvFuser. So, lets use NNC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# AOT Autograd has a suite of already integrated backends. Lets import the NNC compiler backend - ts_compile\n",
+    "from functorch.compile import ts_compile\n",
+    "\n",
+    "# Lets compile the forward and backward through ts_compile.\n",
+    "aot_nnc_fn = aot_function(fn, fw_compiler=ts_compile, bw_compiler=ts_compile)\n",
+    "\n",
+    "# Correctness checking. Lets clone the input so that we can check grads.\n",
+    "cloned_inputs = [x.clone().detach().requires_grad_(True) for x in (a, b, c, d)]\n",
+    "cloned_a, cloned_b, cloned_c, cloned_d = cloned_inputs\n",
+    "\n",
+    "res = aot_nnc_fn(*cloned_inputs)\n",
+    "loss = res.sum()\n",
+    "loss.backward()\n",
+    "assert torch.allclose(ref, res)\n",
+    "assert torch.allclose(a.grad, cloned_a.grad)\n",
+    "assert torch.allclose(b.grad, cloned_b.grad)\n",
+    "assert torch.allclose(c.grad, cloned_c.grad)\n",
+    "assert torch.allclose(d.grad, cloned_d.grad)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lets benchmark the original and AOT Autograd + NNC compiled function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Lets write a function to benchmark the forward and backward pass\n",
+    "import time\n",
+    "import statistics\n",
+    "\n",
+    "def bench(fn, args, prefix):\n",
+    "    warmup = 10\n",
+    "    iterations = 100\n",
+    "\n",
+    "    for _ in range(warmup):\n",
+    "        ref = fn(*args)\n",
+    "        ref.sum().backward()\n",
+    "    \n",
+    "    fw_latencies = []\n",
+    "    bw_latencies = []\n",
+    "    for _ in range(iterations):\n",
+    "        for arg in args:\n",
+    "            arg.grad = None\n",
+    "\n",
+    "        fw_begin = time.perf_counter()\n",
+    "        ref = fn(*args)\n",
+    "        fw_end = time.perf_counter()\n",
+    "\n",
+    "        loss = ref.sum() \n",
+    "\n",
+    "        bw_begin = time.perf_counter()\n",
+    "        loss.backward()\n",
+    "        bw_end = time.perf_counter()\n",
+    "\n",
+    "        fw_latencies.append(fw_end - fw_begin)\n",
+    "        bw_latencies.append(bw_end - bw_begin)\n",
+    "    \n",
+    "    avg_fw_latency = statistics.mean(fw_latencies) * 10**6\n",
+    "    avg_bw_latency = statistics.mean(bw_latencies) * 10**6\n",
+    "    print(prefix, \"Fwd = \" + str(avg_fw_latency) + \" us\", \"Bwd = \" + str(avg_bw_latency) + \" us\", sep=', ')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Eager, Fwd = 982.6959593920038 us, Bwd = 1899.7003795811906 us\n",
+      "AOT, Fwd = 734.2723174951971 us, Bwd = 831.1696897726506 us\n"
+     ]
+    }
+   ],
+   "source": [
+    "large_inputs = [torch.randn(1024, 2048, requires_grad=True) for _ in range(4)]\n",
+    "\n",
+    "# Benchmark the Eager and AOT Autograd functions\n",
+    "bench(fn, large_inputs, \"Eager\")\n",
+    "bench(aot_nnc_fn, large_inputs, \"AOT\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With the help of NNC, AOT Autograd speeds up both the forward and backward pass. If we look at the printed graphs earlier, all the operators are pointwise. The pointwise operators are memory bandwidth bound, and thus benefit from operator fusion. Looking closely at the numbers, the backward pass gets higher speedup. This is because forward pass has to output some intermediate tensors for gradient calculation for the backward pass, preventing it from saving some memory reads and writes. However, such restriction does not exist in the backward graph."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Recomputation (aka Activation Checkpointing)\n",
+    "Recomputation (often called activation checkpointing) is a technique in which, instead of saving some activations for use in backwards, we recompute them **during** the backwards pass. Recomputing saves memory, but we incur performance overhead.\n",
+    "\n",
+    "However, in the presence of fusing compiler, we can do better that that. We can recompute the fusion-friendly operators to save memory, and then rely on the fusing compiler to fuse the recomputed operators. This reduces both memory and runtime. Please refer to this [discuss post](https://dev-discuss.pytorch.org/t/min-cut-optimal-recomputation-i-e-activation-checkpointing-with-aotautograd/467) for more details.\n",
+    "\n",
+    "Here, we use AOT Autograd with NNC to perform similar type of recomputation. At the end of `__torch_dispatch__` tracing, AOT Autograd has a forward graph and joint forward-backward graph. AOT Autograd then uses a partitioner to isolate the forward and backward graph. In the example above, we used a default partitioner. For this experiment, we will use another partitioner called `min_cut_rematerialization_partition` to perform smarter fusion-aware recomputation. The partitioner is configurable and one can write their own partitioner to plug it in AOT Autograd."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\n",
+      "def forward(self, primals_1, primals_2, primals_3, primals_4):\n",
+      "    add = torch.ops.aten.add(primals_1, primals_2);  primals_1 = primals_2 = None\n",
+      "    add_1 = torch.ops.aten.add(add, primals_3);  add = primals_3 = None\n",
+      "    add_2 = torch.ops.aten.add(add_1, primals_4);  add_1 = primals_4 = None\n",
+      "    cos = torch.ops.aten.cos(add_2)\n",
+      "    cos_1 = torch.ops.aten.cos(cos);  cos = None\n",
+      "    return [cos_1, add_2]\n",
+      "    \n",
+      "\n",
+      "\n",
+      "\n",
+      "def forward(self, add_2, tangents_1):\n",
+      "    cos = torch.ops.aten.cos(add_2)\n",
+      "    sin = torch.ops.aten.sin(cos);  cos = None\n",
+      "    neg = torch.ops.aten.neg(sin);  sin = None\n",
+      "    mul = torch.ops.aten.mul(tangents_1, neg);  tangents_1 = neg = None\n",
+      "    sin_1 = torch.ops.aten.sin(add_2);  add_2 = None\n",
+      "    neg_1 = torch.ops.aten.neg(sin_1);  sin_1 = None\n",
+      "    mul_1 = torch.ops.aten.mul(mul, neg_1);  mul = neg_1 = None\n",
+      "    return [mul_1, mul_1, mul_1, mul_1]\n",
+      "    \n"
+     ]
+    }
+   ],
+   "source": [
+    "from functorch.compile import min_cut_rematerialization_partition\n",
+    "\n",
+    "# Lets set up the partitioner. Also set the fwd and bwd compilers to the printer function that we used earlier.\n",
+    "# This will show us how the recomputation has modified the graph.\n",
+    "aot_fn = aot_function(fn, fw_compiler=compiler_fn, bw_compiler=compiler_fn, partition_fn=min_cut_rematerialization_partition)\n",
+    "res = aot_fn(a, b, c, d).sum().backward()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see that compared to default partitioner, forward pass now outputs fewer tensors, and recomputes some operations in the backward pass. Let us try NNC compiler now to perform operator fusions (note that we also have a wrapper function - `memory_efficient_fusion` which internally uses `min_cut_rematerialization_partition` and Torchscript compiler to achieve the same effect as following code)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Lets set up the partitioner and NNC compiler.\n",
+    "aot_recompute_nnc_fn = aot_function(fn, fw_compiler=ts_compile, bw_compiler=ts_compile, partition_fn=min_cut_rematerialization_partition)\n",
+    "\n",
+    "# Correctness checking. Lets clone the input so that we can check grads.\n",
+    "cloned_inputs = [x.clone().detach().requires_grad_(True) for x in (a, b, c, d)]\n",
+    "cloned_a, cloned_b, cloned_c, cloned_d = cloned_inputs\n",
+    "\n",
+    "res = aot_recompute_nnc_fn(*cloned_inputs)\n",
+    "loss = res.sum()\n",
+    "loss.backward()\n",
+    "assert torch.allclose(ref, res)\n",
+    "assert torch.allclose(a.grad, cloned_a.grad)\n",
+    "assert torch.allclose(b.grad, cloned_b.grad)\n",
+    "assert torch.allclose(c.grad, cloned_c.grad)\n",
+    "assert torch.allclose(d.grad, cloned_d.grad)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, lets benchmark the different functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Eager, Fwd = 740.7676504226401 us, Bwd = 1560.5240693548694 us\n",
+      "AOT, Fwd = 713.8530415249988 us, Bwd = 909.1200679540634 us\n",
+      "AOT_Recomp, Fwd = 712.2249767417088 us, Bwd = 791.4606417762116 us\n"
+     ]
+    }
+   ],
+   "source": [
+    "bench(fn, large_inputs, \"Eager\")\n",
+    "bench(aot_nnc_fn, large_inputs, \"AOT\")\n",
+    "bench(aot_recompute_nnc_fn, large_inputs, \"AOT_Recomp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We observe that both forward and backward latency improve over the default partitioner (and a lot better than eager). Fewer outputs in the forward pass and fewer inputs in the backward pass, along with fusion, allows better memory bandwidth utilization leading to further speedups."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Actual Usage\n",
+    "For actual usage on CUDA devices, we've wrapped AOTAutograd in a convenient wrapper - `memory_efficient_fusion`. Use this for fusion on GPU!\n",
+    "\n",
+    "```\n",
+    "from functorch.compile import memory_efficient_fusion\n",
+    "```\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.5 ('base')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "73b6e0ee7c860e06bb349c72324473b318d6cb6c97bcad772bce0703fb8d0dfb"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/colab/jacobians_hessians_colab.ipynb
+++ b/notebooks/colab/jacobians_hessians_colab.ipynb
@@ -1,0 +1,952 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Jacobians, Hessians, hvp, vhp, and more: composing functorch transforms\n",
+        "\n",
+        "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/jacobians_hessians.ipynb\">\n",
+        "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+        "</a>\n",
+        "\n",
+        "Computing jacobians or hessians are useful in a number of non-traditional\n",
+        "deep learning models. It is difficult (or annoying) to compute these quantities\n",
+        "efficiently using a standard autodiff system like PyTorch Autograd; functorch\n",
+        "provides ways of computing various higher-order autodiff quantities efficiently."
+      ],
+      "metadata": {
+        "id": "zPbR6-eP51fe"
+      },
+      "id": "zPbR6-eP51fe"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Computing the Jacobian"
+      ],
+      "metadata": {
+        "id": "3kDj8fhn52j3"
+      },
+      "id": "3kDj8fhn52j3"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import torch\n",
+        "import torch.nn as nn\n",
+        "import torch.nn.functional as F\n",
+        "from functools import partial\n",
+        "_ = torch.manual_seed(0)"
+      ],
+      "metadata": {
+        "id": "w_IinyjzflUH"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "w_IinyjzflUH"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let’s start with a function that we’d like to compute the jacobian of.  This is a simple linear function with non-linear activation.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "cibF_PEYflUH"
+      },
+      "id": "cibF_PEYflUH"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def predict(weight, bias, x):\n",
+        "    return F.linear(x, weight, bias).tanh()"
+      ],
+      "metadata": {
+        "id": "qhcD9hWYflUH"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "qhcD9hWYflUH"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's add some dummy data:   a weight, a bias, and a feature vector x.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "G8tqQrO_flUH"
+      },
+      "id": "G8tqQrO_flUH"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "D = 16\n",
+        "weight = torch.randn(D, D)\n",
+        "bias = torch.randn(D)\n",
+        "x = torch.randn(D) # feature vector"
+      ],
+      "metadata": {
+        "id": "FZ4uJfZGflUH"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "FZ4uJfZGflUH"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's think of `predict` as a function that maps the input `x` from $R^D -> R^D$.\n",
+        "PyTorch Autograd computes vector-Jacobian products. In order to compute the full\n",
+        "Jacobian of this $R^D -> R^D$ function, we would have to compute it row-by-row\n",
+        "by using a different unit vector each time."
+      ],
+      "metadata": {
+        "id": "uMAW-ArQflUH"
+      },
+      "id": "uMAW-ArQflUH"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def compute_jac(xp):\n",
+        "    jacobian_rows = [torch.autograd.grad(predict(weight, bias, xp), xp, vec)[0]\n",
+        "                     for vec in unit_vectors]\n",
+        "    return torch.stack(jacobian_rows)"
+      ],
+      "metadata": {
+        "id": "z-BJPtbpflUI"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "z-BJPtbpflUI"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "xp = x.clone().requires_grad_()\n",
+        "unit_vectors = torch.eye(D)\n",
+        "\n",
+        "jacobian = compute_jac(xp)\n",
+        "\n",
+        "print(jacobian.shape)\n",
+        "print(jacobian[0])  # show first row"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "f1f1ec12-56ef-40f7-8c3c-cbad7bf86644",
+        "id": "zuWGSXspflUI"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "torch.Size([16, 16])\n",
+            "tensor([-0.5956, -0.6096, -0.1326, -0.2295,  0.4490,  0.3661, -0.1672, -1.1190,\n",
+            "         0.1705, -0.6683,  0.1851,  0.1630,  0.0634,  0.6547,  0.5908, -0.1308])\n"
+          ]
+        }
+      ],
+      "id": "zuWGSXspflUI"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Instead of computing the jacobian row-by-row, we can use vmap to get rid of the for-loop and vectorize the computation. \n",
+        "We can’t directly apply vmap to PyTorch Autograd; instead, functorch provides a vjp transform:\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "mxlEOUieflUI"
+      },
+      "id": "mxlEOUieflUI"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from functorch import vmap, vjp\n",
+        "\n",
+        "_, vjp_fn = vjp(partial(predict, weight, bias), x)\n",
+        "\n",
+        "ft_jacobian, = vmap(vjp_fn)(unit_vectors)\n",
+        "\n",
+        "# lets confirm both methods compute the same result\n",
+        "assert torch.allclose(ft_jacobian, jacobian)"
+      ],
+      "metadata": {
+        "id": "DeF6uy4WflUI"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "DeF6uy4WflUI"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In future tutorial a composition of reverse-mode AD and vmap will give us per-sample-gradients. \n",
+        "In this tutorial, composing reverse-mode AD and vmap gives us Jacobian computation! \n",
+        "Various compositions of vmap and autodiff transforms can give us different interesting quantities.\n",
+        "\n",
+        "functorch provides **jacrev** as a convenience function that performs the vmap-vjp composition to compute jacobians. **jacrev** accepts an argnums argument that says which argument we would like to compute Jacobians with respect to.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "Hy4REmwDflUI"
+      },
+      "id": "Hy4REmwDflUI"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from functorch import jacrev\n",
+        "\n",
+        "ft_jacobian = jacrev(predict, argnums=2)(weight, bias, x)\n",
+        "\n",
+        "# confirm \n",
+        "assert torch.allclose(ft_jacobian, jacobian)"
+      ],
+      "metadata": {
+        "id": "Rt7i6_YlflUI"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "Rt7i6_YlflUI"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let’s compare the performance of the two ways to compute the jacobian. The functorch version is much faster (and becomes even faster the more outputs there are). \n",
+        "\n",
+        "In general, we expect that vectorization via vmap can help eliminate overhead and give better utilization of your hardware.\n",
+        "\n",
+        "Vmap does this magic by pushing the outer loop down into the functions primitive operations in order to obtain better performance.\n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "JYe2H1UcflUJ"
+      },
+      "id": "JYe2H1UcflUJ"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's make a quick function to evaluate performance and deal with microseconds and milliseconds measurements:"
+      ],
+      "metadata": {
+        "id": "i_143LZwflUJ"
+      },
+      "id": "i_143LZwflUJ"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def get_perf(first, first_descriptor, second, second_descriptor):\n",
+        "  \"\"\"  takes torch.benchmark objects and compares delta of second vs first. \"\"\"\n",
+        "  faster = second.times[0]\n",
+        "  slower = first.times[0]\n",
+        "  gain = (slower-faster)/slower\n",
+        "  if gain < 0: gain *=-1 \n",
+        "  final_gain = gain*100\n",
+        "  print(f\" Performance delta: {final_gain:.4f} percent improvement with {second_descriptor} \")"
+      ],
+      "metadata": {
+        "id": "II7r6jBtflUJ"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "II7r6jBtflUJ"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "And then run the performance comparison:"
+      ],
+      "metadata": {
+        "id": "r4clPnPKflUJ"
+      },
+      "id": "r4clPnPKflUJ"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from torch.utils.benchmark import Timer\n",
+        "\n",
+        "without_vmap = Timer(stmt=\"compute_jac(xp)\", globals=globals())\n",
+        "with_vmap = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+        "\n",
+        "no_vmap_timer = without_vmap.timeit(500)\n",
+        "with_vmap_timer = with_vmap.timeit(500)\n",
+        "\n",
+        "print(no_vmap_timer)\n",
+        "print(with_vmap_timer)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "cbf77a19-aac9-428d-eba1-74d337c53e49",
+        "id": "ZPtoxF6eflUJ"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "<torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a911b350>\n",
+            "compute_jac(xp)\n",
+            "  2.25 ms\n",
+            "  1 measurement, 500 runs , 1 thread\n",
+            "<torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a6a99d50>\n",
+            "jacrev(predict, argnums=2)(weight, bias, x)\n",
+            "  884.34 us\n",
+            "  1 measurement, 500 runs , 1 thread\n"
+          ]
+        }
+      ],
+      "id": "ZPtoxF6eflUJ"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Lets do a relative performance comparison of the above with our get_perf function:"
+      ],
+      "metadata": {
+        "id": "nGBBi4dZflUJ"
+      },
+      "id": "nGBBi4dZflUJ"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "get_perf(no_vmap_timer, \"without vmap\",  with_vmap_timer, \"vmap\");"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "85d0bc5f-34aa-4826-f953-6c637404490c",
+        "id": "zqV2RzEXflUJ"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            " Performance delta: 60.7170 percent improvement with vmap \n"
+          ]
+        }
+      ],
+      "id": "zqV2RzEXflUJ"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Furthemore, it’s pretty easy to flip the problem around and say we want to compute Jacobians of the parameters to our model (weight, bias) instead of the input."
+      ],
+      "metadata": {
+        "id": "EQAB99EQflUJ"
+      },
+      "id": "EQAB99EQflUJ"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# note the change in input via argnums params of 0,1 to map to weight and bias\n",
+        "ft_jac_weight, ft_jac_bias = jacrev(predict, argnums=(0, 1))(weight, bias, x)"
+      ],
+      "metadata": {
+        "id": "8UZpC8DnflUK"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "8UZpC8DnflUK"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## reverse-mode Jacobian (jacrev) vs forward-mode Jacobian (jacfwd)\n"
+      ],
+      "metadata": {
+        "id": "F3USYENIflUK"
+      },
+      "id": "F3USYENIflUK"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We offer two APIs to compute jacobians: **jacrev** and **jacfwd**: \n",
+        "- jacrev uses reverse-mode AD. As you saw above it is a composition of our vjp and vmap transforms. \n",
+        "- jacfwd uses forward-mode AD. It is implemented as a composition of our jvp and vmap transforms. \n",
+        "\n",
+        "jacfwd and jacrev can be substituted for each other but they have different performance characteristics.\n",
+        "\n",
+        "As a general rule of thumb, if you’re computing the jacobian of an $𝑅^N \\to R^M$ function, and there are many more outputs than inputs (i.e. $M > N$) then jacfwd is preferred, otherwise use jacrev. There are exceptions to this rule, but a non-rigorous argument for this follows:\n",
+        "\n",
+        "In reverse-mode AD, we are computing the jacobian row-by-row, while in forward-mode AD (which computes Jacobian-vector products), we are computing it column-by-column. The Jacobian matrix has M rows and N columns, so if it is taller or wider one way we may prefer the method that deals with fewer rows or columns.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "V7B3vE8dflUK"
+      },
+      "id": "V7B3vE8dflUK"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from functorch import jacrev, jacfwd"
+      ],
+      "metadata": {
+        "id": "k7Tok7m3flUK"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "k7Tok7m3flUK"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "First, let's benchmark with more inputs than outputs:\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "YrV-gZAaflUL"
+      },
+      "id": "YrV-gZAaflUL"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "Din = 32\n",
+        "Dout = 2048\n",
+        "weight = torch.randn(Dout, Din)\n",
+        "\n",
+        "bias = torch.randn(Dout)\n",
+        "x = torch.randn(Din)\n",
+        "\n",
+        "# remember the general rule about taller vs wider...here we have a taller matrix:\n",
+        "print(weight.shape)\n",
+        "\n",
+        "using_fwd = Timer(stmt=\"jacfwd(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+        "using_bwd = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+        "\n",
+        "jacfwd_timing = using_fwd.timeit(500)\n",
+        "jacrev_timing = using_bwd.timeit(500)\n",
+        "\n",
+        "print(f'jacfwd time: {jacfwd_timing}')\n",
+        "print(f'jacrev time: {jacrev_timing}')\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "dd882726-9723-47c0-a72f-3c7835a85aa1",
+        "id": "m5j-4hSxflUL"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "torch.Size([2048, 32])\n",
+            "jacfwd time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d792d0>\n",
+            "jacfwd(predict, argnums=2)(weight, bias, x)\n",
+            "  1.32 ms\n",
+            "  1 measurement, 500 runs , 1 thread\n",
+            "jacrev time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a4dee450>\n",
+            "jacrev(predict, argnums=2)(weight, bias, x)\n",
+            "  12.46 ms\n",
+            "  1 measurement, 500 runs , 1 thread\n"
+          ]
+        }
+      ],
+      "id": "m5j-4hSxflUL"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "and then do a relative benchmark:"
+      ],
+      "metadata": {
+        "id": "k_Sg-4tVflUL"
+      },
+      "id": "k_Sg-4tVflUL"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "get_perf(jacfwd_timing, \"jacfwd\", jacrev_timing, \"jacrev\", );"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "3a6586a1-269d-46d8-d119-e24f6d46277f",
+        "id": "_4T96zGjflUL"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            " Performance delta: 842.8274 percent improvement with jacrev \n"
+          ]
+        }
+      ],
+      "id": "_4T96zGjflUL"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "and now the reverse - more outputs (M) than inputs (N):"
+      ],
+      "metadata": {
+        "id": "RCDPot1yflUL"
+      },
+      "id": "RCDPot1yflUL"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "Din = 2048\n",
+        "Dout = 32\n",
+        "weight = torch.randn(Dout, Din)\n",
+        "bias = torch.randn(Dout)\n",
+        "x = torch.randn(Din)\n",
+        "\n",
+        "using_fwd = Timer(stmt=\"jacfwd(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+        "using_bwd = Timer(stmt=\"jacrev(predict, argnums=2)(weight, bias, x)\", globals=globals())\n",
+        "\n",
+        "jacfwd_timing = using_fwd.timeit(500)\n",
+        "jacrev_timing = using_bwd.timeit(500)\n",
+        "\n",
+        "print(f'jacfwd time: {jacfwd_timing}')\n",
+        "print(f'jacrev time: {jacrev_timing}')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "913e9ccd-3d4f-472a-a749-19cee36d0a16",
+        "id": "_DRFqzqZflUM"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "jacfwd time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d64790>\n",
+            "jacfwd(predict, argnums=2)(weight, bias, x)\n",
+            "  7.99 ms\n",
+            "  1 measurement, 500 runs , 1 thread\n",
+            "jacrev time: <torch.utils.benchmark.utils.common.Measurement object at 0x7fa9a5d67b50>\n",
+            "jacrev(predict, argnums=2)(weight, bias, x)\n",
+            "  1.09 ms\n",
+            "  1 measurement, 500 runs , 1 thread\n"
+          ]
+        }
+      ],
+      "id": "_DRFqzqZflUM"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "and a relative perf comparison:"
+      ],
+      "metadata": {
+        "id": "5SRbMCNsflUM"
+      },
+      "id": "5SRbMCNsflUM"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "get_perf(jacrev_timing, \"jacrev\", jacfwd_timing, \"jacfwd\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "c282ce25-4f6e-44cd-aed7-60f6f5010e5b",
+        "id": "uF_9GaoiflUM"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            " Performance delta: 635.2095 percent improvement with jacfwd \n"
+          ]
+        }
+      ],
+      "id": "uF_9GaoiflUM"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Hessian computation with functorch.hessian\n"
+      ],
+      "metadata": {
+        "id": "J29FQaBQflUM"
+      },
+      "id": "J29FQaBQflUM"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We offer a convenience API to compute hessians: `functorch.hessian`. \n",
+        "Hessians are the jacobian of the jacobian (or the partial derivative of the partial derivative, aka second order).\n",
+        "\n",
+        "This suggests that one can just compose functorch’s jacobian transforms to compute the Hessian. \n",
+        "Indeed, under the hood, `hessian(f)` is simply `jacfwd(jacrev(f))`.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "My4DPH97flUM"
+      },
+      "id": "My4DPH97flUM"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Note: to boost performance: depending on your model, you may also want to use `jacfwd(jacfwd(f))` or `jacrev(jacrev(f))` instead to compute hessians leveraging the rule of thumb above regarding wider vs taller matrices.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "FJt038l5flUM"
+      },
+      "id": "FJt038l5flUM"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from functorch import hessian\n",
+        "\n",
+        "# lets reduce the size in order not to blow out colab. Hessians require significant memory:\n",
+        "Din = 512\n",
+        "Dout = 32\n",
+        "weight = torch.randn(Dout, Din)\n",
+        "bias = torch.randn(Dout)\n",
+        "x = torch.randn(Din)\n",
+        "\n",
+        "hess_api = hessian(predict, argnums=2)(weight, bias, x)\n",
+        "hess_fwdfwd = jacfwd(jacfwd(predict, argnums=2), argnums=2)(weight, bias, x)\n",
+        "#hess_revrev = jacrev(jacrev(predict, argnums=2), argnums=2)(weight, bias, x)\n"
+      ],
+      "metadata": {
+        "id": "jEqr2ywZflUM"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "jEqr2ywZflUM"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's verify we have the same result regardless of using hessian api or using jacfwd(jacfwd())"
+      ],
+      "metadata": {
+        "id": "n9BHcICQflUN"
+      },
+      "id": "n9BHcICQflUN"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "torch.allclose(hess_api, hess_fwdfwd)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "e457e3bc-f085-4f90-966d-f98893b98ea8",
+        "id": "eHiWRkjJflUN"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "True"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 18
+        }
+      ],
+      "id": "eHiWRkjJflUN"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Batch Jacobian and Batch Hessian\n"
+      ],
+      "metadata": {
+        "id": "Gjt1RO8HflUN"
+      },
+      "id": "Gjt1RO8HflUN"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In the above examples we’ve been operating with a single feature vector. In some cases you might want to take the Jacobian of a batch of outputs with respect to a batch of inputs. That is, given a batch of inputs of shape `(B, N)` and a function that goes from $R^N \\to R^M$, we would like a Jacobian of shape `(B, M, N)`. \n",
+        "\n",
+        "The easiest way to do this is to use vmap:"
+      ],
+      "metadata": {
+        "id": "RjIzdoQNflUN"
+      },
+      "id": "RjIzdoQNflUN"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "batch_size = 64\n",
+        "Din = 31\n",
+        "Dout = 33\n",
+        "\n",
+        "weight = torch.randn(Dout, Din)\n",
+        "print(f\"weight shape = {weight.shape}\")\n",
+        "\n",
+        "bias = torch.randn(Dout)\n",
+        "\n",
+        "x = torch.randn(batch_size, Din)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "561eb618-e00f-40d5-bd99-fa51ab82051f",
+        "id": "B1eoEO4UflUN"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "weight shape = torch.Size([33, 31])\n"
+          ]
+        }
+      ],
+      "id": "B1eoEO4UflUN"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "compute_batch_jacobian = vmap(jacrev(predict, argnums=2), in_dims=(None, None, 0))\n",
+        "batch_jacobian0 = compute_batch_jacobian(weight, bias, x)"
+      ],
+      "metadata": {
+        "id": "nZ_V02NhflUN"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "nZ_V02NhflUN"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "If you have a function that goes from (B, N) -> (B, M) instead and are certain that each input produces an independent output, then it’s also sometimes possible to do this without using vmap by summing the outputs and then computing the Jacobian of that function:\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "_OLDiY3MflUN"
+      },
+      "id": "_OLDiY3MflUN"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def predict_with_output_summed(weight, bias, x):\n",
+        "    return predict(weight, bias, x).sum(0)\n",
+        "\n",
+        "batch_jacobian1 = jacrev(predict_with_output_summed, argnums=2)(weight, bias, x).movedim(1, 0)\n",
+        "assert torch.allclose(batch_jacobian0, batch_jacobian1)"
+      ],
+      "metadata": {
+        "id": "_QH4hD8PflUO"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "_QH4hD8PflUO"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "If you instead have a function that goes from $𝑅^𝑁 \\to 𝑅^𝑀$ but inputs that are batched, you compose vmap with jacrev to compute batched jacobians:\n",
+        "\n",
+        "Finally, batch hessians can be computed similarly. It’s easiest to think about them by using vmap to batch over hessian computation, but in some cases the sum trick also works.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "eUjw65cCflUO"
+      },
+      "id": "eUjw65cCflUO"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "compute_batch_hessian = vmap(hessian(predict, argnums=2), in_dims=(None, None, 0))\n",
+        "\n",
+        "batch_hess = compute_batch_hessian(weight, bias, x)\n",
+        "batch_hess.shape"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "f3135cfa-e9e5-4f18-8cb7-0655e8a37cb5",
+        "id": "3vAyQjMsflUO"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "torch.Size([64, 33, 31, 31])"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 22
+        }
+      ],
+      "id": "3vAyQjMsflUO"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Computing Hessian-vector products\n",
+        "\n",
+        "The naive way to compute a Hessian-vector product (hvp) is to materialize the full Hessian and perform a dot-product with a vector. We can do better: it turns out we don't need to materialize the full Hessian to do this. We'll go through two (of many) different strategies to compute Hessian-vector products:\n",
+        "- composing reverse-mode AD with reverse-mode AD\n",
+        "- composing reverse-mode AD with forward-mode AD\n",
+        "\n",
+        "Composing reverse-mode AD with forward-mode AD (as opposed to reverse-mode with reverse-mode) is generally the more memory efficient way to compute a hvp because forward-mode AD doesn't need to construct an Autograd graph and save intermediates for backward:"
+      ],
+      "metadata": {
+        "id": "Wa8E48sQgpkb"
+      },
+      "id": "Wa8E48sQgpkb"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from functorch import jvp, grad, vjp\n",
+        "\n",
+        "def hvp(f, primals, tangents):\n",
+        "  return jvp(grad(f), primals, tangents)[1]"
+      ],
+      "metadata": {
+        "id": "trw6WbAth6BM"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "trw6WbAth6BM"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Here's some sample usage."
+      ],
+      "metadata": {
+        "id": "DQMpRo6nitfr"
+      },
+      "id": "DQMpRo6nitfr"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def f(x):\n",
+        "  return x.sin().sum()\n",
+        "\n",
+        "x = torch.randn(2048)\n",
+        "tangent = torch.randn(2048)\n",
+        "\n",
+        "result = hvp(f, (x,), (tangent,))"
+      ],
+      "metadata": {
+        "id": "sPwg8SOdiVAK"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "sPwg8SOdiVAK"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "If PyTorch forward-AD does not have coverage for your operations, then we can instead compose reverse-mode AD with reverse-mode AD:"
+      ],
+      "metadata": {
+        "id": "zGvUIcB0j1Ez"
+      },
+      "id": "zGvUIcB0j1Ez"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def hvp_revrev(f, primals, tangents):\n",
+        "  _, vjp_fn = vjp(grad(f), *primals)\n",
+        "  return vjp_fn(*tangents)"
+      ],
+      "metadata": {
+        "id": "mdDFZdlekAOK"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "mdDFZdlekAOK"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "result_hvp_revrev = hvp_revrev(f, (x,), (tangent,))\n",
+        "assert torch.allclose(result, result_hvp_revrev[0])"
+      ],
+      "metadata": {
+        "id": "_CuCk9X0lW7C"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "_CuCk9X0lW7C"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.3"
+    },
+    "colab": {
+      "name": "jacobians_hessians.ipynb",
+      "provenance": []
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/notebooks/colab/per_sample_grads_colab.ipynb
+++ b/notebooks/colab/per_sample_grads_colab.ipynb
@@ -1,0 +1,607 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "a474c143-05c4-43b6-b12c-17b592d07a6a",
+      "metadata": {
+        "id": "a474c143-05c4-43b6-b12c-17b592d07a6a"
+      },
+      "source": [
+        "# Per-sample-gradients\n",
+        "\n",
+        "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/per_sample_grads.ipynb\">\n",
+        "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+        "</a>\n",
+        "\n",
+        "## What is it?\n",
+        "\n",
+        "Per-sample-gradient computation is computing the gradient for each and every\n",
+        "sample in a batch of data. It is a useful quantity in differential privacy, meta-learning,\n",
+        "and optimization research.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import torch\n",
+        "import torch.nn as nn\n",
+        "import torch.nn.functional as F\n",
+        "from functools import partial\n",
+        "\n",
+        "torch.manual_seed(0);"
+      ],
+      "metadata": {
+        "id": "Gb-yt4VKUUuc"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "Gb-yt4VKUUuc"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Here's a simple CNN and loss function:\n",
+        "\n",
+        "class SimpleCNN(nn.Module):\n",
+        "    def __init__(self):\n",
+        "        super(SimpleCNN, self).__init__()\n",
+        "        self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
+        "        self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
+        "        self.fc1 = nn.Linear(9216, 128)\n",
+        "        self.fc2 = nn.Linear(128, 10)\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        x = self.conv1(x)\n",
+        "        x = F.relu(x)\n",
+        "        x = self.conv2(x)\n",
+        "        x = F.relu(x)\n",
+        "        x = F.max_pool2d(x, 2)\n",
+        "        x = torch.flatten(x, 1)\n",
+        "        x = self.fc1(x)\n",
+        "        x = F.relu(x)\n",
+        "        x = self.fc2(x)\n",
+        "        output = F.log_softmax(x, dim=1)\n",
+        "        output = x\n",
+        "        return output\n",
+        "\n",
+        "def loss_fn(predictions, targets):\n",
+        "    return F.nll_loss(predictions, targets)"
+      ],
+      "metadata": {
+        "id": "tf-HKHjUUbyY"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "tf-HKHjUUbyY"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let’s generate a batch of dummy data and pretend that we’re working with an MNIST dataset.  \n",
+        "\n",
+        "The dummy images are 28 by 28 and we use a minibatch of size 64.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "VEDPe-EoU5Fa"
+      },
+      "id": "VEDPe-EoU5Fa"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "device = 'cuda'\n",
+        "\n",
+        "num_models = 10\n",
+        "batch_size = 64\n",
+        "data = torch.randn(batch_size, 1, 28, 28, device=device)\n",
+        "\n",
+        "targets = torch.randint(10, (64,), device=device)"
+      ],
+      "metadata": {
+        "id": "WB2Qe3AHUvPN"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "WB2Qe3AHUvPN"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In regular model training, one would forward the minibatch through the model, and then call .backward() to compute gradients.  This would generate an 'average' gradient of the entire mini-batch:\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "GOGJ-OUxVcT5"
+      },
+      "id": "GOGJ-OUxVcT5"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "model = SimpleCNN().to(device=device)\n",
+        "predictions = model(data) # move the entire mini-batch through the model\n",
+        "\n",
+        "loss = loss_fn(predictions, targets)\n",
+        "loss.backward() # back propogate the 'average' gradient of this mini-batch"
+      ],
+      "metadata": {
+        "id": "WYjMx8QTUvRu"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "WYjMx8QTUvRu"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In contrast to the above approach, per-sample-gradient computation is equivalent to: \n",
+        "- for each individual sample of the data, perform a forward and a backward pass to get an individual (per-sample) gradient.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "HNw4_IVzU5Pz"
+      },
+      "id": "HNw4_IVzU5Pz"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def compute_grad(sample, target):\n",
+        "    \n",
+        "    sample = sample.unsqueeze(0)  # prepend batch dimension for processing\n",
+        "    target = target.unsqueeze(0)\n",
+        "\n",
+        "    prediction = model(sample)\n",
+        "    loss = loss_fn(prediction, target)\n",
+        "\n",
+        "    return torch.autograd.grad(loss, list(model.parameters()))\n",
+        "\n",
+        "\n",
+        "def compute_sample_grads(data, targets):\n",
+        "    \"\"\" manually process each sample with per sample gradient \"\"\"\n",
+        "    sample_grads = [compute_grad(data[i], targets[i]) for i in range(batch_size)]\n",
+        "    sample_grads = zip(*sample_grads)\n",
+        "    sample_grads = [torch.stack(shards) for shards in sample_grads]\n",
+        "    return sample_grads\n",
+        "\n",
+        "per_sample_grads = compute_sample_grads(data, targets)"
+      ],
+      "metadata": {
+        "id": "vUsb3VfexJrY"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "vUsb3VfexJrY"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "`sample_grads[0]` is the per-sample-grad for model.conv1.weight. `model.conv1.weight.shape` is `[32, 1, 3, 3]`; notice how there is one gradient, per sample, in the batch for a total of 64.\n",
+        "\n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "aNkX6lFIxzcm"
+      },
+      "id": "aNkX6lFIxzcm"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(per_sample_grads[0].shape)"
+      ],
+      "metadata": {
+        "id": "C3a9_clvyPho",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "407abc1a-846f-4e50-83bc-c90719a26073"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "torch.Size([64, 32, 1, 3, 3])\n"
+          ]
+        }
+      ],
+      "id": "C3a9_clvyPho"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Per-sample-grads, *the efficient way*, using functorch\n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "mFJDWMM9yaYZ"
+      },
+      "id": "mFJDWMM9yaYZ"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can compute per-sample-gradients efficiently by using function transforms. \n",
+        "\n",
+        "First, let’s create a stateless functional version of `model` by using `functorch.make_functional_with_buffers`.  \n",
+        "\n",
+        "This will separate state (the parameters) from the model and turn the model into a pure function:\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "tlkmyQyfY6XU"
+      },
+      "id": "tlkmyQyfY6XU"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from functorch import make_functional_with_buffers, vmap, grad\n",
+        "\n",
+        "fmodel, params, buffers = make_functional_with_buffers(model)"
+      ],
+      "metadata": {
+        "id": "WiSMupvCyecd"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "WiSMupvCyecd"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's review the changes - first, the model has become the stateless FunctionalModuleWithBuffers:"
+      ],
+      "metadata": {
+        "id": "wMsbppPNZklo"
+      },
+      "id": "wMsbppPNZklo"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "fmodel"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Xj0cZOJMZbbB",
+        "outputId": "2e87dfde-3af2-4e1f-cd91-5c232446fb53"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "FunctionalModuleWithBuffers(\n",
+              "  (stateless_model): SimpleCNN(\n",
+              "    (conv1): Conv2d(1, 32, kernel_size=(3, 3), stride=(1, 1))\n",
+              "    (conv2): Conv2d(32, 64, kernel_size=(3, 3), stride=(1, 1))\n",
+              "    (fc1): Linear(in_features=9216, out_features=128, bias=True)\n",
+              "    (fc2): Linear(in_features=128, out_features=10, bias=True)\n",
+              "  )\n",
+              ")"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 15
+        }
+      ],
+      "id": "Xj0cZOJMZbbB"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "And the model parameters now exist independently of the model, stored as a tuple:"
+      ],
+      "metadata": {
+        "id": "zv4_YYPxZvvg"
+      },
+      "id": "zv4_YYPxZvvg"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "for x in params:\n",
+        "  print(f\"{x.shape}\")\n",
+        "\n",
+        "print(f\"\\n{type(params)}\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "tH0TAZhBZ3bS",
+        "outputId": "97c4401f-cccb-43f6-b071-c85a18fc439b"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "torch.Size([32, 1, 3, 3])\n",
+            "torch.Size([32])\n",
+            "torch.Size([64, 32, 3, 3])\n",
+            "torch.Size([64])\n",
+            "torch.Size([128, 9216])\n",
+            "torch.Size([128])\n",
+            "torch.Size([10, 128])\n",
+            "torch.Size([10])\n",
+            "\n",
+            "<class 'tuple'>\n"
+          ]
+        }
+      ],
+      "id": "tH0TAZhBZ3bS"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Next, let’s define a function to compute the loss of the model given a single input rather than a batch of inputs. It is important that this function accepts the parameters, the input, and the target, because we will be transforming over them. \n",
+        "\n",
+        "Note - because the model was originally written to handle batches, we’ll use `torch.unsqueeze` to add a batch dimension.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "cTgIIZ9Wyih8"
+      },
+      "id": "cTgIIZ9Wyih8"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def compute_loss_stateless_model (params, buffers, sample, target):\n",
+        "    batch = sample.unsqueeze(0)\n",
+        "    targets = target.unsqueeze(0)\n",
+        "\n",
+        "    predictions = fmodel(params, buffers, batch) \n",
+        "    loss = loss_fn(predictions, targets)\n",
+        "    return loss"
+      ],
+      "metadata": {
+        "id": "ItURFU3M-p98"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "ItURFU3M-p98"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now, let’s use functorch's `grad` to create a new function that computes the gradient with respect to the first argument of `compute_loss` (i.e. the params)."
+      ],
+      "metadata": {
+        "id": "Qo3sbDK2i_bH"
+      },
+      "id": "Qo3sbDK2i_bH"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "ft_compute_grad = grad(compute_loss_stateless_model)"
+      ],
+      "metadata": {
+        "id": "sqRp_Sxni-Xm"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "sqRp_Sxni-Xm"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The `ft_compute_grad` function computes the gradient for a single (sample, target) pair. We can use vmap to get it to compute the gradient over an entire batch of samples and targets. Note that `in_dims=(None, None, 0, 0)` because we wish to map `ft_compute_grad` over the 0th dimension of the data and targets,  and use the same params and buffers for each.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "2pG3Ofqjjc8O"
+      },
+      "id": "2pG3Ofqjjc8O"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "ft_compute_sample_grad = vmap(ft_compute_grad, in_dims=(None, None, 0, 0))"
+      ],
+      "metadata": {
+        "id": "62ecNMO6inqX"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "62ecNMO6inqX"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Finally, let’s used our transformed function to compute per-sample-gradients:\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "_alXdQ3QkETu"
+      },
+      "id": "_alXdQ3QkETu"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "ft_per_sample_grads = ft_compute_sample_grad(params, buffers, data, targets)\n",
+        "\n",
+        "# we can double check that the results using functorch grad and vmap match the results of hand processing each one individually:\n",
+        "for per_sample_grad, ft_per_sample_grad in zip(per_sample_grads, ft_per_sample_grads):\n",
+        "    assert torch.allclose(per_sample_grad, ft_per_sample_grad, atol=3e-3, rtol=1e-5)"
+      ],
+      "metadata": {
+        "id": "1gehVA1c-BHd"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "1gehVA1c-BHd"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "A quick note: there are limitations around what types of functions can be transformed by vmap. The best functions to transform are ones that are pure functions: a function where the outputs are only determined by the inputs, and that have no side effects (e.g. mutation). vmap is unable to handle mutation of arbitrary Python data structures, but it is able to handle many in-place PyTorch operations.\n",
+        "\n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "BEZaNt1d_bc1"
+      },
+      "id": "BEZaNt1d_bc1"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Performance comparison"
+      ],
+      "metadata": {
+        "id": "BASP151Iml7B"
+      },
+      "id": "BASP151Iml7B"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Curious about how the performance of vmap compares?\n",
+        "\n",
+        "Currently the best results are obtained on newer GPU's such as the A100 (Ampere) where we've seen up to 25x speedups on this example, but here are some results done in Colab:"
+      ],
+      "metadata": {
+        "id": "jr1xNpV4nJ7u"
+      },
+      "id": "jr1xNpV4nJ7u"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def get_perf(first, first_descriptor, second, second_descriptor):\n",
+        "  \"\"\"  takes torch.benchmark objects and compares delta of second vs first. \"\"\"\n",
+        "  second_res = second.times[0]\n",
+        "  first_res = first.times[0]\n",
+        "\n",
+        "  gain = (first_res-second_res)/first_res\n",
+        "  if gain < 0: gain *=-1 \n",
+        "  final_gain = gain*100\n",
+        "\n",
+        "  print(f\" Performance delta: {final_gain:.4f} percent improvement with {first_descriptor} \")"
+      ],
+      "metadata": {
+        "id": "GnAnMkYmoc-j"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "GnAnMkYmoc-j"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from torch.utils.benchmark import Timer\n",
+        "\n",
+        "without_vmap = Timer( stmt=\"compute_sample_grads(data, targets)\", globals=globals())\n",
+        "with_vmap = Timer(stmt=\"ft_compute_sample_grad(params, buffers, data, targets)\",globals=globals())\n",
+        "no_vmap_timing = without_vmap.timeit(100)\n",
+        "with_vmap_timing = with_vmap.timeit(100)\n",
+        "\n",
+        "print(f'Per-sample-grads without vmap {no_vmap_timing}')\n",
+        "print(f'Per-sample-grads with vmap {with_vmap_timing}')"
+      ],
+      "metadata": {
+        "id": "Zfnn2C2g-6Fb",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "922f3901-773f-446b-b562-88e78f49036c"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Per-sample-grads without vmap <torch.utils.benchmark.utils.common.Measurement object at 0x7f71ac3f1850>\n",
+            "compute_sample_grads(data, targets)\n",
+            "  79.86 ms\n",
+            "  1 measurement, 100 runs , 1 thread\n",
+            "Per-sample-grads with vmap <torch.utils.benchmark.utils.common.Measurement object at 0x7f7143e26f10>\n",
+            "ft_compute_sample_grad(params, buffers, data, targets)\n",
+            "  12.93 ms\n",
+            "  1 measurement, 100 runs , 1 thread\n"
+          ]
+        }
+      ],
+      "id": "Zfnn2C2g-6Fb"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "get_perf(with_vmap_timing, \"vmap\", no_vmap_timing,\"no vmap\" )"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "NV9R3LZQoavl",
+        "outputId": "e11e8be9-287d-4e60-e517-e08f8d6909bd"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            " Performance delta: 517.5791 percent improvement with vmap \n"
+          ]
+        }
+      ],
+      "id": "NV9R3LZQoavl"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "There are other optimized solutions (like in https://github.com/pytorch/opacus) to computing per-sample-gradients in PyTorch that also perform better than the naive method. But it’s cool that composing `vmap` and `grad` give us a nice speedup.\n",
+        "\n",
+        "\n",
+        "In general, vectorization with vmap should be faster than running a function in a for-loop and competitive with manual batching. There are some exceptions though, like if we haven’t implemented the vmap rule for a particular operation or if the underlying kernels weren’t optimized for older hardware (GPUs). If you see any of these cases, please let us know by opening an issue at our [GitHub](https://github.com/pytorch/functorch)!\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "UI74G9JarQU8"
+      },
+      "id": "UI74G9JarQU8"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.5"
+    },
+    "colab": {
+      "name": "per_sample_grads.ipynb",
+      "provenance": []
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
The longer-term solution is to rewire the links on the website.

To contribute a change to functorch, please make sure you are submitting a
Pull Request to the functorch folder in https://github.com/pytorch/pytorch
repository. The source of truth for functorch has moved there from
https://github.com/pytorch/functorch ; the pytorch/functorch repository
is now read-only.
