### PR TITLE
Fix functorch-versions.json

### DIFF
--- a/functorch-versions.json
+++ b/functorch-versions.json
@@ -8,36 +8,36 @@
   {
     "name": "2.0 (stable; works with PyTorch 2.0)",
     "version": "2.0",
-    "url": "2.0/"
+    "url": "https://pytorch.org/functorch/2.0/"
   },
   {
     "name": "1.13 (previous version; works with PyTorch 1.13)",
     "version": "1.13",
-    "url": "1.13/"
+    "url": "https://pytorch.org/functorch/1.13/"
   },
   {
     "name": "0.2.1 (unstable; works with PyTorch 1.12.1)",
     "version": "0.2.1",
-    "url": "0.2.1/"
+    "url": "https://pytorch.org/functorch/0.2.1/"
   },
   {
     "name": "0.2.0 (unstable; works with PyTorch 1.12.0)",
     "version": "0.2.0",
-    "url": "0.2.0/"
+    "url": "https://pytorch.org/functorch/0.2.0/"
   },
   {
     "name": "0.1.1 (unstable; works with PyTorch 1.11)",
     "version": "0.1.1",
-    "url": "0.1.1/"
+    "url": "https://pytorch.org/functorch/0.1.1/"
   },
   {
     "name": "0.1.0 (unstable; works with PyTorch 1.11)",
     "version": "0.1.0",
-    "url": "0.1.0/"
+    "url": "https://pytorch.org/functorch/0.1.0/"
   },
   {
     "name": "0.0.1 (unstable; works with PyTorch 1.10)",
     "version": "0.0.1",
-    "url": "0.0.1/"
+    "url": "https://pytorch.org/functorch/0.0.1/"
   }
 ]


### PR DESCRIPTION
Add absolute paths.

To contribute a change to functorch, please make sure you are submitting a
Pull Request to the functorch folder in https://github.com/pytorch/pytorch
repository. The source of truth for functorch has moved there from
https://github.com/pytorch/functorch ; the pytorch/functorch repository
is now read-only.
